### PR TITLE
feat: support environment variables in manager

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.3
+version: 0.6.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -24,8 +24,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Manager add environment variables from map to env obj.
 */}}
-{{- define "opentelemetry-operator.envs" -}}
-{{- range $name, $value := .Values.manager.envs }}
+{{- define "opentelemetry-operator.env" -}}
+{{- range $name, $value := .Values.manager.env }}
 - name: {{ $name }}
   value: {{ $value | quote -}}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -19,3 +19,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "opentelemetry-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{/*
+Manager add environment variables from map to env obj.
+*/}}
+{{- define "opentelemetry-operator.envs" -}}
+{{- range $name, $value := .Values.manager.envs }}
+- name: {{ $name }}
+  value: {{ $value | quote -}}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -19,14 +19,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "opentelemetry-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-
-{{/*
-Manager add environment variables from map to env obj.
-*/}}
-{{- define "opentelemetry-operator.env" -}}
-{{- range $name, $value := .Values.manager.env }}
-- name: {{ $name }}
-  value: {{ $value | quote -}}
-{{- end }}
-{{- end }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
             {{- end }}
           command:
             - /manager
+          {{- if .Values.manager.env }}
+          env:
+            {{- include "opentelemetry-operator.envs" . | nindent 12 -}}
+          {{- end }}
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           name: manager
           ports:

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -29,7 +29,10 @@ spec:
             - /manager
           {{- if .Values.manager.env }}
           env:
-            {{- include "opentelemetry-operator.env" . | nindent 12 -}}
+            {{- range $name, $value := .Values.manager.env  }}
+            - name: {{ $name }}
+              value: {{ $value | quote -}}
+            {{- end }}
           {{- end }}
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           name: manager

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - /manager
           {{- if .Values.manager.env }}
           env:
-            {{- include "opentelemetry-operator.envs" . | nindent 12 -}}
+            {{- include "opentelemetry-operator.env" . | nindent 12 -}}
           {{- end }}
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           name: manager

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -24,6 +24,9 @@ manager:
     requests:
       cpu: 100m
       memory: 64Mi
+  ## Adds additional environment variables
+  ## e.g ENV_VAR: env_value
+  env:
 
 ## Provide OpenTelemetry Operator kube-rbac-proxy container image.
 ##


### PR DESCRIPTION
This PR adds support for configuration of additional environment variables needed  to configure Opentelemetry-Operator Manager. Thanks to that `WATCH_NAMESPACE` variable can be configured during chart deployment.

Functionality:

- If `values.manager.env` is empty then `env` is not added to the manager deployment (default)
- If `values.manager.env` contains map (KEY: value) then it's added to the manager deployment as k8s env obj