### PR TITLE
Update operator e2e tests to always run against appVersion

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -62,6 +62,7 @@ jobs:
           kubectl create namespace opentelemetry-operator-system
           helm install --namespace=opentelemetry-operator-system my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
-          git clone https://github.com/open-telemetry/opentelemetry-operator.git
+          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
+          git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
           kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml
         if: steps.list-changed.outputs.operator-changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -62,7 +62,7 @@ jobs:
           kubectl create namespace opentelemetry-operator-system
           helm install --namespace=opentelemetry-operator-system my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
-          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
+          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
           git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
           kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml
         if: steps.list-changed.outputs.operator-changed == 'true'


### PR DESCRIPTION
Fixes #126 

Today the lint-test workflow runs the operator e2e tests against latest.  This can cause problem if the operator latest is ahead of the chart's target version.  This change updates the lint-test workflow to always run the operator e2e tests against the operator version that matches appVersion.