### PR TITLE
[opentelemetry-demo] Add ability to configure the collector

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.3.0
+version: 0.3.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/otelcol.yaml
+++ b/charts/opentelemetry-demo/templates/otelcol.yaml
@@ -1,12 +1,10 @@
-{{- $ := set . "name" "otelcol" }}
 {{- $otelconfig := include "otel-demo.otelcol.config" .}}
-
 {{- if .Values.observability.otelcol.enabled -}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "otel-demo.name" . }}-{{ .name }}-config
+  name: {{ include "otel-demo.name" . }}-otelcol-config
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 data:
@@ -17,7 +15,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "otel-demo.name" . }}-{{ .name }}
+  name: {{ include "otel-demo.name" . }}-otelcol
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
@@ -32,7 +30,7 @@ spec:
         {{- include "otel-demo.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: otel/opentelemetry-collector:0.55.0
+      - image: {{ .Values.observability.otelcol.image.repository }}:{{ .Values.observability.otelcol.image.tag }}
         name: otel-col
         args: ["--config=/etc/otelcol-config.yml"]
         {{- if .Values.observability.jaeger.enabled }}
@@ -53,13 +51,13 @@ spec:
             subPath: otelcol-config.yml
       volumes:
         - configMap:
-            name: {{ include "otel-demo.name" . }}-{{.name}}-config
+            name: {{ include "otel-demo.name" . }}-otelcol-config
           name: otel-config 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "otel-demo.name" . }}-{{ .name }}
+  name: {{ include "otel-demo.name" . }}-otelcol
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -1,307 +1,331 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "title": "Values",
-    "additionalProperties": false,
-    "properties": {
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "title": "Values",
+  "additionalProperties": false,
+  "properties": {
+    "enabled": {
+      "description": "Usually used when using Opentelemetry-demo as a subchart.",
+      "type": "boolean"
+    },
+    "global": {
+      "type": "object"
+    },
+    "observability": {
+      "$ref": "#/definitions/Observability"
+    },
+    "default": {
+      "$ref": "#/definitions/Default"
+    },
+    "image": {
+      "$ref": "#/definitions/Image"
+    },
+    "serviceAccount": {
+      "type": "string"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "required": [
+    "components",
+    "image",
+    "observability",
+    "serviceAccount"
+  ],
+  "definitions": {
+    "Components": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "redis": {
+          "$ref": "#/definitions/Service"
+        },
+        "adService": {
+          "$ref": "#/definitions/Service"
+        },
+        "cartService": {
+          "$ref": "#/definitions/Service"
+        },
+        "checkoutService": {
+          "$ref": "#/definitions/Service"
+        },
+        "currencyService": {
+          "$ref": "#/definitions/Service"
+        },
+        "emailService": {
+          "$ref": "#/definitions/Service"
+        },
+        "featureflagService": {
+          "$ref": "#/definitions/Service"
+        },
+        "ffsPostgres": {
+          "$ref": "#/definitions/Service"
+        },
+        "frontend": {
+          "$ref": "#/definitions/Service"
+        },
+        "loadgenerator": {
+          "$ref": "#/definitions/Service"
+        },
+        "paymentService": {
+          "$ref": "#/definitions/Service"
+        },
+        "productCatalogService": {
+          "$ref": "#/definitions/Service"
+        },
+        "recommendationService": {
+          "$ref": "#/definitions/Service"
+        },
+        "shippingService": {
+          "$ref": "#/definitions/Service"
+        }
+      },
+      "title": "Components"
+    },
+    "Service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
         "enabled": {
-          "description": "Usually used when using Opentelemetry-demo as a subchart.",
           "type": "boolean"
         },
-        "global": {
-          "type": "object"
+        "servicePort": {
+          "type": "integer"
         },
-        "observability": {
-            "$ref": "#/definitions/Observability"
+        "env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Env"
+          }
         },
-        "default": {
-            "$ref": "#/definitions/Default"
+        "ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Port"
+          }
         },
         "image": {
-            "$ref": "#/definitions/Image"
+          "type": "string"
         },
-        "serviceAccount": {
-            "type": "string"
-        },
-        "components": {
-            "$ref": "#/definitions/Components"
+        "podAnnotations": {
+          "type": "object"
         }
+      },
+      "required": [
+        "enabled"
+      ],
+      "title": "Service"
     },
