### PR TITLE
[opentelemetry-demo] Fix how DATABASE_URL gets set for Feature flag service

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.1.4
+version: 0.1.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -54,7 +54,7 @@ Get Pod Env
 {{- end}}
 {{- end }}
 {{- if not $hasDatabaseUrl }}
-{{- $_ := set . "env" (append .env (dict "name" "DATABASE_URL" "value" (printf "ecto://ffs:ffs@%s-ffs-postgres:5432/ffs" $prefix)) | uniq) }}
+{{- $_ := set . "env" (append .env (dict "name" "DATABASE_URL" "value" (printf "ecto://ffs:ffs@%s-ffs-postgres:5432/ffs" $prefix))) }}
 {{- end}}
 {{- end }}
 

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -46,6 +46,18 @@ Get Pod Env
 {{- define "otel-demo.pod.env" -}}
 {{- $prefix := include "otel-demo.name" $ }}
 
+{{- if eq .name "featureflag-service" }}
+{{- $hasDatabaseUrl := false }}
+{{- range .env }}
+{{- if eq .name "DATABASE_URL" }}
+{{- $hasDatabaseUrl = true }}
+{{- end}}
+{{- end }}
+{{- if not $hasDatabaseUrl }}
+{{- $_ := set . "env" (append .env (dict "name" "DATABASE_URL" "value" (printf "ecto://ffs:ffs@%s-ffs-postgres:5432/ffs" $prefix)) | uniq) }}
+{{- end}}
+{{- end }}
+
 {{- if .default.enabled  }}
 {{- if .env }}
 {{- $defaultEnvMap := dict }}

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -89,8 +89,10 @@ components:
   featureflagService:
     enabled: true
     env:
-    - name: DATABASE_URL
-      value: ecto://ffs:ffs@ffs-postgres:5432/ffs
+    # DATABASE_URL will be automatically added to use the enabled ffsPostgres component.
+    # If a different url is desired, set DATABASE_URL here.
+    # - name: DATABASE_URL
+    #   value: 
     - name: GRPC_PORT
       value: '50053'
     - name: PORT

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -92,7 +92,7 @@ components:
     # DATABASE_URL will be automatically added to use the enabled ffsPostgres component.
     # If a different url is desired, set DATABASE_URL here.
     # - name: DATABASE_URL
-    #   value: 
+    #   value:
     - name: GRPC_PORT
       value: '50053'
     - name: PORT


### PR DESCRIPTION
This PR updates the Feature flag service env vars to automatically set DATABASE_URL based on the ffs-postgres service name, which includes the release name.  If DATABASE_URL is set directly in the feature flag service's env vars it takes precedence.

Fixes #335 