### PR TITLE
Fix email service address

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.2.6
+version: 0.2.7
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -61,10 +61,6 @@ Exclude email service and treat differently because the addr. for the email serv
 {{- end }}
 {{- end }}
 
-
-
-
-
 {{- if eq .name "featureflag-service" }}
 {{- $hasDatabaseUrl := false }}
 {{- range .env }}

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -46,12 +46,24 @@ Note: Consider that dependent variables need to be declared before the reference
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- $prefix := include "otel-demo.name" $ }}
+{{/*
+Exclude email service and treat differently because the addr. for the email service needs to contain the http:// protocol prefix.
+*/}}
 {{- if .depends }}
-{{- range $depend := .depends }}
+{{- range $depend := (without .depends "email-service") }}
 - name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
   value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
 {{- end }}
+
+{{- if has "email-service" .depends }}
+- name: {{ printf "EMAIL_SERVICE_ADDR" }}
+  value: {{ printf "http://%s-email-service:%0.f" $prefix (get $.serviceMapping "email-service" )}}
 {{- end }}
+{{- end }}
+
+
+
+
 
 {{- if eq .name "featureflag-service" }}
 {{- $hasDatabaseUrl := false }}


### PR DESCRIPTION
The PR fixes #363. I.e. the email service is prefixed with http:// properly. 
Below picture shows that the order confirmations are sent properly.

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/36307788/190679469-e5897a38-5154-41e3-98ac-a4722c320b63.png">

@dineshg13  My datadog trial runs out in 3 days. However, I need an extension until the end of the month to present the demo. I already wrote the support without an answer yet. If you know a shortcut for an extension that does not involve speaking to a sales rep: My email for the datadog account is "nico@canida.io" 😁