### PR TITLE
add annotations to deployment for standalone collector

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.9
+version: 0.5.10
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+{{- if .Values.standaloneCollector.annotations }}
+  annotations:
+    {{- toYaml .Values.standaloneCollector.annotations | nindent 4 }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.standaloneCollector.replicaCount }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -219,6 +219,8 @@ standaloneCollector:
 
   podAnnotations: {}
 
+  annotations: {}
+
   # Configuration override that will be merged into the standalone collector default config
   configOverride: {}
 


### PR DESCRIPTION
This provides the ability to add arbitrary deployment annotations when using the standalone collector. This will enable the use of any operators that rely on deployment annotations.

Example for wave config reloading:
```yaml
standaloneCollector:
  enabled: true

  replicaCount: 1

  resources:
    limits:
      cpu: 1
      memory: 2Gi

  podAnnotations: {}

  annotations:
    wave.pusher.com/update-on-config-change: "true"
```