### PR TITLE
Add ability to mount extra ConfigMaps to OTel collector pods

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.4
+version: 0.5.6
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -53,6 +53,14 @@ containers:
     volumeMounts:
       - mountPath: /conf
         name: {{ .Chart.Name }}-configmap
+      {{- range .Values.extraConfigMapMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+        {{- if .subPath }}
+        subPath: {{ .subPath }}
+        {{- end }}
+      {{- end }}
       {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
@@ -84,6 +92,11 @@ volumes:
       items:
         - key: relay
           path: relay.yaml
+  {{- range .Values.extraConfigMapMounts }}
+  - name: {{ .name }}
+    configMap:
+      name: {{ .configMap }}
+  {{- end }}
   {{- range .Values.extraHostPathMounts }}
   - name: {{ .name }}
     hostPath:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -100,6 +100,7 @@ tolerations: []
 affinity: {}
 
 extraEnvs: []
+extraConfigMapMounts: []
 extraHostPathMounts: []
 secretMounts: []
 


### PR DESCRIPTION
This PR would add the ability to mount extra ConfigMaps by setting the `extraConfigMapMounts` value.

Values set example:

```yaml
standaloneCollector:
  enabled: true
  
  configOverride:
    receivers:
      jaeger:
        protocols:
          grpc:
        remote_sampling:
          strategy_file: "/conf/jaeger/strategies.json"

extraConfigMapMounts:
- name: jaeger-sampling-strategies
  configMap: jaeger-sampling-strategies
  mountPath: /conf/jaeger
  readOnly: true
```

Extra ConfigMap example:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: jaeger-sampling-strategies
data:
  strategies.json: |-
    {
      "default_strategy":
        {
          "type": "probabilistic",
          "param": 1
        }
    }
```
