### PR TITLE
Updated default collector version to 0.48.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.12.1
+version: 0.13.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.47.0
+appVersion: 0.48.0

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0169178595958e64fddb5217b2e37306cd486549e563db94d46cf2af0cb0930
+        checksum/config: 294dce6218066ebb50a5c966389b963f87ec4de2ac69cff379f02f0ff0a9deb7
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
@@ -36,7 +36,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.47.0"
+          image: "otel/opentelemetry-collector-contrib:0.48.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 16a2701362c0b0946768257cf9a681979ed9b6d6a274dd56cff0531cd938f4a0
+        checksum/config: c0d0c7464ec0f5bbb14a3c629828e83075a63048f37b2cbb5f597c45bfa73cde
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
@@ -37,7 +37,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.47.0"
+          image: "otel/opentelemetry-collector-contrib:0.48.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a4eaf97a54f468568eb69407489b2d1c3d4800fa22bee5c6b4fb593fc8eb2bfd
+        checksum/config: 3f3ff1eb2e419fe2fcc6e90a576af8ecdeec2a76b0268f3a0e748f31f81ea111
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
@@ -36,7 +36,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.47.0"
+          image: "otel/opentelemetry-collector-contrib:0.48.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 16a2701362c0b0946768257cf9a681979ed9b6d6a274dd56cff0531cd938f4a0
+        checksum/config: c0d0c7464ec0f5bbb14a3c629828e83075a63048f37b2cbb5f597c45bfa73cde
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
@@ -37,7 +37,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.47.0"
+          image: "otel/opentelemetry-collector-contrib:0.48.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.12.1
+    helm.sh/chart: opentelemetry-collector-0.13.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.47.0"
+    app.kubernetes.io/version: "0.48.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
This PR updates the default collector image version to 0.48.0. Reviewing opentelemetry-collector and opentelemetry-collector-contrib I see no breaking changes that will affect the chart configuration.

Fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/160