### PR TITLE
Fix default memory_limiter configuration for helm version 3.5.x

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.0
+version: 0.5.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2,27 +2,28 @@
 Default memory limiter configuration for OpenTelemetry Collector based on k8s resource limits.
 */}}
 {{- define "opentelemetry-collector.memoryLimiter" -}}
-processors:
-  memory_limiter:
-    # check_interval is the time between measurements of memory usage.
-    check_interval: 5s
+# check_interval is the time between measurements of memory usage.
+check_interval: 5s
 
-    # By default limit_mib is set to 80% of ".Values.resources.limits.memory"
-    limit_mib: {{ include "opentelemetry-collector.getMemLimitMib" .Values.resources.limits.memory }}
+# By default limit_mib is set to 80% of ".Values.resources.limits.memory"
+limit_mib: {{ include "opentelemetry-collector.getMemLimitMib" .Values.resources.limits.memory }}
 
-    # By default spike_limit_mib is set to 25% of ".Values.resources.limits.memory"
-    spike_limit_mib: {{ include "opentelemetry-collector.getMemSpikeLimitMib" .Values.resources.limits.memory }}
+# By default spike_limit_mib is set to 25% of ".Values.resources.limits.memory"
+spike_limit_mib: {{ include "opentelemetry-collector.getMemSpikeLimitMib" .Values.resources.limits.memory }}
 
-    # By default ballast_size_mib is set to 40% of ".Values.resources.limits.memory"
-    ballast_size_mib: {{ include "opentelemetry-collector.getMemBallastSizeMib" .Values.resources.limits.memory }}
+# By default ballast_size_mib is set to 40% of ".Values.resources.limits.memory"
+ballast_size_mib: {{ include "opentelemetry-collector.getMemBallastSizeMib" .Values.resources.limits.memory }}
 {{- end }}
 
 {{/*
 Merge user supplied top-level (not particular to standalone or agent) config into memory limiter config.
 */}}
 {{- define "opentelemetry-collector.baseConfig" -}}
-{{- $config := include "opentelemetry-collector.memoryLimiter" . | fromYaml  -}}
-{{- .Values.config | mustMergeOverwrite $config  | toYaml }}
+{{- $processorsConfig := get .Values.config "processors" }}
+{{- if not $processorsConfig.memory_limiter }}
+{{- $_ := set $processorsConfig "memory_limiter" (include "opentelemetry-collector.memoryLimiter" . | fromYaml) }}
+{{- end }}
+{{- .Values.config | toYaml }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Starting from helm 3.5.0, merging rules were changed: now if null value merged into a dict, null value is preserved.

In order to make it cleaner and working across all helm versions, this commit replaces the merge operation with a conditional set.

If user wants to override the default memory_limiter configuration, they should override all the fields. That behavior seems more practical than partial override for the this processor.

Resolves https://github.com/open-telemetry/opentelemetry-helm-charts/issues/34