### PR TITLE
fix: Service Account Name for the deployment

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.2
+version: 0.11.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ template "opentelemetry-operator.name" . }}-controller-manager
+      serviceAccountName: {{ template "opentelemetry-operator.serviceAccountName" . }}-controller-manager
       terminationGracePeriodSeconds: 10
       {{- if .Values.admissionWebhooks.enabled }}
       volumes:


### PR DESCRIPTION
# Overview

As reported on #313, the `ServiceAccountName` in the spec of the `deployment` for the Open Telemetry Operator Helm Chart is wrongly set if the user overrides the name:

If the user overrides the ServiceAccount creation for the Open Telemetry Operator in a value file like this:

```yaml
manager:
  serviceAccount:
    create: false
    name: test
```

The ClusterRoleBinding resource is created correctly:

```yaml
# Source: opentelemetry-operator/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:
    app.kubernetes.io/name: opentelemetry-operator
  name: opentelemetry-operator-proxy-rolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: opentelemetry-operator-proxy-role
subjects:
  - kind: ServiceAccount
    name: test-controller-manager
    namespace: default
```

But the `ServiceAccountName` in the `spec` section of the deployment is set incorrectly:

```yaml
# Source: opentelemetry-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: opentelemetry-operator
    control-plane: controller-manager
  name: opentelemetry-operator-controller-manager
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: opentelemetry-operator
      control-plane: controller-manager
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: manager
      labels:
        app.kubernetes.io/name: opentelemetry-operator
        control-plane: controller-manager
    spec:
      hostNetwork: false
      containers:
      [...]
      serviceAccountName: opentelemetry-operator-controller-manager
      [...]
```
    
As you can see in the last lines of this example: `serviceAccountName: opentelemetry-operator-controller-manager` when that service account does not exists and it should be set to `serviceAccountName: test-controller-manager`.

# Changes

The PR changes the `deployment` of the Open Telemetry Operator Helm chart so it uses the `serviceAccountName: {{ template "opentelemetry-operator.serviceAccountName" . }}-controller-manager` as the rest of the chart instead of `serviceAccountName: {{ template "opentelemetry-operator.name" . }}-controller-manager` fixing the previous mentioned issue.