### PR TITLE
[opentelemetry-demo] Add test workflow and scenario for demo

### DIFF
--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -1,0 +1,24 @@
+name: Test Demo Chart
+
+on:
+  pull_request:
+    paths: 
+    - 'charts/opentelemetry-demo/**'
+    branches:
+      - main
+
+jobs:
+  collector-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          create-kind-cluster: "true"
+
+      - name: Run chart-testing (install)
+        run: ct install --charts charts/opentelemetry-demo

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.1.0
+version: 0.1.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:


### PR DESCRIPTION
This PR adds a new test workflow and default test scenario for the opentelemetry-demo chart.

Closes #287 

@dmitryax I agree that it is annoying to have to add a new workflow for a new chart after https://github.com/open-telemetry/opentelemetry-helm-charts/pull/181 😆 