### PR TITLE
[opentelemetry-demo] Refactor image configuration

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.5.5
+version: 0.6.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .name }}
-          image: '{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default (printf "v%s-%s" (default .Chart.AppVersion .defaultValues.image.tag) (.name | replace "-" "" | lower)) }}'
+          image: '{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default (printf "v%s-%s" (default .Chart.AppVersion .defaultValues.image.tag) (replace "-" "" .name)) }}'
           imagePullPolicy: {{ .imageOverride.pullPolicy | default .defaultValues.image.pullPolicy }}
           {{- if or .ports .servicePort}}
           ports:

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .name }}
-          image: "{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default .defaultValues.image.tag | default .Chart.AppVersion }}"
+          image: '{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default (printf "v%s-%s" (default .Chart.AppVersion .defaultValues.image.tag) (.name | replace "-" "" | lower)) }}'
           imagePullPolicy: {{ .imageOverride.pullPolicy | default .defaultValues.image.pullPolicy }}
           {{- if or .ports .servicePort}}
           ports:

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -19,16 +19,17 @@ spec:
         {{- toYaml .podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .imageConfig.pullSecrets }}
+      {{- if or .defaultValues.image.pullSecrets .imageOverride.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .imageConfig.pullSecrets | nindent 8}}
+        {{- .imageOverride.pullSecrets | default .defaultValues.image.pullSecrets | toYaml | nindent 8}}
       {{- end }}
       {{- with .serviceAccountName }}
       serviceAccountName: {{ .serviceAccountName}}
       {{- end }}
       containers:
         - name: {{ .name }}
-          image: {{ .image | default (printf "%s:v%s-%s" .imageConfig.repository .Chart.AppVersion (.name | replace "-" "" | lower)) }}
+          image: "{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default .defaultValues.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .imageOverride.pullPolicy | default .defaultValues.image.pullPolicy }}
           {{- if or .ports .servicePort}}
           ports:
             {{- include "otel-demo.pod.ports" . | nindent 10 }}

--- a/charts/opentelemetry-demo/templates/component.yaml
+++ b/charts/opentelemetry-demo/templates/component.yaml
@@ -3,7 +3,6 @@
     {{- $config := set . "name" ($name | kebabcase) }}
     {{- $config := set . "Release" $.Release }}
     {{- $config := set . "Chart" $.Chart }}
-    {{- $config := set . "imageConfig" $.Values.image }}
     {{- $config := set . "serviceAccount" $.Values.serviceAccount }}
     {{- $config := set . "observability" $.Values.observability }}
     {{- $config := set . "defaultValues" $.Values.default }}

--- a/charts/opentelemetry-demo/templates/jaeger.yaml
+++ b/charts/opentelemetry-demo/templates/jaeger.yaml
@@ -1,5 +1,5 @@
 {{- $config := set . "name" "jaeger" }}
-{{- if $.Values.observability.jaeger.enabled -}}
+{{- if .Values.observability.jaeger.enabled -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -21,7 +21,7 @@ spec:
       - env:
         - name: COLLECTOR_ZIPKIN_HTTP_PORT
           value: "9411"
-        image: jaegertracing/all-in-one
+        image: "{{ .Values.observability.jaeger.image.repository }}:{{ .Values.observability.jaeger.image.tag }}"
         name: jaeger
         ports:
           - containerPort: 5775

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -17,9 +17,6 @@
     "default": {
       "$ref": "#/definitions/Default"
     },
-    "image": {
-      "$ref": "#/definitions/Image"
-    },
     "serviceAccount": {
       "type": "string"
     },
@@ -32,7 +29,6 @@
   },
   "required": [
     "components",
-    "image",
     "observability",
     "serviceAccount"
   ],
@@ -124,8 +120,8 @@
             "$ref": "#/definitions/Port"
           }
         },
-        "image": {
-          "type": "string"
+        "imageOverride": {
+          "$ref": "#/definitions/Image"
         },
         "podAnnotations": {
           "type": "object"
@@ -183,8 +179,14 @@
           "items": {
             "$ref": "#/definitions/Env"
           }
+        },
+        "image": {
+          "$ref": "#/definitions/Image"
         }
       },