-    "required": [
-        "components",
-        "image",
-        "observability",
-        "serviceAccount"
-    ],
-    "definitions": {
-        "Components": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "redis": {
-                    "$ref": "#/definitions/Service"
-                },
-                "adService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "cartService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "checkoutService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "currencyService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "emailService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "featureflagService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "ffsPostgres": {
-                    "$ref": "#/definitions/Service"
-                },
-                "frontend": {
-                    "$ref": "#/definitions/Service"
-                },
-                "loadgenerator": {
-                    "$ref": "#/definitions/Service"
-                },
-                "paymentService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "productCatalogService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "recommendationService": {
-                    "$ref": "#/definitions/Service"
-                },
-                "shippingService": {
-                    "$ref": "#/definitions/Service"
-                }
-            },
-            "title": "Components"
+    "Env": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "Service": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "servicePort": {
-                    "type": "integer"
-                },
-                "env": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Env"
-                    }
-                },
-                "ports": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Port"
-                    }
-                },
-                "image": {
-                    "type": "string"
-                },
-                "podAnnotations": {
-                  "type": "object"
-                }
-            },
-            "required": [
-                "enabled"
-             ],
-            "title": "Service"
+        "value": {
+          "type": "string"
         },
-        "Env": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                },
-                "valueFrom": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                      "configMapKeyRef": {
-                        "$ref": "#/definitions/ConfigMapKeyRef"
-                      },
-                      "fieldRef": {
-                        "$ref": "#/definitions/FieldRef"
-                      },
-                      "resourceFieldRef": {
-                        "$ref": "#/definitions/ResourceFieldRef"
-                      },
-                      "secretKeyRef": {
-                        "$ref": "#/definitions/SecretKeyRef"
-                      }
-                    }
-                }
+        "valueFrom": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "configMapKeyRef": {
+              "$ref": "#/definitions/ConfigMapKeyRef"
             },
-            "required": [
-                "name"
-            ],
-            "title": "Env"
+            "fieldRef": {
+              "$ref": "#/definitions/FieldRef"
+            },
+            "resourceFieldRef": {
+              "$ref": "#/definitions/ResourceFieldRef"
+            },
+            "secretKeyRef": {
+              "$ref": "#/definitions/SecretKeyRef"
+            }
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Env"
+    },
+    "Default": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
         },
-        "Default": {
+        "env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Env"
+          }
+        }
+      },
+      "title": "Default"
+    },
+    "ConfigMapKeyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "title": "ConfigMapKeyRef"
+    },
+    "FieldRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fieldPath": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "fieldPath"
+      ],
+      "title": "FieldRef"
+    },
+    "ResourceFieldRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "type": "string"
+        },
+        "containerName": {
+          "type": "string"
+        },
+        "divisor": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "title": "ResourceFieldRef"
+    },
+    "SecretKeyRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "Port": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "title": "Port"
+    },
+    "Image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "required": [
+        "repository"
+      ],
+      "title": "Image"
+    },
+    "Observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "otelcol": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "enabled": {
               "type": "boolean"
             },
-            "env": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Env"
+            "image": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
               }
-            }
-          },
-          "title": "Default"
-        },
-        "ConfigMapKeyRef": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "key": {
-              "type": "string"
             },
-            "name": {
-              "type": "string"
-            },
-            "optional": {
-              "type": "boolean"
+            "config": {
+              "type": "object"
             }
           },
           "required": [
-            "key"
-          ],
-          "title": "ConfigMapKeyRef"
-        },
-        "FieldRef":{
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "fieldPath": {
-              "type": "string"
-            },
-            "apiVersion": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "fieldPath"
-          ],
-          "title": "FieldRef"
-        },
-        "ResourceFieldRef": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "resource": {
-              "type": "string"
-            },
-            "containerName": {
-              "type": "string"
-            },
-            "divisor": {
-              "type": "integer"
-            }
-          },
-          "required": [
-            "resource"
-          ],
-          "title": "ResourceFieldRef"
-        },
-        "SecretKeyRef": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "key": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "optional": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "key"
+            "enabled"
           ]
         },
-        "Port": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "name",
-                "value"
-            ],
-            "title": "Port"
-        },
-        "Image": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "repository": {
-                    "type": "string"
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "items": {}
-                }
-            },
-            "required": [
-                "repository"
-            ],
-            "title": "Image"
-        },
-        "Observability": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "otelcol": {
-                    "$ref": "#/definitions/ObservabilityProp"
-                },
-                "jaeger": {
-                    "$ref": "#/definitions/ObservabilityProp"
-                }
-            },
-            "required": [
-                "jaeger",
-                "otelcol"
-            ],
-            "title": "Observability"
-        },
-        "ObservabilityProp": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enabled"
-            ],
-            "title": "ObservabilityProp"
+        "jaeger": {
+          "$ref": "#/definitions/ObservabilityProp"
         }
+      },
+      "required": [
+        "jaeger",
+        "otelcol"
+      ],
+      "title": "Observability"
+    },
+    "ObservabilityProp": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "title": "ObservabilityProp"
     }
+  }
 }

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -1,6 +1,35 @@
 observability:
