### PR TITLE
Update sidecar example in Operator README

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.7
+version: 0.6.8
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -257,7 +257,7 @@ spec:
     receivers:
       jaeger:
         protocols:
-          grpc:
+          thrift_compact:
     processors:
 
     exporters:


### PR DESCRIPTION
This PR updates the sidecar example in the Operator README, as it does not work. It changes the `jaegerreceiver` protocol to `thrift_compact` instead of `grpc`. This is also reflected in a PR on the `opentelemetry-operator` repository, [837](https://github.com/open-telemetry/opentelemetry-operator/pull/837).