### PR TITLE
Bump chart version

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.3.1
+version: 0.3.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/


### PR DESCRIPTION
Related to #72 and #74 - the releaser update wasn't enough on its own because it was comparing to the failed release.