### PR TITLE
Allow operator pod to start when admissionWebhooks are disabled ADDENDUM

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.8.5
+version: 0.8.6
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             {{- if not .Values.admissionWebhooks.enabled }}
             - name: ENABLE_WEBHOOKS
-              value: false
+              value: "false"
             {{- end }}
             {{- range $name, $value := .Values.manager.env }}
             - name: {{ $name }}


### PR DESCRIPTION
It seems I managed to broke master. While testing today I get :
```Error: INSTALLATION FAILED: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string```

This pr fixes it. 

Initial issue is https://github.com/open-telemetry/opentelemetry-helm-charts/issues/238