### PR TITLE
opentelemetry-demo: Support overriding OTEL_EXPORTER_OTLP_ENDPOINT and d OTEL_EXPORTER_OTLP_TRACES_ENDPOINT

### DIFF
--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -34,3 +34,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: {{ .name}}
 {{- end}}
 {{- end }}
+
+{{- define "otel-demo.otelExporterOTLPGRPCEndpoint" -}}
+{{- if .observability.otelExporterOTLPGRPCEndpoint }}
+{{- .observability.otelExporterOTLPGRPCEndpoint }}
+{{- else -}}
+http://{{- include "otel-demo.name" . }}-otelcol:4317
+{{- end }}
+{{- end }}
+
+{{- define "otel-demo.otelExporterOTLPHTTPEndpoint" -}}
+{{- if .observability.otelExporterOTLPHTTPEndpoint }}
+{{- .observability.otelExporterOTLPHTTPEndpoint }}
+{{- else -}}
+http://{{- include "otel-demo.name" . }}-otelcol:4318
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -4,7 +4,7 @@ Note: Consider that dependent variables need to be declared before the reference
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- if .useDefault.env  }}
-{{ toYaml .defaultValues.env }}
+{{ tpl (toYaml .defaultValues.env) . }}
 {{- end }}
 {{- if .env }}
 {{ tpl (toYaml .env) . }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -282,6 +282,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "otelExporterOTLPGRPCEndpoint": {
+          "type": "string"
+        },
+        "otelExporterOTLPHTTPEndpoint": {
+          "type": "string"
+        },
         "otelcol": {
           "type": "object",
           "additionalProperties": false,
@@ -302,7 +308,7 @@
               "$ref": "#/definitions/Image"
             }
           }
-          
+
         }
       },
       "required": [

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -1,4 +1,7 @@
 observability:
+  # override the otel exporter endpoint to use
+  otelExporterOTLPGRPCEndpoint: ""
+  otelExporterOTLPHTTPEndpoint: ""
   # collector settings are configured in the opentelemetry-collector section.
   otelcol:
     enabled: true
@@ -13,6 +16,11 @@ observability:
 
 default:
   env:
+    # if sending to an otel-collector daemonset, this is required
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
     - name: OTEL_SERVICE_NAME
       valueFrom:
         fieldRef:
@@ -35,6 +43,8 @@ default:
           fieldPath: metadata.name
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: '{{ include "otel-demo.otelExporterOTLPGRPCEndpoint" . }}'
   image:
     repository: otel/demo
     # Overrides the image tag whose default is the chart appVersion.
@@ -65,8 +75,6 @@ components:
     imageOverride: {}
     servicePort: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: AD_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -84,8 +92,6 @@ components:
         value: http://*:8080
       - name: REDIS_ADDR
         value: '{{ include "otel-demo.name" . }}-redis:6379'
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CART_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -111,8 +117,6 @@ components:
         value: '{{ include "otel-demo.name" . }}-shipping-service:8080'
       - name: EMAIL_SERVICE_ADDR
         value: 'http://{{ include "otel-demo.name" . }}-email-service:8080'
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CHECKOUT_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -127,8 +131,6 @@ components:
     env:
       - name: PORT
         value: "8080"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CURRENCY_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -145,10 +147,8 @@ components:
         value: production
       - name: PORT
         value: "8080"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
+        value: '{{ include "otel-demo.otelExporterOTLPHTTPEndpoint" . }}/v1/traces'
       - name: EMAIL_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -168,8 +168,6 @@ components:
         value: grpc
       - name: DATABASE_URL
         value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffs-postgres:5432/ffs'
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
     ports:
       - name: grpc
         value: 50053
@@ -192,8 +190,6 @@ components:
         value: ffs
       - name: POSTGRES_USER
         value: ffs
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
     ports:
       - name: postgres
         value: 5432
@@ -223,8 +219,6 @@ components:
         value: '{{ include "otel-demo.name" . }}-recommendation-service:8080'
       - name: SHIPPING_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-shipping-service:8080'
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: FRONTEND_PORT
         value: "8080"
     podAnnotations: {}
@@ -251,8 +245,6 @@ components:
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: LOADGENERATOR_PORT
         value: "8089"
     podAnnotations: {}
@@ -265,8 +257,6 @@ components:
     imageOverride: {}
     servicePort: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
     podAnnotations: {}
@@ -279,8 +269,6 @@ components:
     imageOverride: {}
     servicePort: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: PRODUCT_CATALOG_SERVICE_PORT
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
@@ -299,8 +287,6 @@ components:
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: RECOMMENDATION_SERVICE_PORT
         value: "8080"
       - name: PRODUCT_CATALOG_SERVICE_ADDR
@@ -317,10 +303,8 @@ components:
     env:
       - name: PORT
         value: "8080"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: '{{ include "otel-demo.otelExporterOTLPGRPCEndpoint" . }}'
       - name: SHIPPING_SERVICE_PORT
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
@@ -343,8 +327,6 @@ components:
         value: "grpc"
       - name: OTEL_PHP_TRACES_PROCESSOR
         value: "simple"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: '{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: QUOTE_SERVICE_PORT
         value: "8080"
     podAnnotations: {}


### PR DESCRIPTION
I've got my own OTEL collector running as a daemonset, and would like to be able to use it instead of the provided Otel collector. However the endpoint is hardcoded, so this change allows users to override the endpoint. Additionally, when running the collector as a daemonset, you need to send to the hostIP of the node in Kubernetes, so this exposes that as the `HOST_IP` env-var so pods can use this to send to the local Otel agent.

Example values.yaml:
```
observability:
  otelExporterOTLPGRPCEndpoint: "http://$(HOST_IP):4317"
  otelExporterOTLPHTTPEndpoint: "http://$(HOST_IP):4318"
  otelcol:
    enabled: false
  jaeger:
    enabled: false
```