### PR TITLE
Rename environment variables for demo/featureflag-service

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -93,10 +93,12 @@ components:
     # If a different url is desired, set DATABASE_URL here.
     # - name: DATABASE_URL
     #   value:
-    - name: GRPC_PORT
-      value: '50053'
-    - name: PORT
+    - name: FEATURE_FLAG_GRPC_SERVICE_PORT
       value: '50052'
+    - name: FEATURE_FLAG_SERVICE_PORT
+      value: '50053'
+    - name: SECRET_KEY_BASE
+      value: 'Vive++6s/oRCd7xI3zSvyUGH1AJQS0BE3xjNrEOJEVmzOg5qPBlTYE+5kgz2cfBE'
     ports:
     - name: grpc
       value: 50052


### PR DESCRIPTION
This fixes the issue with the featureflagservice pod not starting in https://github.com/open-telemetry/opentelemetry-helm-charts/issues/343

There is probably a better way to do this in the .tpl files, and the product-catalog-service appears to have the wrong port for the feature flag grpc. 
