### PR TITLE
Update podDisruptionBudget default values

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.8.3
+version: 0.8.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podDisruptionBudget.enabled .Values.standaloneCollector.enabled }}
+{{- if and .podDisruptionBudget standaloneCollector.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podDisruptionBudget | toYaml | trim | indent 2 .Values.standaloneCollector.enabled }}
+{{- if and .Values.podDisruptionBudget.enabled .Values.standaloneCollector.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- with podDisruptionBudget.minAvailable }}
+     minAvailable: {{ . }}
+  {{- end }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .podDisruptionBudget standaloneCollector.enabled }}
+{{- if and .Values.podDisruptionBudget | toYaml | trim | indent 2 .Values.standaloneCollector.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -6,10 +6,12 @@ metadata:
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:
-  {{- with podDisruptionBudget.minAvailable }}
-     minAvailable: {{ . }}
-  {{- end }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
   selector:
     matchLabels:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -328,8 +328,8 @@ serviceMonitor:
   #  release: kube-prometheus-stack
 
 # PodDisruptionBudget is used only if standaloneCollector enabled
-podDisruptionBudget: {}
-#   minAvailable: 2
+podDisruptionBudget:
+  minAvailable: 2
 #   maxUnavailable: 1
 
 # autoscaling is used only if standaloneCollector enabled

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -330,7 +330,7 @@ serviceMonitor:
 # PodDisruptionBudget is used only if standaloneCollector enabled
 podDisruptionBudget:
   enabled: false
-  minAvailable: 2
+#   minAvailable: 2
 #   maxUnavailable: 1
 
 # autoscaling is used only if standaloneCollector enabled

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -329,6 +329,7 @@ serviceMonitor:
 
 # PodDisruptionBudget is used only if standaloneCollector enabled
 podDisruptionBudget:
+  enabled: false
   minAvailable: 2
 #   maxUnavailable: 1
 

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -313,11 +313,7 @@ serviceMonitor:
   #  release: kube-prometheus-stack
 
 # PodDisruptionBudget is used only if standaloneCollector enabled
-podDisruptionBudget:
-  enabled: false
-  # Use minAvailable or maxUnavailable option
-  minAvailable: 2
-  # maxUnavailable: 1
+podDisruptionBudget: {}
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -317,7 +317,7 @@ podDisruptionBudget:
   enabled: false
   # Use minAvailable or maxUnavailable option
   minAvailable: 2
-  # maxUnavailable:
+  # maxUnavailable: 1
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -316,7 +316,7 @@ serviceMonitor:
 podDisruptionBudget:
   enabled: false
   minAvailable: 2
-  maxUnavailable: null
+  maxUnavailable:
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -314,6 +314,8 @@ serviceMonitor:
 
 # PodDisruptionBudget is used only if standaloneCollector enabled
 podDisruptionBudget: {}
+#   minAvailable: 2
+#   maxUnavailable: 1
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -315,6 +315,7 @@ serviceMonitor:
 # PodDisruptionBudget is used only if standaloneCollector enabled
 podDisruptionBudget:
   enabled: false
+  # Use minAvailable or maxUnavailable option
   minAvailable: 2
   maxUnavailable:
 

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -316,7 +316,7 @@ serviceMonitor:
 podDisruptionBudget:
   enabled: false
   minAvailable: 2
-  maxUnavailable: 1
+  maxUnavailable: null
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -317,7 +317,7 @@ podDisruptionBudget:
   enabled: false
   # Use minAvailable or maxUnavailable option
   minAvailable: 2
-  maxUnavailable:
+  # maxUnavailable:
 
 # autoscaling is used only if standaloneCollector enabled
 autoscaling:


### PR DESCRIPTION
By default, you can only have one or the other. If both are set then we get the following error: 

```
EXIT STATUS
  1
 
COMBINED OUTPUT:
  Error: UPGRADE FAILED: release opentelemetry-collector failed, and has been rolled back due to atomic being set: failed to create resource: PodDisruptionBudget.policy "opentelemetry-collector" is invalid: spec: Invalid value: policy.PodDisruptionBudgetSpec{MinAvailable:(*intstr.IntOrString)(0xc045b8be40), Selector:(*v1.LabelSelector)(0xc045b8be60), MaxUnavailable:(*intstr.IntOrString)(0xc045b8be20)}: minAvailable and maxUnavailable cannot be both set
```