### PR TITLE
Increase default image version to 0.46.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.9.2
+version: 0.9.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.43.0
+appVersion: 0.46.0


### PR DESCRIPTION
Updated appVersion to 0.46.0 so that the default image version will be 0.46.0.  Reviewing the Core and Contrib change log and release notes I didn't see anything that would affect the charts.  Let me know if there is something I missed.