### PR TITLE
[operator] Create leader election role/rb only when leaderElection enabled

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.13.0
+version: 0.13.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/role.yaml
+++ b/charts/opentelemetry-operator/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.role.create }}
+{{- if and .Values.role.create .Values.manager.leaderElection.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/opentelemetry-operator/templates/rolebinding.yaml
+++ b/charts/opentelemetry-operator/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.role.create }}
+{{- if and .Values.role.create .Values.manager.leaderElection.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
Signed-off-by: birca <Allex21ro@yahoo.com>
Currently leader election role/rb are conditioned by the `role.create` flag . I've made it dependent on the existing `manager.leaderElection.enabled` as well . 