### PR TITLE
Change `--otelcol-image` to `--collector-image`

### DIFF
--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
-            - --otelcol-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
+            - --collector-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
           command:
             - /manager


### PR DESCRIPTION
This PR changes the CLI flag name from `--otelcol-image` to `--collector-image` to reflect the new naming of the CLI flag.