### PR TITLE
Support additional config stanzas for collector

### DIFF
--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -96,3 +96,9 @@ service:
         - jaeger
         {{- end}}
 {{- end }}
+
+{{- define "otel-demo.otelcol.extras.config" -}}
+{{- if .Values.observability.additionalConfig.enabled }}
+{{ toYaml .Values.observability.additionalConfig.values }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-demo/templates/otelcol.yaml
+++ b/charts/opentelemetry-demo/templates/otelcol.yaml
@@ -1,5 +1,6 @@
 {{- $ := set . "name" "otelcol" }}
 {{- $otelconfig := include "otel-demo.otelcol.config" .}}
+{{- $otelconfigextras := include "otel-demo.otelcol.extras.config" .}}
 
 {{- if .Values.observability.otelcol.enabled -}}
 ---
@@ -13,6 +14,17 @@ data:
   otelcol-config.yml: |
 
     {{- $otelconfig | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otel-demo.name" . }}-{{ .name }}-extras-config
+  labels:
+    {{- include "otel-demo.labels" . | nindent 4 }}
+data:
+  otelcol-extras-config.yml: |
+
+    {{- $otelconfigextras | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -34,7 +46,7 @@ spec:
       containers:
       - image: otel/opentelemetry-collector:0.55.0
         name: otel-col
-        args: ["--config=/etc/otelcol-config.yml"]
+        args: ["--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-extras-config.yml"]
         {{- if .Values.observability.jaeger.enabled }}
         env:
           - name: JAEGER_ADDR
@@ -51,10 +63,16 @@ spec:
           - mountPath: /etc/otelcol-config.yml
             name: otel-config 
             subPath: otelcol-config.yml
+          - mountPath: /etc/otelcol-extras-config.yml
+            name: otel-extras-config
+            subPath: otelcol-extras-config.yml
       volumes:
         - configMap:
             name: {{ include "otel-demo.name" . }}-{{.name}}-config
-          name: otel-config 
+          name: otel-config
+        - configMap:
+            name: {{ include "otel-demo.name" . }}-{{.name}}-extras-config
+          name: otel-extras-config
 ---
 apiVersion: v1
 kind: Service

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -282,11 +282,15 @@
                 },
                 "jaeger": {
                     "$ref": "#/definitions/ObservabilityProp"
+                },
+                "additionalConfig": {
+                  "$ref": "#/definitions/AdditionalConfigProp"
                 }
             },
             "required": [
                 "jaeger",
-                "otelcol"
+                "otelcol",
+                "additionalConfig"
             ],
             "title": "Observability"
         },
@@ -302,6 +306,19 @@
                 "enabled"
             ],
             "title": "ObservabilityProp"
+        },
+        "AdditionalConfigProp": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "title": "AdditionalConfigProp"
         }
     }
 }

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -3,6 +3,27 @@ observability:
     enabled: true
   jaeger:
     enabled: true
+  additionalConfig:
+    enabled: false
+    values:
+      exporters:
+        otlp/2: 
+            endpoint: "sample.endpoint"
+            headers: 
+              sample-header: "foo"
+      service:
+        pipelines:
+          traces/2:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlp/2]
+          metrics/2:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlp/2]
+
+
+
 
 # if the enabled is true, the items in this object will apply to all components
 default:


### PR DESCRIPTION
This PR adds functionality to add arbitrary collector configuration to the deployment, similar to how the config-extras config functions in the demo project today. If values.observability.additionalconfig.enabled is `true`, the values will be added and merged with the existing config via conventional collector config merging rules.