### PR TITLE
Updated default collector version to 0.51.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.16.4
+version: 0.17.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ maintainers:
   - name: pjanotti
   - name: tigrannajaryan
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.50.0
+appVersion: 0.51.0

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 956c07dde4e5f7cefbd96562ed29f969daeb61521f46807148a716ae53b7e64c
+        checksum/config: 7c2112222d446eb6dafa858abca1598611cb45c23dbecd1d022cd9c0f5c23378
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -38,7 +38,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 29bb48fe5726fb826db919b6bf74d49a3639b248d658a6a407187801df5ff5fa
+        checksum/config: 622cba5d3292ec6105325114ff7455ccb6ec5a9bb4acd2eea8eae9c697799b90
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 303d734c472e9156243c3e6b93529222bc8e366f9d7ab731053cd23b4ebdad44
+        checksum/config: 38c7adf590cc1fcd4685a62cf588ada864a9c0b3453b39f7906b648a7824d415
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -38,7 +38,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 118f366afd5d044f72490610cd0ee085b6a293772b29d0e1603b19f4410dddee
+        checksum/config: ed1ab0ea8e58f5c9920ce50dadfb79274db2901eeda9ad43ca99490ccc83fe64
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -38,7 +38,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b5586ce5838c3659be9a0277d956196eceb06ce34a6565626bdb30fc81618b11
+        checksum/config: 1149b6a1151455a2209345e087e7df27b1d823ad762041c4835bd35219592c30
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -38,7 +38,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 209819cc7f8d740224dbdddea8eaa2c885d5125af295eb55b0f47a05df6cfb14
+        checksum/config: cae2cf9ab11f0c04729bcf7e478bfdb78753bec129965ebae2a0527e9c952d83
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -38,7 +38,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 80efd5470734f47bcb9d57b80f79cf5f4e4041a5b7104bc718515c4b4eb5d403
+        checksum/config: 717900d0077e35041f99de4fd559a1be34e980b92d66869b826617bd2c0d6b9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 09f0d49afab86ac12b77d4a5e85059efa6ad25bae704531f2af035d191a66806
+        checksum/config: 73b90e6a83ba09c457d6ce7e8567d335ecb3e84bb32c8445bfa13165b7e8aced
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.50.0"
+          image: "otel/opentelemetry-collector-contrib:0.51.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: otlp

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.16.4
+    helm.sh/chart: opentelemetry-collector-0.17.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.50.0"
+    app.kubernetes.io/version: "0.51.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
This PR updates the default collector image version to 0.51.0. Reviewing opentelemetry-collector and opentelemetry-collector-contrib I see no breaking changes that will affect the chart configuration.  [There was an update to the filelog receiver k8s example to fix native OTel logs collection issue where 0 length logs cause errors](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9754), but our filelog receiver template already has the correct regex.

Fixes #209 