### PR TITLE
chore: update otel-collector to 0.36.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.5.10
+version: 0.5.11
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.22.0
+appVersion: 0.36.0

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -111,7 +111,8 @@ Default config override for agent collector deamonset
 exporters:
   otlp:
     endpoint: {{ include "opentelemetry-collector.fullname" . }}:4317
-    insecure: true
+    tls:
+      insecure: true
 {{- end }}
 
 {{- if .Values.standaloneCollector.enabled }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -12,7 +12,6 @@ containers:
       - /{{ .Values.command.name }}
       - --config=/conf/relay.yaml
       - --metrics-addr=0.0.0.0:8888
-      - --mem-ballast-size-mib={{ template "opentelemetry-collector.getMemBallastSizeMib" .Values.resources.limits.memory }}
       {{- range .Values.command.extraArgs }}
       - {{ . }}
       {{- end }}


### PR DESCRIPTION
Collector bumped to 0.36.0

Additional compatibility changes:
* `insecure` relocated as per https://github.com/open-telemetry/opentelemetry-collector/pull/4063
* `mem-ballast-size-mib` removed as per open-telemetry/opentelemetry-collector#3626