### PR TITLE
feat: Provide integration with Artifact Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenTelemetry Helm Charts
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opentelemetry-helm)](https://artifacthub.io/packages/search?repo=opentelemetry-helm)
 
 This repository contains [Helm](https://helm.sh/) charts for OpenTelemetry project.
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -2,5 +2,5 @@
 # Used to become verified publisher and more - https://artifacthub.io/docs/topics/repositories/#verified-publisher
 repositoryID: 05f5cc01-3904-4382-abd7-06b0aa8ed01b
 owners:
-  - name: kerkhove.tom
-    email: kerkhove.tom@gmail.com
+  - name: Dmitrii Anoshin
+    email: anoshindx@gmail.com

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+# Artifact Hub repository metadata file
+# Used to become verified publisher and more - https://artifacthub.io/docs/topics/repositories/#verified-publisher
+repositoryID: 05f5cc01-3904-4382-abd7-06b0aa8ed01b
+owners:
+  - name: kerkhove.tom
+    email: kerkhove.tom@gmail.com


### PR DESCRIPTION
Provide integration with Artifact Hub so that Helm charts are discoverable there.

I have already created and configured an organization on Artifact Hub and configured it so that it will be [a verified publisher](https://artifacthub.io/docs/topics/repositories/#verified-publisher).

Once things are merged, you can apply to [claim official status](https://artifacthub.io/docs/topics/repositories/#official-status).

Outcome: https://artifacthub.io/packages/search?repo=opentelemetry-helm&sort=relevance&page=1

Relates to https://github.com/open-telemetry/opentelemetry-helm-charts/issues/108