### PR TITLE
Force namespace constraints on test manifests

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.4
+version: 0.11.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "opentelemetry-operator.name" . }}-cert-manager-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
   annotations:

--- a/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "opentelemetry-operator.name" . }}-controller-manager-metrics-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
   annotations:
@@ -32,6 +33,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "opentelemetry-operator.name" . }}-webhook-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
   annotations:


### PR DESCRIPTION
Make sure the test templates sets a proper namespace to ensure easier cleanup when testing the Helm chart