### PR TITLE
Added priorityClassName to pod template and values file

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.6
+version: 0.5.7
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -85,6 +85,9 @@ containers:
         mountPath: /var/lib/docker/containers
         readOnly: true
       {{- end }}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName | quote }}
+{{- end }}
 volumes:
   - name: {{ .Chart.Name }}-configmap
     configMap:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -99,6 +99,10 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Allows for pod scheduler prioritisation
+# Can be overridden here or for agentCollector and standaloneCollector independently.
+priorityClassName: ""
+
 extraEnvs: []
 extraConfigMapMounts: []
 extraHostPathMounts: []
@@ -170,6 +174,7 @@ agentCollector:
   # nodeSelector: {}
   # tolerations: []
   # affinity: {}
+  # priorityClassName: ""
 
   # The following option overrides can be used with host receiver
   # extraEnvs:
@@ -227,6 +232,7 @@ standaloneCollector:
   # nodeSelector: {}
   # tolerations: []
   # affinity: {}
+  # priorityClassName: ""
   # ports: {}
 
 service:


### PR DESCRIPTION
This will add the ability to set a priorityClassName as part of the deployment.

The Deployment for the agents can be set to a higher priority to make sure the scheduler deploys the agents first before any apps are deployed.