### PR TITLE
Updated default image to 0.47.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.11.0
+version: 0.12.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.46.0
+appVersion: 0.47.0


### PR DESCRIPTION
This PR updates the default collector image version to 0.47.0.  Reviewing opentelemetry-collector and opentelemetry-collector-contrib I see no breaking changes that will affect the chart configuration.

Fixes #153 