### PR TITLE
Fix: use --collector-image instead of --otelcol-image

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.1
+version: 0.6.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
-            - --otelcol-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
+            - --collector-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
           command:
             - /manager


### PR DESCRIPTION
It looks like the underlying operator image was updated to accept the flag `--collector-image` instead of `--otelcol-image` (which we currently set).

See https://github.com/open-telemetry/opentelemetry-operator/blob/7101339a6b346ec929e81cacfdbd270f04824356/main.go#L87

This updates the Chart to set the correct flag