### PR TITLE
fixed: helm chart broken with otel/opentelemetry-collector-contrib >=…

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.8.1
+version: 0.8.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.37.1
+appVersion: 0.43.0

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -129,7 +129,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
 
 command:
-  name: otelcontribcol
+  name: otelcol-contrib
 ```
 
 The way this feature works is it adds a `filelog` receiver on the `logs` pipeline. This receiver is preconfigured
@@ -175,7 +175,7 @@ image:
   repository: otel/opentelemetry-collector-contrib
 
 command:
-  name: otelcontribcol
+  name: otelcol-contrib
 ```
 
 ### Other configuration options

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -134,6 +134,9 @@ service:
       exporters: [otlp]
     traces:
       exporters: [otlp]
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
 {{- end }}
 {{- end }}
 

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -11,7 +11,6 @@ containers:
     command:
       - /{{ .Values.command.name }}
       - --config=/conf/relay.yaml
-      - --metrics-addr=0.0.0.0:8888
       {{- range .Values.command.extraArgs }}
       - {{ . }}
       {{- end }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -86,7 +86,7 @@ imagePullSecrets: []
 
 # OpenTelemetry Collector executable
 command:
-  name: otelcontribcol
+  name: otelcol-contrib
   extraArgs: []
 
 serviceAccount:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -41,6 +41,9 @@ config:
     zipkin:
       endpoint: 0.0.0.0:9411
   service:
+    telemetry:
+      metrics:
+        address: 0.0.0.0:8888
     extensions:
       - health_check
       - memory_ballast


### PR DESCRIPTION
These changes attempt to make the helm chart compatible with the otel/opentelemetry-collector-contrib container >= 0.42.0. It resolves #110

It looks like not only the container’s entrypoint changed but so too has its args.