### PR TITLE
Update cert-manager to v1.6.0

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install cert-manager
         run: |
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
         if: steps.list-changed.outputs.operator-changed == 'true'

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.admissionWebhooks.enabled .Values.admissionWebhooks.certManager.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "opentelemetry-operator.name" . }}-serving-cert
@@ -21,7 +21,7 @@ spec:
       - {{ template "opentelemetry-operator.name" . }}
 {{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "opentelemetry-operator.name" . }}-selfsigned-issuer


### PR DESCRIPTION
- Update `apiVersion` from `cert-manager.io/v1alpha2` → `cert-manager.io/v1` for `Issuer` and `Certificate` resources, as v1alpha2 [is not supported by cert-manager v1.6.0 anymore](https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/)
- Update lint-test GitHub action to test against cert-manager v1.6.0