### PR TITLE
[opentelemetry-demo] Move env vars into values.yaml

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.5.4
+version: 0.5.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -1,119 +1,14 @@
 {{/*
-Component Depends Config
-*/}}
-{{- define "otel-demo.pod.dependsConfig" -}}
-cart-service:
-  - redis
-checkout-service:
-  - cart-service
-  - currency-service
-  - email-service
-  - payment-service
-  - product-catalog-service
-  - shipping-service
-frontend:
-  - ad-service
-  - cart-service
-  - checkout-service
-  - currency-service
-  - product-catalog-service
-  - recommendation-service
-  - shipping-service
-loadgenerator:
-  - frontend
-recommendation-service:
-  - product-catalog-service
-{{- end}}
-
-
-{{/*
-Get Services Port Mapping
-*/}}
-{{- define "otel-demo.pod.serviceMapping" -}}
-{{ $servicePortMap := default dict }}
-{{- range $name, $config := .Values.components }}
-    {{- if $config.servicePort }}
-    {{ $name | kebabcase }}: {{ $config.servicePort }}
-    {{- else if $config.ports }}
-    {{ $name | kebabcase}}: {{ (get (index $config.ports 0 ) "value") }}
-    {{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Get Pod Env
 Note: Consider that dependent variables need to be declared before the referenced env varibale.
 */}}
 {{- define "otel-demo.pod.env" -}}
-{{- $prefix := include "otel-demo.name" $ }}
-{{/*
-Exclude email service and treat differently because the addr. for the email service needs to contain the http:// protocol prefix.
-*/}}
-{{- if .depends }}
-{{- range $depend := (without .depends "email-service") }}
-- name: {{ printf "%s_ADDR" $depend | snakecase | upper }}
-  value: {{ printf "%s-%s:%0.f" $prefix ($depend | kebabcase) (get $.serviceMapping $depend )}}
-{{- end }}
-
-{{- if has "email-service" .depends }}
-- name: {{ printf "EMAIL_SERVICE_ADDR" }}
-  value: {{ printf "http://%s-email-service:%0.f" $prefix (get $.serviceMapping "email-service" )}}
-{{- end }}
-{{- end }}
-
-{{- if eq .name "featureflag-service" }}
-{{- $hasDatabaseUrl := false }}
-{{- range .env }}
-{{- if eq .name "DATABASE_URL" }}
-{{- $hasDatabaseUrl = true }}
-{{- end}}
-{{- end }}
-{{- if not $hasDatabaseUrl }}
-{{- $_ := set . "env" (append .env (dict "name" "DATABASE_URL" "value" (printf "ecto://ffs:ffs@%s-ffs-postgres:5432/ffs" $prefix))) }}
-{{- end}}
-{{- end }}
-
 {{- if .useDefault.env  }}
 {{ toYaml .defaultValues.env }}
 {{- end }}
-
 {{- if .env }}
-{{ toYaml .env }}
+{{ tpl (toYaml .env) . }}
 {{- end }}
-
-{{- if .observability.otelcol.enabled }}
-{{- if eq .name "quote-service" }}
-- name: OTEL_EXPORTER_OTLP_ENDPOINT
-  value: {{ include "otel-demo.name" . }}-otelcol:4317
-{{- else }}
-- name: OTEL_EXPORTER_OTLP_ENDPOINT
-  value: http://{{ include "otel-demo.name" . }}-otelcol:4317
-{{- end }}
-{{- if eq .name "shipping-service" }}
-- name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-  value: http://{{ include "otel-demo.name" . }}-otelcol:4317
-{{- end }}
-{{- if eq .name "email-service" }}
-- name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-  value: http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces
-{{- end }}
-{{- end }}
-
-{{- if .servicePort}}
-- name: {{ printf "%s_PORT" .name | snakecase | upper }}
-  value: {{.servicePort | quote}}
-{{- end }}
-
-{{- if eq .name "product-catalog-service" }}
-- name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-  value: {{ (printf "%s-featureflag-service:50053" $prefix ) }}
-{{- end }}
-
-{{- if eq .name "shipping-service" }}
-- name: QUOTE_SERVICE_ADDR
-  value: {{ (printf "http://%s-quote-service:8080" $prefix ) }}
-{{- end }}
-
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-demo/templates/component.yaml
+++ b/charts/opentelemetry-demo/templates/component.yaml
@@ -1,14 +1,11 @@
-{{ $serviceMapping := include "otel-demo.pod.serviceMapping" . | fromYaml}}
-{{ $depends := include "otel-demo.pod.dependsConfig" . | fromYaml }}
 {{- range $name, $config := .Values.components }}
+    {{- $config := set . "Template" $.Template }}
     {{- $config := set . "name" ($name | kebabcase) }}
     {{- $config := set . "Release" $.Release }}
     {{- $config := set . "Chart" $.Chart }}
     {{- $config := set . "imageConfig" $.Values.image }}
     {{- $config := set . "serviceAccount" $.Values.serviceAccount }}
     {{- $config := set . "observability" $.Values.observability }}
-    {{- $config := set . "serviceMapping" $serviceMapping }}
-    {{- $config := set . "depends" (get $depends $config.name) }}
     {{- $config := set . "defaultValues" $.Values.default }}
 
     {{- if $config.enabled -}}

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -50,9 +50,15 @@ components:
     useDefault:
       env: true
     servicePort: 8080
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: AD_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  sidecar.opentelemetry.io/inject: "false"
     #  instrumentation.opentelemetry.io/inject-java: "true"
