### PR TITLE
Expose metrics port in deployment/service

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.8.11
+version: 0.8.12
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           name: manager
           ports:
+            - containerPort: {{ .Values.manager.ports.metricsPort }}
+              name: metrics
+              protocol: TCP
             {{- if .Values.admissionWebhooks.enabled }}
             - containerPort: {{ .Values.manager.ports.webhookPort }}
               name: webhook-server

--- a/charts/opentelemetry-operator/templates/service.yaml
+++ b/charts/opentelemetry-operator/templates/service.yaml
@@ -12,6 +12,10 @@ spec:
       port: {{ .Values.kubeRBACProxy.ports.proxyPort }}
       protocol: TCP
       targetPort: https
+    - name: metrics
+      port: {{ .Values.manager.ports.metricsPort }}
+      protocol: TCP
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager


### PR DESCRIPTION
@dmitryax @tylerbenson Split the svcmon pr into ports and svcmonitor
https://github.com/open-telemetry/opentelemetry-helm-charts/issues/252

This needs to be merged first