### PR TITLE
fix: agent collector using the legacy gRPC port

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.4.1
+version: 0.4.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -108,7 +108,7 @@ Default config override for agent collector deamonset
 {{- if .Values.standaloneCollector.enabled }}
 exporters:
   otlp:
-    endpoint: {{ include "opentelemetry-collector.fullname" . }}:55680
+    endpoint: {{ include "opentelemetry-collector.fullname" . }}:4317
     insecure: true
 {{- end }}
 


### PR DESCRIPTION
When enabling the standalone collector, the chart wires the agent's OTLP exporter to the standalone collector at the [legacy port](https://github.com/open-telemetry/opentelemetry-collector/blob/88ab1a6fd923010b1397edb38fbd01375531e3bb/receiver/otlpreceiver/otlp.go#L129-L140).

It didn't work because the `service` of the standalone collector [only listens](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/3057edf2d973b0268ec82ffe92857a6b9926f8bb/charts/opentelemetry-collector/values.yaml#L101-L106) on the correct port (4317).