### PR TITLE
[opentelemetry-collector] Bump collector version to 0.62.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.35.1
+version: 0.36.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.61.0
+appVersion: 0.62.0

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: da227b4825c61921205c9371051d0fc1c13079404c4f9545f26008fdf06b31e7
+        checksum/config: 08f2bd62c191e8adc8ea73c8ef0cd1db55bc92c9a8b5544b7c8e2380dd3c8268
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47bf01ed85b617ede41b6c3328b365614341716a0b836622a813d6ecaadec24b
+        checksum/config: a914c35a73560afb2edf47815e8136835b1d3460b64f2b92d298d0521a8d308f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a0cabf35314639861f259d1b2b4dbdd27399d3298297221e2bc00fd71c790896
+        checksum/config: cc49f3a5669b3fd3e4a411f3d7042d4c3b3f5d90811b360ec6fbefef764adb73
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9f7c133aa8d1bc4ee355192f97897b03ad4198e0df226ec8d8fd3ccfd495b7af
+        checksum/config: 4eff4c6aee0c5116e342f076e1679671e8a0bfb3a1ad5bbb6a2a3ff90c578f8b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 53c7081b0254d611cca9504e0faf579258b8df1ea6d74977c299b90ac286c2c1
+        checksum/config: 6d048bfe91d28462748c593191943890763c0a826a1642c0618dc3107807d9f0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 53c7081b0254d611cca9504e0faf579258b8df1ea6d74977c299b90ac286c2c1
+        checksum/config: 6d048bfe91d28462748c593191943890763c0a826a1642c0618dc3107807d9f0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -40,7 +40,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f02a99063253043710eb8cccaea239a32b8ac785c553b31fda61c9852d73dfdc
+        checksum/config: 55d122257bb2cf8817454a6f25787618ed740387a75dd1a8d35840db3f23d8c3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bdebc55a4f2d0418f5fd366270d1a7c4ac624851be04843421669e4d025c0506
+        checksum/config: c956c88fff7d1a764d43a7f01e2c0e569bc757fea0540c7dd0bb5b96a6e18b7a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: otlp

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/config.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
     component: statefulset-collector
 spec:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,10 +5,10 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.35.1
+    helm.sh/chart: opentelemetry-collector-0.36.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.61.0"
+    app.kubernetes.io/version: "0.62.0"
     app.kubernetes.io/managed-by: Helm
   
 spec:
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.61.0"
+          image: "otel/opentelemetry-collector-contrib:0.62.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact


### PR DESCRIPTION
The PR bumps the default collector version to 0.62.0. Reading through Contrib and Core Release notes I did not see any breaking changes.