### PR TITLE
implement secret mounting

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.1
+version: 0.5.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -61,6 +61,10 @@ containers:
         mountPropagation: {{ .mountPropagation }}
         {{- end }}
       {{- end }}
+      {{- range .Values.secretMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .path }}
+      {{- end }}
       {{- if and $.isAgent .Values.agentCollector.containerLogs.enabled }}
       - name: varlogpods
         mountPath: /var/log/pods
@@ -80,6 +84,11 @@ volumes:
   - name: {{ .name }}
     hostPath:
       path: {{ .hostPath }}
+  {{- end }}
+  {{- range .Values.secretMounts }}
+  - name: {{ .name }}
+    secret:
+      secretName: {{ .secretName }}
   {{- end }}
   {{- if and $.isAgent .Values.agentCollector.containerLogs.enabled }}
   - name: varlogpods

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -63,7 +63,11 @@ containers:
       {{- end }}
       {{- range .Values.secretMounts }}
       - name: {{ .name }}
-        mountPath: {{ .path }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+        {{- if .subPath }}
+        subPath: {{ .subPath }}
+        {{- end }}
       {{- end }}
       {{- if and $.isAgent .Values.agentCollector.containerLogs.enabled }}
       - name: varlogpods

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -101,6 +101,7 @@ affinity: {}
 
 extraEnvs: []
 extraHostPathMounts: []
+secretMounts: []
 
 # Configuration for ports, shared between agentCollector, standaloneCollector and service.
 # Can be overridden here or for agentCollector and standaloneCollector independently.


### PR DESCRIPTION
Adds the ability for people to mount secrets. This can be used for referencing certificates in the config, like so:

```
secretMounts:
- name: jaeger-cert
  secretName: jaeger-cert
  mountPath: /etc/tls
  readOnly: true
  subPath: jaeger # subPath is optional
```

```
exporters:
    jaeger:
      endpoint: localhost
      cert_file: /etc/tls/tls.crt
      key_file: /etc/tls/tls.key
```