### PR TITLE
Update OTEL Operator to v0.46.0 release

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.4
+version: 0.6.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -15,4 +15,4 @@ maintainers:
   - name: alolita
   - name: Aneurysm9
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.45.0
+appVersion: 0.46.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -174,6 +174,10 @@ spec:
                 imagePullPolicy:
                   description: ImagePullPolicy indicates the pull policy to be used for retrieving the container image (Always, Never, IfNotPresent)
                   type: string
+                maxReplicas:
+                  description: MaxReplicas sets an upper bound to the autoscaling feature. If MaxReplicas is set autoscaling is enabled.
+                  format: int32
+                  type: integer
                 mode:
                   description: Mode represents how the collector should be deployed (deployment, daemonset, statefulset or sidecar)
                   enum:

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -101,6 +101,18 @@ rules:
       - update
       - watch
   - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.45.0
+    tag: v0.46.0
   collectorImage:
     repository:
     tag:


### PR DESCRIPTION
diff opentelemetry-operator.yaml between v0.45.0 and v0.46.0
```
644a645,648
>               maxReplicas:
>                 description: MaxReplicas sets an upper bound to the autoscaling feature. If MaxReplicas is set autoscaling is enabled.
>                 format: int32
>                 type: integer
2275a2280,2291
>   - autoscaling
>   resources:
>   - horizontalpodautoscalers
>   verbs:
>   - create
>   - delete
>   - get
>   - list
>   - patch
>   - update
>   - watch
> - apiGroups:
2477c2493
<         image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.45.0
---
>         image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.46.0
```