+      "required": [
+        "image"
+      ],
       "title": "Default"
     },
     "ConfigMapKeyRef": {
@@ -276,32 +278,31 @@
       ],
       "title": "Port"
     },
-    "Image": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "repository": {
-          "type": "string"
-        },
-        "pullSecrets": {
-          "type": "array",
-          "items": {}
-        }
-      },
-      "required": [
-        "repository"
-      ],
-      "title": "Image"
-    },
     "Observability": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "otelcol": {
-          "$ref": "#/definitions/ObservabilityProp"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
         },
         "jaeger": {
-          "$ref": "#/definitions/ObservabilityProp"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "$ref": "#/definitions/Image"
+            }
+          }
+          
         }
       },
       "required": [
@@ -310,18 +311,25 @@
       ],
       "title": "Observability"
     },
-    "ObservabilityProp": {
+    "Image": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {}
         }
       },
-      "required": [
-        "enabled"
-      ],
-      "title": "ObservabilityProp"
+      "title": "Image"
     }
   }
 }

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -182,7 +182,7 @@ components:
     enabled: true
     useDefault:
       env: true
-    imageOverride: 
+    imageOverride:
       repository: "cimg/postgres"
       tag: "14.2"
     env:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -1,8 +1,15 @@
 observability:
+  # collector settings are configured in the opentelemetry-collector section.
   otelcol:
     enabled: true
   jaeger:
     enabled: true
+    image:
+      repository: jaegertracing/all-in-one
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "latest"
+      pullPolicy: IfNotPresent
+      pullSecrets: []
 
 default:
   env:
@@ -28,10 +35,12 @@ default:
           fieldPath: metadata.name
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
-
-image:
-  repository: otel/demo
-  pullSecrets: []
+  image:
+    repository: otel/demo
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
 
 serviceAccount: ""
 
@@ -40,7 +49,10 @@ components:
     enabled: true
     useDefault:
       env: true
-    image: redis:alpine
+    # Options to override the default image settings.
+    imageOverride:
+      repository: "redis"
+      tag: "alpine"
     ports:
       - name: redis
         value: 6379
@@ -49,6 +61,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -63,6 +76,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: ASPNETCORE_URLS
@@ -81,6 +95,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: CART_SERVICE_ADDR
@@ -106,6 +121,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: PORT
@@ -121,6 +137,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: APP_ENV
@@ -140,6 +157,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     env:
       - name: FEATURE_FLAG_GRPC_SERVICE_PORT
         value: "50053"
@@ -163,6 +181,9 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: 
+      repository: "cimg/postgres"
+      tag: "14.2"
     env:
       - name: POSTGRES_DB
         value: ffs
@@ -172,7 +193,6 @@ components:
         value: ffs
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
-    image: cimg/postgres:14.2
     ports:
       - name: postgres
         value: 5432
@@ -183,6 +203,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: FRONTEND_ADDR
@@ -212,6 +233,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8089
     env:
       - name: FRONTEND_ADDR
@@ -239,6 +261,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -252,6 +275,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -267,6 +291,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: OTEL_PYTHON_LOG_CORRELATION
@@ -286,6 +311,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: PORT
@@ -305,6 +331,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    imageOverride: {}
     servicePort: 8080
     env:
       - name: OTEL_TRACES_SAMPLER

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -38,6 +38,7 @@ default:
   image:
     repository: otel/demo
     # Overrides the image tag whose default is the chart appVersion.
+    # The service's name will be applied to the end of this value.
     tag: ""
     pullPolicy: IfNotPresent
     pullSecrets: []


### PR DESCRIPTION
This PR refactors the chart's image configuration options to be more flexible and apparent.  Users may now:

1. change the jaeger image settings
2. change the default image settings for otel demo services.  this was doable before, but only for repository and pullSecrets.  Now includes tag and pullPolicy.
3. change individual service image settings.  Previously could only set the repository and tag.

Fixes #406