### PR TITLE
Add the namespace and namespaceSelector to serviceMonitor

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.22.2
+version: 0.22.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.55.0
+appVersion: 0.56.0

--- a/charts/opentelemetry-collector/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-collector/templates/servicemonitor.yaml
@@ -3,12 +3,22 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.extraLabels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    matchNames:
+    {{- range .Values.serviceMonitor.namespaceSelector }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -269,6 +269,9 @@ serviceMonitor:
   # The service monitor by default scrapes the metrics port.
   # The metrics port needs to be enabled as well.
   enabled: false
+  # namespace: customNamespace
+  # namespaceSelector:
+  # - opentelemetry-namespace 
   metricsEndpoints:
   - port: metrics
     # interval: 15s


### PR DESCRIPTION
- Added the namespace param to values and serviceMonitor manifest
- Added the namespaceSelector to values and serviceMonitor manifest

# Allow to specify different namespace for ServiceMonitor

Curently if you enable the ServiceMonitor this is installed in the same namespace as the the helm chart installation, but if you already have a prometheus configuration and only wants to add the opentelemtry target to your current configuration it is not possible to specify the params `namespace` and `namespaceSelector` otherwise you'll need to create a new prometheus instance to be able to scrape metrics.


Current values:

```
serviceMonitor:
  # The service monitor by default scrapes the metrics port.
  # The metrics port needs to be enabled as well.
  enabled: true
  metricsEndpoints:
  - port: metrics
    # interval: 15s
```


Suggested values:

```
serviceMonitor:
  # The service monitor by default scrapes the metrics port.
  # The metrics port needs to be enabled as well.
  enabled: true
  # namespace: customNamespace
  # namespaceSelector:
  # - opentelemetryNamespace
  metricsEndpoints:
  - port: metrics
    # interval: 15s
```


Example:

Installing the prometheus operator as:

```
helm install --namespace monitoring --create-namespace prometheus-operator prometheus-community/kube-prometheus-stack --dry-run
```

this will create all prometheus related resources including the prometheus instance:

```
❯ kubectl get prometheuses.monitoring.coreos.com -n monitoring 
NAME                                    VERSION   REPLICAS   AGE
prometheus-operator-kube-p-prometheus   v2.36.1   1          160m
```


Then install the opentelemetry-collector using the values:

create a value file with the next values:

```
mode: deployment

replicaCount: 1

containerLogs:
  enabled: true

resources:
  limits:
    cpu: 200m
    memory: 128Mi

config:
  receivers:
    jaeger: null
    prometheus: null
    zipkin: null
  service:
    pipelines:
      traces:
        receivers:
          - otlp
      metrics:
        receivers:
          - otlp
      logs: null

# prometheus related values
serviceMonitor:
  # The service monitor by default scrapes the metrics port.
  # The metrics port needs to be enabled as well.
  enabled: true
  namespace: monitoring
  namespaceSelector:
  - opentelemetry 
  metricsEndpoints:
  - port: metrics
    # interval: 15s
  
  # additional labels for the ServiceMonitor
  extraLabels:
   release: prometheus-operator

ports:
  
  metrics:
    # The metrics port is disabled by default. However you need to enable the port
    # in order to use the ServiceMonitor (serviceMonitor.enabled) or PodMonitor (podMonitor.enabled).
    enabled: true
    containerPort: 8888
    servicePort: 8888
    protocol: TCP
```


Install opentelemetry-collector:

```
helm install --namespace opentelemetry --create-namespace -f my-values.yaml opentelemetry opentelemetry-helm-charts/charts/opentelemetry-collector/ 
```

This will create the opentelemetry collector:

Chart: 

```
❯ helm list -n opentelemetry
NAME            NAMESPACE       REVISION        UPDATED                                         STATUS          CHART                           APP VERSION
opentelemetry   opentelemetry   1               2022-07-21 14:36:34.307787429 +0200 CEST        deployed        opentelemetry-collector-0.22.2  0.55.0 
```

deployment: 

```
❯ kubectl get pods -n opentelemetry 
NAME                                                     READY   STATUS    RESTARTS   AGE
opentelemetry-opentelemetry-collector-66c664445f-v6hh8   1/1     Running   0          117m
```

and also create the serviceMonitor

```
❯ kubectl get servicemonitors.monitoring.coreos.com -n monitoring 
NAME                                                 AGE
opentelemetry-opentelemetry-collector                118m
prometheus-operator-grafana                          164m
prometheus-operator-kube-p-alertmanager              164m
prometheus-operator-kube-p-apiserver                 164m
prometheus-operator-kube-p-coredns                   164m
prometheus-operator-kube-p-kube-controller-manager   164m
prometheus-operator-kube-p-kube-etcd                 164m
prometheus-operator-kube-p-kube-proxy                164m
prometheus-operator-kube-p-kube-scheduler            164m
prometheus-operator-kube-p-kubelet                   164m
prometheus-operator-kube-p-operator                  164m
prometheus-operator-kube-p-prometheus                164m
prometheus-operator-kube-state-metrics               164m
prometheus-operator-prometheus-node-exporter         164m
```

and this will add the opentelemtry automatically to the prometheus targets:

![image](https://user-images.githubusercontent.com/43817767/180244671-3f7bc926-7e81-4edd-8572-bdc6e448e46f.png)


Signed-off-by: Kadaffy Talavera <kadaffy@ongres.com>