### PR TITLE
collector chart 0.9.4 cannot be deployed with some helm versions

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.9.4
+version: 0.9.5
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -4,6 +4,9 @@
   "title": "Values",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object"
+    },
     "nameOverride": {
       "description": "Override name of the chart used in Kubernetes object names.",
       "type": "string"


### PR DESCRIPTION
The helm chart with 0.9.4 set `additionalProperties` to false in `values.schema.json`.

Depending on the helm version used the chart fails to be deployed with the following error message:
 \- (root): Additional property global is not allowed

There is also an issue already in the helm repository:
https://github.com/helm/helm/issues/10392

Current established workaround is to add global to the allowed properties or set additionalProperties to true. I choose the first possibility