### PR TITLE
Added more flexible volume variables

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.9.6
+version: 0.10.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.10.0
+version: 0.11.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -1,0 +1,11 @@
+{{- if not (eq (toString .Values.extraConfigMapMounts) "<nil>") }}
+[WARNING] "extraConfigMapMounts" parameter is deprecated, please use "extraVolumes" or "extraVolumesMounts" instead.
+{{ end }}
+
+{{- if not (eq (toString .Values.extraHostPathMounts) "<nil>") }}
+[WARNING] "extraHostPathMounts" parameter is deprecated, please use "extraVolumes" or "extraVolumesMounts" instead.
+{{ end }}
+
+{{- if not (eq (toString .Values.secretMounts) "<nil>") }}
+[WARNING] "secretMounts" parameter is deprecated, please use "extraVolumes" or "extraVolumesMounts" instead.
+{{ end }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -83,6 +83,9 @@ containers:
         mountPath: /var/lib/docker/containers
         readOnly: true
       {{- end }}
+      {{- if .Values.extraVolumeMounts }}
+      {{- toYaml .Values.extraVolumeMounts | nindent 6 }}
+      {{- end }}
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName | quote }}
 {{- end }}
@@ -115,6 +118,9 @@ volumes:
   - name: varlibdockercontainers
     hostPath:
       path: /var/lib/docker/containers
+  {{- end }}
+  {{- if .Values.extraVolumes }}
+  {{- toYaml .Values.extraVolumes | nindent 2 }}
   {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -161,6 +161,18 @@
         "type": "object"
       }
     },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "ports": {
       "type": "object",
       "patternProperties": {

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -140,9 +140,8 @@ affinity: {}
 priorityClassName: ""
 
 extraEnvs: []
-extraConfigMapMounts: []
-extraHostPathMounts: []
-secretMounts: []
+extraVolumes: []
+extraVolumeMounts: []
 
 # Configuration for ports, shared between agentCollector, standaloneCollector and service.
 # Can be overridden here or for agentCollector and standaloneCollector independently.


### PR DESCRIPTION
This PR adds new `extraVolumes` and `extraVolumeMounts` variable and deprecates `extraConfigMapMounts`, `extraHostPathMounts`, and `secretMounts`.  

Going forward, `extraVolumes` and `extraVolumeMounts` will allow more flexible `volumes` and `volumeMounts` by putting the configuration in the hands of the user.

Fixes #133 