### PR TITLE
[chore] Add dependency step to setup

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -23,3 +23,7 @@ runs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.3.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
+
+    - name: Add Dependencies
+      shell: bash
+      run: helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
Adds the dependency chart so that `helm dependency build` works as expected.  This hasn't been causing issues because any time `check-examples` was run we had already run `ct lint`, which added the dependency repo.  But for PRs that don't need linting, such as this PR and https://github.com/open-telemetry/opentelemetry-helm-charts/pull/434, we still need something to add the dependency repo.