### PR TITLE
Bump version to force release.

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.13.0
+version: 0.13.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 294dce6218066ebb50a5c966389b963f87ec4de2ac69cff379f02f0ff0a9deb7
+        checksum/config: b3cd38847f5560804064e4d665b4c11af4d99240647408126b8f8de4a66c3bf8
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0d0c7464ec0f5bbb14a3c629828e83075a63048f37b2cbb5f597c45bfa73cde
+        checksum/config: c33936634eca7258893900536841d6c5a41c8457fb8645ecbe41ad6a06273d12
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/agent-and-standalone/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3f3ff1eb2e419fe2fcc6e90a576af8ecdeec2a76b0268f3a0e748f31f81ea111
+        checksum/config: 8efff07da200b815feda02e98243bb023e45ccad6751c88e92f0034670e57ca6
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-collector/examples/agent-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/agent-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0d0c7464ec0f5bbb14a3c629828e83075a63048f37b2cbb5f597c45bfa73cde
+        checksum/config: c33936634eca7258893900536841d6c5a41c8457fb8645ecbe41ad6a06273d12
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"

--- a/charts/opentelemetry-collector/examples/standalone-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.13.0
+    helm.sh/chart: opentelemetry-collector-0.13.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.48.0"


### PR DESCRIPTION
Release 0.13.0 did not work properly.  Bumping patch version to force new release.  Related to https://github.com/open-telemetry/opentelemetry-helm-charts/pull/161