### PR TITLE
Allow user-defined install namespace for operator

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -59,7 +59,8 @@ jobs:
           until kubectl get ns opentelemetry-operator-system 2>&1 | grep "namespaces \"opentelemetry-operator-system\" not found"; do sleep 1; done
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
-          helm install my-opentelemetry-operator ./charts/opentelemetry-operator
+          kubectl create namespace opentelemetry-operator-system
+          helm install --namespace=opentelemetry-operator-system my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
           git clone https://github.com/open-telemetry/opentelemetry-operator.git
           kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.5.4
+version: 0.6.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -58,25 +58,17 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 
 ## Install Chart
 
-If you didn't create the namespace `opentelemetry-operator-system` before (steps in the third method to generate the TLS cert),
-the OpenTelemetry Operator chart will be installed in the namespace automatically. The installation command example is as below.
-
 ```console
 $ helm install \
   my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 
-However, if you create the namespace and place the TLS cert in the desired secret, you will need to set `createNamespace`
-to `false` to make sure Helm won't try to create an existing namespace, which would cause an error. Installation command example is as below.
+If you created a custom namespace, like in the TLS Certificate Requirement section above, you will need to specify the namespace with the `--namespace` helm option:
 
 ```console
-$ helm install \
-  my-opentelemetry-operator open-telemetry/opentelemetry-operator \
-  --set createNamespace=false
+$ helm install --namespace opentelemetry-operator-system \
+  my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
-
-Note that `--namespace` option here won't affect where the OpenTelemetry Operator and other resources this chart contains are installed.
-It will only affect on where the Helm chart release info is stored, which is `default` namespace by default.
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
@@ -96,12 +88,6 @@ The OpenTelemetry Collector CRD created by this chart won't be removed by defaul
 
 ```console
 $ kubectl delete crd opentelemetrycollectors.opentelemetry.io
-```
-
-If the namespace wasn't created by the Helm chart, you'll need to manually remove it as well:
-
-```console
-$ kubectl delete ns opentelemetry-operator-system
 ```
 
 ## Upgrade Chart

--- a/charts/opentelemetry-operator/release/release-checklist.md
+++ b/charts/opentelemetry-operator/release/release-checklist.md
@@ -10,7 +10,7 @@
 - [ ] If you see any template files need to be updated, update them to maintain consistency with the ones in the manifest (especially be careful with `role.yaml` and `clusterrole.yaml`).  \
   Create a new YAML file under `templates` directory if it doesn't exist.
   Use `{{ template "opentelemetry-operator.name" . }}` to represent the name of OTEL Operator which probably is `opentelemetry-operator` in the manifest.
-  Use `{{ template "opentelemetry-operator.namespace" . }}` to represent the namespace which probably is `opentelemetry-operator-system` in the manifest.
+  Use `{{ .Release.Namespace }}` to represent the namespace.
 - [ ] Update `README` if there is a breaking change in the Operator Helm chart
 - [ ] Bump chart version in `Chart.yaml`
 

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -19,10 +19,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "opentelemetry-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Define the namespace where the resources in the chart will be installed.
-*/}}
-{{- define "opentelemetry-operator.namespace" -}}
-opentelemetry-operator-system
-{{- end -}}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/mutatingwebhookconfiguration.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/mutatingwebhookconfiguration.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" (include "opentelemetry-operator.namespace" .) (include "opentelemetry-operator.name" .) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" .Release.Namespace (include "opentelemetry-operator.name" .) }}
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-mutating-webhook-configuration
@@ -13,7 +13,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-instrumentation
     failurePolicy: Fail
     name: minstrumentation.kb.io
@@ -33,7 +33,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-opentelemetrycollector
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: mopentelemetrycollector.kb.io
@@ -53,7 +53,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /mutate-v1-pod
     failurePolicy: Ignore
     name: mpod.kb.io

--- a/charts/opentelemetry-operator/templates/admission-webhooks/validatingwebhookconfiguration.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/validatingwebhookconfiguration.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" (include "opentelemetry-operator.namespace" .) (include "opentelemetry-operator.name" .) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-serving-cert" .Release.Namespace (include "opentelemetry-operator.name" .) }}
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-validating-webhook-configuration
@@ -13,7 +13,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
     failurePolicy: Fail
     name: vinstrumentationcreateupdate.kb.io
@@ -33,7 +33,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
     failurePolicy: Ignore
     name: vinstrumentationdelete.kb.io
@@ -52,7 +52,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: vopentelemetrycollectorcreateupdate.kb.io
@@ -72,7 +72,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-        namespace: {{ template "opentelemetry-operator.namespace" . }}
+        namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
     failurePolicy: Ignore
     name: vopentelemetrycollectordelete.kb.io

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-serving-cert
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-    - {{ template "opentelemetry-operator.name" . }}-webhook-service.{{ template "opentelemetry-operator.namespace" . }}.svc
-    - {{ template "opentelemetry-operator.name" . }}-webhook-service.{{ template "opentelemetry-operator.namespace" . }}.svc.cluster.local
+    - {{ template "opentelemetry-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    - {{ template "opentelemetry-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     {{- if .Values.admissionWebhooks.certManager.issuerRef }}
     {{- toYaml .Values.admissionWebhooks.certManager.issuerRef | nindent 4 }}
@@ -29,7 +29,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-selfsigned-issuer
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "opentelemetry-operator.name" . }}-controller-manager
-    namespace: {{ template "opentelemetry-operator.namespace" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -26,4 +26,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "opentelemetry-operator.name" . }}-controller-manager
-    namespace: {{ template "opentelemetry-operator.namespace" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager
   name: {{ template "opentelemetry-operator.name" . }}-controller-manager
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/opentelemetry-operator/templates/namespace.yaml
+++ b/charts/opentelemetry-operator/templates/namespace.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.createNamespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app.kubernetes.io/name: opentelemetry-operator
-    control-plane: controller-manager
-  name: {{ template "opentelemetry-operator.namespace" . }}
-{{- end }}

--- a/charts/opentelemetry-operator/templates/role.yaml
+++ b/charts/opentelemetry-operator/templates/role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-leader-election-role
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-operator/templates/rolebinding.yaml
+++ b/charts/opentelemetry-operator/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-leader-election-rolebinding
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,4 +12,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "opentelemetry-operator.name" . }}-controller-manager
-    namespace: {{ template "opentelemetry-operator.namespace" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/opentelemetry-operator/templates/service.yaml
+++ b/charts/opentelemetry-operator/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager
   name: {{ template "opentelemetry-operator.name" . }}-controller-manager-metrics-service
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: https
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-webhook-service
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/charts/opentelemetry-operator/templates/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/templates/serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: {{ template "opentelemetry-operator.name" . }}-controller-manager
-  namespace: {{ template "opentelemetry-operator.namespace" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -6,11 +6,6 @@
 ##
 nameOverride: ""
 
-## Create the opentelemetry-operator-system namespace where the operator will be installed to.
-## Disable this if you have already created the namespace.
-##
-createNamespace: true
-
 ## Provide OpenTelemetry Operator manager container image and resources.
 ##
 manager:


### PR DESCRIPTION
As mentioned in #73 it is rather unusual for a chart to both 1) Automatically create the install namespace; and 2) Not allow changing the install namespace.

In my experience it is more idiomatic in Helm to control the install namespace by specifying the `--namespace` helm flag.

This PR:

- Removes the namespace auto-create functionality
- Removes the hardcoded namespace name and;
- Uses `{{ .Release.Namespace }}` for `metadata.namespace` and related references

Fixes #73 