### PR TITLE
feat(collector): add additional ports and explicitly define OTLP endpoints

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.7.1
+version: 0.8.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -148,6 +148,12 @@ ports:
     servicePort: 4317
     hostPort: 4317
     protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    hostPort: 4318
+    protocol: TCP
   jaeger-thrift-compact:
     enabled: true
     containerPort: 6831

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -26,8 +26,10 @@ config:
           endpoint: 0.0.0.0:6831
     otlp:
       protocols:
-        grpc: null
-        http: null
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
     prometheus:
       config:
         scrape_configs:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -22,6 +22,8 @@ config:
           endpoint: 0.0.0.0:14250
         thrift_http:
           endpoint: 0.0.0.0:14268
+        thrift_compact:
+          endpoint: 0.0.0.0:6831
     otlp:
       protocols:
         grpc: null
@@ -146,6 +148,12 @@ ports:
     servicePort: 4317
     hostPort: 4317
     protocol: TCP
+  jaeger-thrift-compact:
+    enabled: true
+    containerPort: 6831
+    servicePort: 6831
+    hostPort: 6831
+    protocol: UDP
   jaeger-thrift:
     enabled: true
     containerPort: 14268

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -156,7 +156,7 @@ ports:
     servicePort: 4318
     hostPort: 4318
     protocol: TCP
-  jaeger-thrift-compact:
+  jaeger-compact:
     enabled: true
     containerPort: 6831
     servicePort: 6831


### PR DESCRIPTION
Fixes #94

This PR: 
- explicitly defines the OTLP endpoints in the collectors config 
- enables Jaeger compact thrift protocol to serve as drop in replacement for the Jaeger Agent