### PR TITLE
[chore] add opentelemetry-demo to example targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TMP_DIRECTORY = ./tmp
-CHARTS ?= opentelemetry-collector opentelemetry-operator
+CHARTS ?= opentelemetry-collector opentelemetry-operator opentelemetry-demo
 
 .PHONY: generate-examples
 generate-examples: 


### PR DESCRIPTION
Adds opentelemetry-demo to the `CHARTS` so its examples can be generated and checked.