+  # Configuration for the demo's OpenTelemetry Collector
   otelcol:
     enabled: true
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: 0.60.0
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      exporters:
+        logging: {}
+      processors:
+        batch: {}
+      service:
+        pipelines:
+          traces:
+            receivers:
+              - otlp
+            processors:
+              - batch
+            exporters:
+              - logging
+
+  # Configuration for the demo's Jaeger backend.
+  # When enabled, the demo will deploy a Jaeger instance and
+  # update the collector to export traces to it.
   jaeger:
     enabled: true
 
@@ -12,7 +41,7 @@ default:
       valueFrom:
         fieldRef:
           apiVersion: v1
-          fieldPath: 'metadata.labels[''app.kubernetes.io/component'']'
+          fieldPath: "metadata.labels['app.kubernetes.io/component']"
     - name: OTEL_K8S_NAMESPACE
       valueFrom:
         fieldRef:
@@ -41,8 +70,8 @@ components:
     enabled: true
     image: redis:alpine
     ports:
-    - name: redis
-      value: 6379
+      - name: redis
+        value: 6379
 
   adService:
     enabled: true
@@ -54,8 +83,8 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: ASPNETCORE_URLS
-      value: http://*:8080
+      - name: ASPNETCORE_URLS
+        value: http://*:8080
     podAnnotations: {}
     #  sidecar.opentelemetry.io/inject: "false"
     #  instrumentation.opentelemetry.io/inject-dotnet: "true"
@@ -70,8 +99,8 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: PORT
-      value: '8080'
+      - name: PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -79,45 +108,45 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: APP_ENV
-      value: production
-    - name: PORT
-      value: '8080'
+      - name: APP_ENV
+        value: production
+      - name: PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
   featureflagService:
     enabled: true
     env:
-    # DATABASE_URL will be automatically added to use the enabled ffsPostgres component.
-    # If a different url is desired, set DATABASE_URL here.
-    # - name: DATABASE_URL
-    #   value:
-    - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-      value: '50053'
-    - name: FEATURE_FLAG_SERVICE_PORT
-      value: '8081'
+      # DATABASE_URL will be automatically added to use the enabled ffsPostgres component.
+      # If a different url is desired, set DATABASE_URL here.
+      # - name: DATABASE_URL
+      #   value:
+      - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+        value: "50053"
+      - name: FEATURE_FLAG_SERVICE_PORT
+        value: "8081"
     ports:
-    - name: grpc
-      value: 50053
-    - name: http
-      value: 8081
+      - name: grpc
+        value: 50053
+      - name: http
+        value: 8081
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
   ffsPostgres:
     enabled: true
     env:
-    - name: POSTGRES_DB
-      value: ffs
-    - name: POSTGRES_PASSWORD
-      value: ffs
-    - name: POSTGRES_USER
-      value: ffs
+      - name: POSTGRES_DB
+        value: ffs
+      - name: POSTGRES_PASSWORD
+        value: ffs
+      - name: POSTGRES_USER
+        value: ffs
     image: cimg/postgres:14.2
     ports:
-    - name: postgres
-      value: 5432
+      - name: postgres
+        value: 5432
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -125,8 +154,8 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: FRONTEND_ADDR
-      value: :8080
+      - name: FRONTEND_ADDR
+        value: :8080
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -134,18 +163,18 @@ components:
     enabled: true
     servicePort: 8089
     env:
-    - name: LOCUST_WEB_PORT
-      value: '8089'
-    - name: LOCUST_USERS
-      value: '10'
-    - name: LOCUST_HOST
-      value: 'http://$(FRONTEND_ADDR)'
-    - name: LOCUST_HEADLESS
-      value: 'false'
-    - name: LOCUST_AUTOSTART
-      value: 'true'
-    - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
-      value: python
+      - name: LOCUST_WEB_PORT
+        value: "8089"
+      - name: LOCUST_USERS
+        value: "10"
+      - name: LOCUST_HOST
+        value: "http://$(FRONTEND_ADDR)"
+      - name: LOCUST_HEADLESS
+        value: "false"
+      - name: LOCUST_AUTOSTART
+        value: "true"
+      - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+        value: python
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-python: "true"
 
@@ -165,10 +194,10 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: OTEL_PYTHON_LOG_CORRELATION
-      value: 'true'
-    - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
-      value: python
+      - name: OTEL_PYTHON_LOG_CORRELATION
+        value: "true"
+      - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+        value: python
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-python: "true"
 
@@ -176,7 +205,7 @@ components:
     enabled: true
     servicePort: 8080
     env:
-    - name: PORT
-      value: '8080'
+      - name: PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"


### PR DESCRIPTION
This PR adds to the demo chart the ability to configure the collector and its image.  It uses similar techniques as the collector chart's preset to handle enabling and disabling of jaeger.