### PR TITLE
enhance otel demo chart‘s schema

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.1.1
+version: 0.1.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -5,8 +5,11 @@
     "additionalProperties": false,
     "properties": {
         "enabled": {
-          "description": "Usually used when using Opentelemetry-collector as a subchart.",
+          "description": "Usually used when using Opentelemetry-demo as a subchart.",
           "type": "boolean"
+        },
+        "global": {
+          "type": "object"
         },
         "observability": {
             "$ref": "#/definitions/Observability"

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -4,6 +4,10 @@
     "title": "Values",
     "additionalProperties": false,
     "properties": {
+        "enabled": {
+          "description": "Usually used when using Opentelemetry-collector as a subchart.",
+          "type": "boolean"
+        },
         "observability": {
             "$ref": "#/definitions/Observability"
         },


### PR DESCRIPTION
if otel demo chart become a subchart, we need add a schema to suport `enabled` and `global` value.