### PR TITLE
Add PHP quote service

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.5.0
+version: 0.5.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -95,8 +95,17 @@ Exclude email service and treat differently because the addr. for the email serv
 {{- end }}
 
 {{- if .observability.otelcol.enabled }}
+{{- if eq .name "quote-service" }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ include "otel-demo.name" . }}-otelcol:4317
+{{- else }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: http://{{ include "otel-demo.name" . }}-otelcol:4317
+{{- end }}
+{{- if eq .name "shipping-service" }}
+- name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  value: http://{{ include "otel-demo.name" . }}-otelcol:4317
+{{- end }}
 {{- end }}
 
 {{- if .servicePort}}
@@ -107,6 +116,11 @@ Exclude email service and treat differently because the addr. for the email serv
 {{- if eq .name "product-catalog-service" }}
 - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
   value: {{ (printf "%s-featureflag-service:50053" $prefix ) }}
+{{- end }}
+
+{{- if eq .name "shipping-service" }}
+- name: QUOTE_SERVICE_ADDR
+  value: {{ (printf "http://%s-quote-service:8080" $prefix ) }}
 {{- end }}
 
 {{- end }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -82,6 +82,9 @@
         },
         "shippingService": {
           "$ref": "#/definitions/Service"
+        },
+        "quoteService": {
+          "$ref": "#/definitions/Service"
         }
       },
       "title": "Components"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -181,6 +181,22 @@ components:
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
+  quoteService:
+    enabled: true
+    servicePort: 8080
+    env:
+      - name: OTEL_TRACES_SAMPLER
+        value: "parentbased_always_on"
+      - name: OTEL_TRACES_EXPORTER
+        value: "otlp"
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: "grpc"
+      - name: OTEL_PHP_TRACES_PROCESSOR
+        value: "simple"
+    podAnnotations: {}
+    #  instrumentation.opentelemetry.io/inject-sdk: "true"
+
+
 opentelemetry-collector:
   nameOverride: otelcol
   mode: deployment


### PR DESCRIPTION
This is tested and working as expected, with traces from shipping and quote services. It's a little bit kludgy to accommodate the slight variances in how each service wants the environment variables formatted w/ or w/out protocols, but it all works (even without the ffs port fix).

Fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/397