### PR TITLE
Fix resolution of dependent environment variable.

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.2.4
+version: 0.2.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -42,9 +42,19 @@ Get Services Port Mapping
 
 {{/*
 Get Pod Env
+Note: Consider that dependent variables need to be declared before the referenced env varibale.
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- $prefix := include "otel-demo.name" $ }}
+
+# {{ $.depends }}
+# {{ .name }}
+{{- if hasKey $.depends .name }}
+{{- range $depend := get $.depends .name }}
+- name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
+  value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
+{{- end }}
+{{- end }}
 
 {{- if eq .name "featureflag-service" }}
 {{- $hasDatabaseUrl := false }}
@@ -92,15 +102,6 @@ Get Pod Env
 {{- if eq .name "product-catalog-service" }}
 - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
   value: {{ (printf "%s-featureflag-service:50031" $prefix ) }}
-{{- end }}
-
-# {{ $.depends }}
-# {{ .name }}
-{{- if hasKey $.depends .name }}
-{{- range $depend := get $.depends .name }}
-- name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
-  value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
-{{- end }}
 {{- end }}
 
 {{- end }}

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -139,7 +139,7 @@ components:
     - name: LOCUST_USERS
       value: '10'
     - name: LOCUST_HOST
-      value: http://${FRONTEND_ADDR}
+      value: 'http://$(FRONTEND_ADDR)'
     - name: LOCUST_HEADLESS
       value: 'false'
     - name: LOCUST_AUTOSTART


### PR DESCRIPTION
The PR fixes the connection between the loadgenerator and the frontend as described in #358. There are 2 issues at the same time:

1. The below snippet generates environment variables for the pod containing the address of another service that it depends on. 


```
# {{ $.depends }}
# {{ .name }}
{{- if hasKey $.depends .name }}
{{- range $depend := get $.depends .name }}
- name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
  value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
{{- end }}
{{- end }}
```

E.g. the loadgenerator depends on the frontend and therefore `FRONTEND_ADDR: my-release-frontend:8080` is created. To reference `FRONTEND_ADDR` it must be created before the dependent environment variable. The order matters. (Source: [Docs](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/#define-an-environment-dependent-variable-for-a-container))

I moved the above block to the top of the env variable definitions because the variables will get referenced but never reference other variables themselves.

2. A dependent variable is declared using parentheses instead of curly brackets. I.e. we need to reference `FRONTEND_ADDR` as follows: `http://$(FRONTEND_ADDR)`

After testing the changes in this PR, the error rate in the APM tool dropped from 100% to 0% and the whole demo seems to be working fine. The requests seem to propagate properly through all the services.
<img width="999" alt="image" src="https://user-images.githubusercontent.com/36307788/189977299-7214e60f-077c-4c27-8ecb-7cbea6a3faed.png">
