### PR TITLE
Update OTEL Operator to v0.45.0 release

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.2
+version: 0.6.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -15,4 +15,4 @@ maintainers:
   - name: alolita
   - name: Aneurysm9
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.43.0
+appVersion: 0.45.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -1630,7 +1630,7 @@ spec:
               description: OpenTelemetryCollectorStatus defines the observed state of OpenTelemetryCollector.
               properties:
                 messages:
-                  description: Messages about actions performed by the operator on this resource.
+                  description: 'Messages about actions performed by the operator on this resource. Deprecated: use Kubernetes events instead.'
                   items:
                     type: string
                   type: array

--- a/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
@@ -23,6 +23,15 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - jsonPath: .spec.exporter.endpoint
+          name: Endpoint
+          type: string
+        - jsonPath: .spec.sampler.type
+          name: Sampler
+          type: string
+        - jsonPath: .spec.sampler.argument
+          name: Sampler Arg
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.43.0
+    tag: v0.45.0
   collectorImage:
     repository:
     tag:


### PR DESCRIPTION
 diff `opentelemetry-operator.yaml` between v0.43.0 and v0.45.0
```
>     - jsonPath: .spec.exporter.endpoint
>       name: Endpoint
>       type: string
>     - jsonPath: .spec.sampler.type
>       name: Sampler
>       type: string
>     - jsonPath: .spec.sampler.argument
>       name: Sampler Arg
>       type: string
2092c2101
<                 description: Messages about actions performed by the operator on this resource.
---
>                 description: 'Messages about actions performed by the operator on this resource. Deprecated: use Kubernetes events instead.'
2468c2477
<         image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.43.0
---
>         image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.45.0
```