### PR TITLE
Defined configuration for headless service

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.10
+version: 0.5.11
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.headless }}
+  clusterIP: "None"
+  {{- end}}
   ports:
     {{- range $key, $port := .Values.ports }}
     {{- if $port.enabled }}

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -12,8 +12,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.headless }}
-  clusterIP: "None"
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
   {{- end}}
   ports:
     {{- range $key, $port := .Values.ports }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -239,7 +239,6 @@ standaloneCollector:
 
 service:
   type: ClusterIP
-  headless: false
   annotations: {}
 
 podMonitor:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -239,6 +239,7 @@ standaloneCollector:
 
 service:
   type: ClusterIP
+  headless: false
   annotations: {}
 
 podMonitor:


### PR DESCRIPTION
Defined configuration for headless service in open-telemetry helm charts. 

This allows us to directly interact with PODs instead of proxy.


Co-authored-by: Betsy Behun <betsybehun@gmail.com>

closes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/61