### PR TITLE
Remove conditional metrics address

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.3
+version: 0.11.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -23,11 +23,7 @@ spec:
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - args:
-            {{- if .Values.manager.serviceMonitor.enabled }}
             - --metrics-addr=0.0.0.0:{{ .Values.manager.ports.metricsPort }}
-            {{- else}}
-            - --metrics-addr=127.0.0.1:{{ .Values.manager.ports.metricsPort }}
-            {{- end }}
             {{- if .Values.manager.leaderElection.enabled }}
             - --enable-leader-election
             {{- end }}


### PR DESCRIPTION
Following up from [here](https://cloud-native.slack.com/archives/C03HVLM8LAH/p1660146696356489) we want to make it always possible to scrape metrics of the otel operator