### PR TITLE
Add `--otelcol-image` CLI Flag to Operator Helm Chart

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.5.1
+version: 0.5.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         - args:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
+            - --otelcol-image="{{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}"
           command:
             - /manager
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -19,7 +19,9 @@ spec:
         - args:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
+            {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
             - --otelcol-image="{{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}"
+            {{- end }}
           command:
             - /manager
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -17,6 +17,9 @@ manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: v0.41.1
+  collectorImage:
+    repository: otel/opentelemetry-collector
+    tag: 0.0.0
   resources:
     limits:
       cpu: 100m

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -18,8 +18,8 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: v0.41.1
   collectorImage:
-    repository: 
-    tag: 
+    repository:
+    tag:
   resources:
     limits:
       cpu: 100m

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -18,8 +18,8 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: v0.41.1
   collectorImage:
-    repository: otel/opentelemetry-collector
-    tag: 0.0.0
+    repository: 
+    tag: 
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
This PR addresses #111 and adds the functionality to set the default Collector image through the Operator helm chart if the user explicitly configures it. Otherwise, the behavior of the chart is unchanged.

To set the default Collector image, you must `--set` a repository (`manager.collectorImage.repository`) and a tag (`manager.collectorImage.tag`) when you run the `helm install` command.