### PR TITLE
Remove move statement for run id

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.16.2
+version: 0.16.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -81,9 +81,6 @@ data:
         - from: attributes.restart_count
           to: attributes["k8s.container.restart_count"]
           type: move
-        - from: attributes.run_id
-          to: attributes["run_id"]
-          type: move
         - from: attributes.uid
           to: attributes["k8s.pod.uid"]
           type: move

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -192,9 +192,6 @@ receivers:
         from: attributes.restart_count
         to: attributes["k8s.container.restart_count"]
       - type: move
-        from: attributes.run_id
-        to: attributes["run_id"]
-      - type: move
         from: attributes.uid
         to: attributes["k8s.pod.uid"]
       # Clean up log body


### PR DESCRIPTION
Fixes #204

This PR removes the `move` operation for `run_id` from the generated `filelog` receiver config. This was causing log entries to not be processed.