### PR TITLE
Add missing label to service for ServiceMonitor

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.7
+version: 0.5.8
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    component: standalone-collector
   {{- if .Values.service.annotations }}
   annotations:
     {{ toYaml .Values.service.annotations | nindent 4 }}


### PR DESCRIPTION
Currently the ServiceMonitor fails to capture the prometheus metrics exposed by the collector when deploying in standalone mode due to the absence of the label `component: standalone-collector`.

Current ServiceMonitor selector (version 0.5.6)
```
  selector:
    matchLabels:
      app.kubernetes.io/instance: opentelemetry-collector
      app.kubernetes.io/name: opentelemetry-collector
      component: standalone-collector
```
service labels:
```
  labels:
    app.kubernetes.io/instance: opentelemetry-collector
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: opentelemetry-collector
    app.kubernetes.io/version: 0.22.0
    helm.sh/chart: opentelemetry-collector-0.5.6
```

This PR adds the missing label to the service so that the metrics can be properly scraped by prom operator