### PR TITLE
[chore] Add dependent repositories step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           version: v3.4.1
 
+      - name: Add dependent repositories
+        run: |
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         with:


### PR DESCRIPTION
Fixes the release workflow to work with the demo chart. Without the workaround proposed in https://github.com/helm/chart-releaser-action/issues/74 we can't release the demo due to its dependency.