### PR TITLE
chore: update otel-collector to 0.20.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.4.2
+version: 0.4.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.19.0
+appVersion: 0.20.0


### PR DESCRIPTION
Following [the 0.20.0 release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.20.0) from a week ago.