### PR TITLE
fix: agent default config override template

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.2.1
+version: 0.2.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -105,16 +105,16 @@ Get otel memory_limiter ballast_size_mib value based on 40% of resources.memory.
 Default config override for agent collector deamonset
 */}}
 {{- define "opentelemetry-collector.agentConfigOverride" -}}
-exporters:
   {{- if .Values.standaloneCollector.enabled }}
+exporters:
   otlp:
     endpoint: {{ include "opentelemetry-collector.fullname" . }}:55680
     insecure: true
   {{- end }}
 
+    {{- if .Values.standaloneCollector.enabled }}
 service:
   pipelines:
-    {{- if .Values.standaloneCollector.enabled }}
     metrics:
       exporters: [otlp]
     traces:

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -105,19 +105,19 @@ Get otel memory_limiter ballast_size_mib value based on 40% of resources.memory.
 Default config override for agent collector deamonset
 */}}
 {{- define "opentelemetry-collector.agentConfigOverride" -}}
-  {{- if .Values.standaloneCollector.enabled }}
+{{- if .Values.standaloneCollector.enabled }}
 exporters:
   otlp:
     endpoint: {{ include "opentelemetry-collector.fullname" . }}:55680
     insecure: true
-  {{- end }}
+{{- end }}
 
-    {{- if .Values.standaloneCollector.enabled }}
+{{- if .Values.standaloneCollector.enabled }}
 service:
   pipelines:
     metrics:
       exporters: [otlp]
     traces:
       exporters: [otlp]
-    {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
move `exporters` and `service.pipelines` into if statement to avoid
setting them to null when standalone is disabled

Signed-off-by: naseemkullah <naseem@transit.app>