### PR TITLE
Simplify dependency propagation

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.2.5
+version: 0.2.6
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -46,11 +46,8 @@ Note: Consider that dependent variables need to be declared before the reference
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- $prefix := include "otel-demo.name" $ }}
-
-# {{ $.depends }}
-# {{ .name }}
-{{- if hasKey $.depends .name }}
-{{- range $depend := get $.depends .name }}
+{{- if .depends }}
+{{- range $depend := .depends }}
 - name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
   value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
 {{- end }}

--- a/charts/opentelemetry-demo/templates/component.yaml
+++ b/charts/opentelemetry-demo/templates/component.yaml
@@ -8,7 +8,7 @@
     {{- $config := set . "serviceAccount" $.Values.serviceAccount }}
     {{- $config := set . "observability" $.Values.observability }}
     {{- $config := set . "serviceMapping" $serviceMapping }}
-    {{- $config := set . "depends" $depends }}
+    {{- $config := set . "depends" (get $depends $config.name) }}
     {{- $config := set . "default" $.Values.default }}
 
     {{- if $config.enabled -}}


### PR DESCRIPTION
1. I removed the below comments because they are just confusing in the final template.

```
# {{ $.depends }}
# {{ .name }}
```

2. I also changed that each service only receives its own dependencies because it confused me in the first place that the complete dependency map was passed down.