### PR TITLE
charts/opentelemetry-operator: define default container

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.6
+version: 0.6.7
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       control-plane: controller-manager
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         app.kubernetes.io/name: opentelemetry-operator
         control-plane: controller-manager


### PR DESCRIPTION
Use [kubectl well-known annotation](https://github.com/paulfantom/opentelemetry-helm-charts/pull/new/default-container) to define default container in a pod. This simplifies operations like getting logs from a container as seen below:

```shell
# Current way of getting manager logs
kubectl logs opentelemetry-operator-controller-manager-5d47c94d97-w7xs9 -c manager
# After PR is merged
kubectl logs opentelemetry-operator-controller-manager-5d47c94d97-w7xs9
```