### PR TITLE
[demo] Use docker library postgres image which has multiarch images

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.6.1
+version: 0.6.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-ad-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad-service
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   name: example-cart-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart-service
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: example-checkout-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout-service
@@ -71,7 +71,7 @@ kind: Service
 metadata:
   name: example-currency-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency-service
@@ -93,7 +93,7 @@ kind: Service
 metadata:
   name: example-email-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email-service
@@ -115,7 +115,7 @@ kind: Service
 metadata:
   name: example-featureflag-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflag-service
@@ -140,7 +140,7 @@ kind: Service
 metadata:
   name: example-ffs-postgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffs-postgres
@@ -162,7 +162,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -184,7 +184,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -206,7 +206,7 @@ kind: Service
 metadata:
   name: example-payment-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment-service
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: example-product-catalog-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog-service
@@ -250,7 +250,7 @@ kind: Service
 metadata:
   name: example-quote-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote-service
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-recommendation-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation-service
@@ -294,7 +294,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -316,7 +316,7 @@ kind: Service
 metadata:
   name: example-shipping-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping-service
@@ -338,7 +338,7 @@ kind: Deployment
 metadata:
   name: example-ad-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad-service
@@ -400,7 +400,7 @@ kind: Deployment
 metadata:
   name: example-cart-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart-service
@@ -466,7 +466,7 @@ kind: Deployment
 metadata:
   name: example-checkout-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout-service
@@ -540,7 +540,7 @@ kind: Deployment
 metadata:
   name: example-currency-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency-service
@@ -604,7 +604,7 @@ kind: Deployment
 metadata:
   name: example-email-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email-service
@@ -672,7 +672,7 @@ kind: Deployment
 metadata:
   name: example-featureflag-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflag-service
@@ -742,7 +742,7 @@ kind: Deployment
 metadata:
   name: example-ffs-postgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffs-postgres
@@ -763,7 +763,7 @@ spec:
     spec:
       containers:
         - name: ffs-postgres
-          image: 'cimg/postgres:14.2'
+          image: 'postgres:14'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -808,7 +808,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -886,7 +886,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -962,7 +962,7 @@ kind: Deployment
 metadata:
   name: example-payment-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment-service
@@ -1024,7 +1024,7 @@ kind: Deployment
 metadata:
   name: example-product-catalog-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog-service
@@ -1088,7 +1088,7 @@ kind: Deployment
 metadata:
   name: example-quote-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote-service
@@ -1158,7 +1158,7 @@ kind: Deployment
 metadata:
   name: example-recommendation-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation-service
@@ -1226,7 +1226,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1284,7 +1284,7 @@ kind: Deployment
 metadata:
   name: example-shipping-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping-service

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.6.1
+    helm.sh/chart: opentelemetry-demo-0.6.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -183,8 +183,8 @@ components:
     useDefault:
       env: true
     imageOverride:
-      repository: "cimg/postgres"
-      tag: "14.2"
+      repository: "postgres"
+      tag: "14"
     env:
       - name: POSTGRES_DB
         value: ffs


### PR DESCRIPTION
The docker library postgres has multiarch images which works with ARM64 hosts. Currently the demo works poorly on M1 Macs because a number of images being used are amd64 only, this improves the situation by fixing the Postgres image.

I'm also assuming `cimg/postgres` doesn't have anything special for OTEL specifically. I checked their Dockerfile and it looked pretty vanilla, so I think this change should be minimal.