### PR TITLE
Break out collector and operator specific tests

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,11 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
     - name: Set up Helm
       uses: azure/setup-helm@v1
       with:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,30 @@
+name: Setup
+description: sets up helm lint and testing environment
+inputs:
+  create-kind-cluster:  # id of input
+    description: 'Whether or not to create a kind cluster during setup'
+    required: true
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.4.1
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.0.1
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.2.0
+      if: ${{ inputs.create-kind-cluster == 'true' }}

--- a/.github/workflows/collector-test.yaml
+++ b/.github/workflows/collector-test.yaml
@@ -11,7 +11,10 @@ jobs:
   collector-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/collector-test.yaml
+++ b/.github/workflows/collector-test.yaml
@@ -1,0 +1,30 @@
+name: Test Collector Chart
+
+on:
+  pull_request:
+    paths: 
+    - 'charts/opentelemetry-collector/**'
+    branches:
+      - main
+
+jobs:
+  collector-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          create-kind-cluster: "true"
+
+      - name: Run make check-examples
+        run: make check-examples
+
+      - name: Run chart-testing (install)
+        run: ct install --charts charts/opentelemetry-collector
+
+      - name: Run daemonset and deployment install test
+        run: |
+          kubectl apply -f ./charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered
+          kubectl rollout status daemonset example-opentelemetry-collector-agent --timeout=30s
+          kubectl rollout status deployment example-opentelemetry-collector --timeout=30s

--- a/.github/workflows/collector-test.yaml
+++ b/.github/workflows/collector-test.yaml
@@ -20,9 +20,6 @@ jobs:
         with:
           create-kind-cluster: "true"
 
-      - name: Run make check-examples
-        run: make check-examples
-
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-collector
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,19 @@
+name: Lint Charts
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          create-kind-cluster: "false"
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch main
+
+      - name: Run make check-examples
+        run: make check-examples

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -1,67 +1,30 @@
-name: Lint and Test Charts
+name: Test Operator Charts
 
 on:
   pull_request:
+    paths: 
+    - 'charts/opentelemetry-operator/**'
     branches:
       - main
 
 jobs:
-  lint-test:
+  operator-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          fetch-depth: 0
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.1
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch main)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-          if [[ "$changed" == *"opentelemetry-operator"* ]]; then
-            echo "::set-output name=operator-changed::true"
-          fi
-
-      - name: Run chart-testing (lint)
-        run: ct lint --target-branch main
-
-      - name: Run make check-examples
-        run: make check-examples
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
-        if: steps.list-changed.outputs.changed == 'true'
+          create-kind-cluster: "true"
 
       - name: Install cert-manager
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
           kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
-        if: steps.list-changed.outputs.operator-changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch main
-
-      - name: Run daemonset and deployment install test
-        run: |
-          kubectl apply -f ./charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered
-          kubectl rollout status daemonset example-opentelemetry-collector-agent --timeout=30s
-          kubectl rollout status deployment example-opentelemetry-collector --timeout=30s
+        run: ct install --charts charts/opentelemetry-operator
 
       - name: Run KUTTL smoke tests
         run: |
@@ -74,4 +37,3 @@ jobs:
           appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
           git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
           kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml
-        if: steps.list-changed.outputs.operator-changed == 'true'

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -11,7 +11,10 @@ jobs:
   operator-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
This PR breaks our collector and operator specific tests into their own workflows.  Setup steps are moved to a composite action so they can be used across the 3 different workflows.  The collector and operator workflows are only run when files in the chart have been changed.

After this change the integration tests will run regardless of whether or not the chart passes linting, but all existing lint checks are still applied via the lint workflow.  This will allow the charts to be tested even if they aren't passing the lint test, but also the PR will not be completable until linting also passes.

Fixes #179 