### PR TITLE
[opentelemetry-demo] only add annotation section when required

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.2.1
+version: 0.2.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.2.2
+version: 0.2.3
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -14,8 +14,10 @@ spec:
     metadata:
       labels:
         {{- include "otel-demo.selectorLabels" . | nindent 8 }}
+      {{- if .podAnnotations }}
       annotations:
-        {{- include "otel-demo.pod.annotations" . | nindent 8 }}
+        {{- toYaml .podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .imageConfig.pullSecrets }}
       imagePullSecrets:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -121,12 +121,3 @@ Get Pod ports
   name: service
 {{- end }}
 {{- end }}
-
-{{/*
-Get Pod Annotations
-*/}}
-{{- define "otel-demo.pod.annotations" -}}
-{{- if .podAnnotations }}
-{{ toYaml .podAnnotations}}
-{{- end }}
-{{- end }}


### PR DESCRIPTION
Fix bug where annotation section was always rendered even if there were no annotations