### PR TITLE
[demo] set featureflagservice traces export to grpc

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.5.1
+version: 0.5.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -97,6 +97,8 @@ components:
         value: "50053"
       - name: FEATURE_FLAG_SERVICE_PORT
         value: "8081"
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: grpc
     ports:
       - name: grpc
         value: 50053


### PR DESCRIPTION
The `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` needs to be set to `grpc` for Elixir to send using that protocol as the default.