### PR TITLE
Added new values to allow custom ports

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.8.1
+version: 0.8.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -23,8 +23,10 @@ spec:
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - args:
-            - --metrics-addr=127.0.0.1:8080
+            - --metrics-addr=127.0.0.1:{{ .Values.manager.ports.metricsPort }}
             - --enable-leader-election
+            - --health-probe-addr=:{{ .Values.manager.ports.healthzPort }}
+            - --webhook-port={{ .Values.manager.ports.webhookPort }}
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
             - --collector-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
@@ -40,19 +42,19 @@ spec:
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           name: manager
           ports:
-            - containerPort: 9443
+            - containerPort: {{ .Values.manager.ports.webhookPort }}
               name: webhook-server
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: {{ .Values.manager.ports.healthzPort }}
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: {{ .Values.manager.ports.healthzPort }}
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: {{ toYaml .Values.manager.resources | nindent 12 }}
@@ -61,14 +63,14 @@ spec:
               name: cert
               readOnly: true
         - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
+            - --secure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.ports.proxyPort }}
+            - --upstream=http://127.0.0.1:{{ .Values.manager.ports.metricsPort }}/
             - --logtostderr=true
             - --v=0
           image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
           name: kube-rbac-proxy
           ports:
-            - containerPort: 8443
+            - containerPort: {{ .Values.kubeRBACProxy.ports.proxyPort }}
               name: https
               protocol: TCP
           {{- with .Values.kubeRBACProxy.resources }}

--- a/charts/opentelemetry-operator/templates/service.yaml
+++ b/charts/opentelemetry-operator/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: 9443
+      targetPort: webhook-server
   selector:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -17,6 +17,10 @@ manager:
   collectorImage:
     repository:
     tag:
+  ports:
+    metricsPort: 8080
+    webhookPort: 9443
+    healthzPort: 8081
   resources:
     limits:
       cpu: 100m
@@ -34,6 +38,8 @@ kubeRBACProxy:
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     tag: v0.8.0
+  ports:
+    proxyPort: 8443
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -37,9 +37,9 @@ manager:
 kubeRBACProxy:
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
+    tag: v0.11.0
   ports:
     proxyPort: 8443
-    tag: v0.11.0
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
This PR is related to the following issues: 

* https://github.com/open-telemetry/opentelemetry-helm-charts/issues/214
* https://github.com/open-telemetry/opentelemetry-operator/issues/896

It includes updates to the `opentelemetry-operator` chart to allow custom values to be used for ports:

```
--set manager.ports.metricsPort=8085
--set kubeRBACProxy.ports.proxyPort=8445
--set manager.ports.webhookPort=9445
--set manager.ports.healthzPort=8005
```

The default values for all these ports are the same as before and it's reflected in `values.yaml`

```yaml
manager:
# other values ...
  ports:
    metricsPort: 8080
    webhookPort: 9443
    healthzPort: 8081

kubeRBACProxy:
# other values ....
  ports:
    proxyPort: 8443
```

:warning: At this point, it's not going to work until PR https://github.com/open-telemetry/opentelemetry-operator/pull/899 is completed. If you want to test it meanwhile, please comment out or remove the lines: 

```yaml
            - --health-probe-addr=:{{ .Values.manager.ports.healthzPort }}
            - --webhook-port={{ .Values.manager.ports.webhookPort }}
```

https://github.com/abelperezok/opentelemetry-helm-charts/blob/new-values-custom-ports/charts/opentelemetry-operator/templates/deployment.yaml#L28-L29

Also, make sure you keep using the default values for both health check and webhook until the new version of the operator is published.
