### PR TITLE
Added Port Templating block to override service ports

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.7.0
+version: 0.7.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -211,3 +211,19 @@ service:
         - otlp
 {{- end }}
 {{- end }}
+
+{{/* Build the list of port for standalone service */}}
+{{- define "opentelemetry-collector.standalonePortsConfig" -}}
+{{- $ports := deepCopy .Values.ports }}
+{{- if .Values.standaloneCollector.ports  }}
+{{- $ports = deepCopy .Values.standaloneCollector.ports | mustMergeOverwrite (deepCopy .Values.ports) }}
+{{- end }}
+{{- range $key, $port := $ports }}
+{{- if $port.enabled }}
+- name: {{ $key }}
+  port: {{ $port.servicePort }}
+  targetPort: {{ $key }}
+  protocol: {{ $port.protocol }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -14,16 +14,8 @@ spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
-  {{- end}}
-  ports:
-    {{- range $key, $port := .Values.ports }}
-    {{- if $port.enabled }}
-    - name: {{ $key }}
-      port: {{ $port.servicePort }}
-      targetPort: {{ $key }}
-      protocol: {{ $port.protocol }}
-    {{- end }}
-    {{- end }}
+  {{- end }}
+  ports: {{ include "opentelemetry-collector.standalonePortsConfig" . | nindent 4 }}
   selector:
     {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
     component: standalone-collector


### PR DESCRIPTION
Hello,

This PR sets up service ports overriding with the `standaloneCollector.ports` variable. It's properly done in the deploy but was not in the service.

Thanks,