### PR TITLE
declare metrics port by default

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.9.1
+version: 0.9.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -183,6 +183,13 @@ ports:
     servicePort: 9411
     hostPort: 9411
     protocol: TCP
+  metrics:
+    # The metrics port is disabled by default. However you need to enable the port
+    # in order to use the ServiceMonitor (serviceMonitor.enabled) or PodMonitor (podMonitor.enabled).
+    enabled: false
+    containerPort: 8888
+    servicePort: 8888
+    protocol: TCP
 
 # Configuration for agent OpenTelemetry Collector daemonset, enabled by default
 agentCollector:
@@ -309,19 +316,24 @@ ingress:
 #        - collector.example.com
 
 podMonitor:
+  # The pod monitor by default scrapes the metrics port.
+  # The metrics port needs to be enabled as well.
   enabled: false
-  metricsEndpoints: {}
-  # - port: prometheus
+  metricsEndpoints:
+  - port: metrics
+    # interval: 15s
 
   # additional labels for the PodMonitor
   extraLabels: {}
   #   release: kube-prometheus-stack
 
 serviceMonitor:
+  # The service monitor by default scrapes the metrics port.
+  # The metrics port needs to be enabled as well.
   enabled: false
-  metricsEndpoints: {}
-  # - port: metrics
-  #   interval: 15s
+  metricsEndpoints:
+  - port: metrics
+    # interval: 15s
 
   # additional labels for the ServiceMonitor
   extraLabels: {}


### PR DESCRIPTION
## Current situation
The metrics port is not declared, not sure what the reason is for that.

## Proposal
Declare metrics port by default.