### PR TITLE
chore(ot-operator): update version to v0.51.0

### DIFF
--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -2,8 +2,8 @@ name: Test Operator Charts
 
 on:
   pull_request:
-    paths: 
-    - 'charts/opentelemetry-operator/**'
+    paths:
+      - 'charts/opentelemetry-operator/**'
     branches:
       - main
 
@@ -29,14 +29,30 @@ jobs:
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-operator
 
-      - name: Run KUTTL smoke tests
+      - name: Get opentelemetry-operator repository
         run: |
-          until kubectl get ns opentelemetry-operator-system 2>&1 | grep "namespaces \"opentelemetry-operator-system\" not found"; do sleep 1; done
+          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
+          git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
+
+      - name: Use public target-allocator image in tests
+        run: |
+          LOCAL_TARGET_ALLOCATOR_IMG="local\/opentelemetry-operator-targetallocator:e2e"
+          PUBLIC_TARGET_ALLOCATOR_IMG="ghcr.io\/open-telemetry\/opentelemetry-operator\/target-allocator:0.1.0"
+
+          sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/smoke-targetallocator/02-install.yaml
+          sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/targetallocator-features/02-install.yaml
+
+      - name: Install kuttl
+        run: |
           sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
           sudo chmod +x /usr/local/bin/kubectl-kuttl
+
+      - name: Install opentelemetry-operator chart
+        run: |
+          until kubectl get ns opentelemetry-operator-system 2>&1 | grep "namespaces \"opentelemetry-operator-system\" not found"; do sleep 1; done
           kubectl create namespace opentelemetry-operator-system
           helm install --namespace=opentelemetry-operator-system my-opentelemetry-operator ./charts/opentelemetry-operator
           kubectl wait --timeout=5m --for=condition=available deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system
-          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
-          git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
-          kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml
+
+      - name: Run e2e tests
+        run:  kubectl kuttl test ./opentelemetry-operator/tests/e2e --config ./charts/opentelemetry-operator/release/kuttl-test.yaml

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.6.9
+version: 0.7.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -15,4 +15,4 @@ maintainers:
   - name: alolita
   - name: Aneurysm9
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.46.0
+appVersion: 0.51.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -189,7 +189,7 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description: NodeSelector to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment mode
+                  description: NodeSelector to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment modes
                   type: object
                 podAnnotations:
                   additionalProperties:

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -186,6 +186,11 @@ spec:
                     - sidecar
                     - statefulset
                   type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment mode
+                  type: object
                 podAnnotations:
                   additionalProperties:
                     type: string
@@ -438,9 +443,16 @@ spec:
                     image:
                       description: Image indicates the container image to use for the OpenTelemetry TargetAllocator.
                       type: string
+                    prometheusCR:
+                      description: PrometheusCR defines the configuration for the retrieval of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.com/v1 and podmonitor.monitoring.coreos.com/v1 )  retrieval. All CR instances which the ServiceAccount has access to will be retrieved. This includes other namespaces.
+                      properties:
+                        enabled:
+                          description: Enabled indicates whether to use a PrometheusOperator custom resources as targets or not.
+                          type: boolean
+                      type: object
                   type: object
                 tolerations:
-                  description: Toleration to schedule OpenTelemetry Collector pods. This is only relevant to daemonsets, statefulsets and deployments
+                  description: Toleration to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment mode
                   items:
                     description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                     properties:
@@ -1640,9 +1652,20 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 replicas:
-                  description: Replicas is currently not being set and might be removed in the next version.
+                  description: 'Replicas is currently not being set and might be removed in the next version. Deprecated: use "OpenTelemetryCollector.Status.Scale.Replicas" instead.'
                   format: int32
                   type: integer
+                scale:
+                  description: Scale is the OpenTelemetryCollector's scale subresource status.
+                  properties:
+                    replicas:
+                      description: The total number non-terminated pods targeted by this OpenTelemetryCollector's deployment or statefulSet.
+                      format: int32
+                      type: integer
+                    selector:
+                      description: The selector used to match the OpenTelemetryCollector's deployment or statefulSet pods.
+                      type: string
+                  type: object
                 version:
                   description: Version of the managed OpenTelemetry Collector (operand)
                   type: string
@@ -1652,8 +1675,9 @@ spec:
       storage: true
       subresources:
         scale:
+          labelSelectorPath: .status.scale.selector
           specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
+          statusReplicasPath: .status.scale.replicas
         status: {}
 status:
   acceptedNames:

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -452,7 +452,7 @@ spec:
                       type: object
                   type: object
                 tolerations:
-                  description: Toleration to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment mode
+                  description: Toleration to schedule OpenTelemetry Collector pods. This is only relevant to daemonset, statefulset, and deployment modes
                   items:
                     description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                     properties:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.46.0
+    tag: v0.51.0
   collectorImage:
     repository:
     tag:


### PR DESCRIPTION
Update of the OpenTelemetry Operator to [v0.51.0](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.51.0)