### PR TITLE
Minor Fix to `--otelcol-image` CLI Flag

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.5.2
+version: 0.5.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
-            - --otelcol-image="{{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}"
+            - --otelcol-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
           command:
             - /manager


### PR DESCRIPTION
This PR is a minor fix to #113 and removes extra quotation marks in the CLI flag in `deployment.yaml`. 