### PR TITLE
Upgrade cert-manager API version to v1

### DIFF
--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.admissionWebhooks.enabled .Values.admissionWebhooks.certManager.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "opentelemetry-operator.name" . }}-serving-cert
@@ -21,7 +21,7 @@ spec:
       - {{ template "opentelemetry-operator.name" . }}
 {{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "opentelemetry-operator.name" . }}-selfsigned-issuer


### PR DESCRIPTION
I know this PR duplicate with [[#96]](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/96), but that PR has no updates for a long time.
We need upgrade our cert-manager to v1.6.0, but **legacy cert-manager API versions are no-longer served** in v1.6.0.