### PR TITLE
Bump up operator chart version to 0.53.0

### DIFF
--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "title": "Values",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "global": {
       "type": "object"

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "title": "Values",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "global": {
       "type": "object"

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
   - name: alolita
   - name: Aneurysm9
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.52.0
+appVersion: 0.53.0

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
   - name: alolita
   - name: Aneurysm9
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.51.0
+appVersion: 0.52.0

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.7.0
+version: 0.7.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.52.0
+    tag: v0.53.0
   collectorImage:
     repository:
     tag:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.51.0
+    tag: v0.52.0
   collectorImage:
     repository:
     tag:


### PR DESCRIPTION
fix https://github.com/open-telemetry/opentelemetry-helm-charts/issues/227

I compared the differences between related to 0.51.0 and 0.52.0 from https://github.com/open-telemetry/opentelemetry-operator/releases, and there was no change, so card files didn't need to be updated