+
   cartService:
     enabled: true
     useDefault:
@@ -61,6 +67,12 @@ components:
     env:
       - name: ASPNETCORE_URLS
         value: http://*:8080
+      - name: REDIS_ADDR
+        value: '{{ include "otel-demo.name" . }}-redis:6379'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: CART_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  sidecar.opentelemetry.io/inject: "false"
     #  instrumentation.opentelemetry.io/inject-dotnet: "true"
@@ -70,6 +82,23 @@ components:
     useDefault:
       env: true
     servicePort: 8080
+    env:
+      - name: CART_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-cart-service:8080'
+      - name: CURRENCY_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-currency-service:8080'
+      - name: PAYMENT_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-payment-service:8080'
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-product-catalog-service:8080'
+      - name: SHIPPING_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-shipping-service:8080'
+      - name: EMAIL_SERVICE_ADDR
+        value: 'http://{{ include "otel-demo.name" . }}-email-service:8080'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: CHECKOUT_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -80,6 +109,10 @@ components:
     servicePort: 8080
     env:
       - name: PORT
+        value: "8080"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: CURRENCY_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
@@ -94,6 +127,12 @@ components:
         value: production
       - name: PORT
         value: "8080"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
+      - name: EMAIL_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -102,16 +141,16 @@ components:
     useDefault:
       env: true
     env:
-      # DATABASE_URL will be automatically added to use the enabled ffsPostgres component.
-      # If a different url is desired, set DATABASE_URL here.
-      # - name: DATABASE_URL
-      #   value:
       - name: FEATURE_FLAG_GRPC_SERVICE_PORT
         value: "50053"
       - name: FEATURE_FLAG_SERVICE_PORT
         value: "8081"
       - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
         value: grpc
+      - name: DATABASE_URL
+        value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffs-postgres:5432/ffs'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
     ports:
       - name: grpc
         value: 50053
@@ -131,6 +170,8 @@ components:
         value: ffs
       - name: POSTGRES_USER
         value: ffs
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
     image: cimg/postgres:14.2
     ports:
       - name: postgres
@@ -146,6 +187,24 @@ components:
     env:
       - name: FRONTEND_ADDR
         value: :8080
+      - name: AD_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-ad-service:8080'
+      - name: CART_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-cart-service:8080'
+      - name: CHECKOUT_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-checkout-service:8080'
+      - name: CURRENCY_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-currency-service:8080'
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-product-catalog-service:8080'
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-recommendation-service:8080'
+      - name: SHIPPING_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-shipping-service:8080'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: FRONTEND_PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -155,6 +214,8 @@ components:
       env: true
     servicePort: 8089
     env:
+      - name: FRONTEND_ADDR
+        value: '{{ include "otel-demo.name" . }}-frontend:8080'
       - name: LOCUST_WEB_PORT
         value: "8089"
       - name: LOCUST_USERS
@@ -167,6 +228,10 @@ components:
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: LOADGENERATOR_PORT
+        value: "8089"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-python: "true"
 
@@ -175,6 +240,11 @@ components:
     useDefault:
       env: true
     servicePort: 8080
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: PAYMENT_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-nodejs: "true"
 
@@ -183,6 +253,13 @@ components:
     useDefault:
       env: true
     servicePort: 8080
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: PRODUCT_CATALOG_SERVICE_PORT
+        value: "8080"
+      - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-featureflag-service:50053'
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -196,6 +273,12 @@ components:
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: RECOMMENDATION_SERVICE_PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-product-catalog-service:8080'
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-python: "true"
 
@@ -207,6 +290,14 @@ components:
     env:
       - name: PORT
         value: "8080"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: SHIPPING_SERVICE_PORT
+        value: "8080"
+      - name: QUOTE_SERVICE_ADDR
+        value: 'http://{{ include "otel-demo.name" . }}-quote-service:8080'
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -224,6 +315,10 @@ components:
         value: "grpc"
       - name: OTEL_PHP_TRACES_PROCESSOR
         value: "simple"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: '{{ include "otel-demo.name" . }}-otelcol:4317'
+      - name: QUOTE_SERVICE_PORT
+        value: "8080"
     podAnnotations: {}
     #  instrumentation.opentelemetry.io/inject-sdk: "true"
 
@@ -234,7 +329,7 @@ opentelemetry-collector:
   config:
     exporters:
       jaeger:
-        endpoint: "{{ .Release.Name }}-jaeger:14250"
+        endpoint: '{{ include "opentelemetry-collector.fullname" . }}-jaeger:14250'
         tls:
           insecure: true
     service:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -329,7 +329,7 @@ opentelemetry-collector:
   config:
     exporters:
       jaeger:
-        endpoint: '{{ include "opentelemetry-collector.fullname" . }}-jaeger:14250'
+        endpoint: '{{ .Release.Name }}-jaeger:14250'
         tls:
           insecure: true
     service:


### PR DESCRIPTION
This PR moves all the env var logic into the values.yaml instead of the template helper.  

The original intent of the helper was to handle setting env vars that all services shared based on their dependencies.  In reality, there are so exceptions that it became very difficult to modify env vars and to add more exceptions.

I propose explicitly listing out each service's env vars in the values.yaml, utilizing `tpl` to handle situations where services rely on each other. This has the advantage of allowing users to set the env vars for each service exactly how they need. 

Fixes #340