### PR TITLE
[demo] - update jaeger config

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.8.0
+version: 0.9.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.7.0
+version: 0.8.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-ad-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad-service
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   name: example-cart-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart-service
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: example-checkout-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout-service
@@ -71,7 +71,7 @@ kind: Service
 metadata:
   name: example-currency-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency-service
@@ -93,7 +93,7 @@ kind: Service
 metadata:
   name: example-email-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email-service
@@ -115,7 +115,7 @@ kind: Service
 metadata:
   name: example-featureflag-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflag-service
@@ -140,7 +140,7 @@ kind: Service
 metadata:
   name: example-ffs-postgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffs-postgres
@@ -162,7 +162,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -184,7 +184,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -206,7 +206,7 @@ kind: Service
 metadata:
   name: example-payment-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment-service
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: example-product-catalog-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog-service
@@ -250,7 +250,7 @@ kind: Service
 metadata:
   name: example-quote-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote-service
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-recommendation-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation-service
@@ -294,7 +294,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -316,7 +316,7 @@ kind: Service
 metadata:
   name: example-shipping-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping-service
@@ -338,7 +338,7 @@ kind: Deployment
 metadata:
   name: example-ad-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad-service
@@ -400,7 +400,7 @@ kind: Deployment
 metadata:
   name: example-cart-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart-service
@@ -466,7 +466,7 @@ kind: Deployment
 metadata:
   name: example-checkout-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout-service
@@ -540,7 +540,7 @@ kind: Deployment
 metadata:
   name: example-currency-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency-service
@@ -604,7 +604,7 @@ kind: Deployment
 metadata:
   name: example-email-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email-service
@@ -672,7 +672,7 @@ kind: Deployment
 metadata:
   name: example-featureflag-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflag-service
@@ -742,7 +742,7 @@ kind: Deployment
 metadata:
   name: example-ffs-postgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffs-postgres
@@ -808,7 +808,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -886,7 +886,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -962,7 +962,7 @@ kind: Deployment
 metadata:
   name: example-payment-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment-service
@@ -1024,7 +1024,7 @@ kind: Deployment
 metadata:
   name: example-product-catalog-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog-service
@@ -1088,7 +1088,7 @@ kind: Deployment
 metadata:
   name: example-quote-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote-service
@@ -1158,7 +1158,7 @@ kind: Deployment
 metadata:
   name: example-recommendation-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation-service
@@ -1226,7 +1226,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1284,7 +1284,7 @@ kind: Deployment
 metadata:
   name: example-shipping-service
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping-service

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -93,7 +93,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -115,7 +115,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -140,7 +140,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -162,7 +162,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -184,7 +184,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -206,7 +206,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -250,7 +250,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -294,7 +294,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -316,7 +316,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -338,7 +338,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -400,7 +400,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -466,7 +466,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -540,7 +540,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -604,7 +604,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -672,7 +672,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -742,7 +742,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -808,7 +808,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -886,7 +886,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -962,7 +962,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1024,7 +1024,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1088,7 +1088,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1158,7 +1158,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1226,7 +1226,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1284,7 +1284,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.8.0
+    helm.sh/chart: opentelemetry-demo-0.9.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -18,9 +18,9 @@ spec:
       protocol: TCP
       targetPort: 16686
     - name: collector
-      port: 14250
+      port: 4317
       protocol: TCP
-      targetPort: 14250
+      targetPort: 4317
   selector:
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.7.0
+    helm.sh/chart: opentelemetry-demo-0.8.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -53,25 +53,16 @@ spec:
         app.kubernetes.io/component: jaeger
     spec:
       containers:
-      - env:
-        - name: COLLECTOR_ZIPKIN_HTTP_PORT
-          value: "9411"
-        image: "jaegertracing/all-in-one:latest"
-        name: jaeger
-        ports:
-          - containerPort: 5775
-            protocol: UDP
-          - containerPort: 6831
-            protocol: UDP
-          - containerPort: 6832
-            protocol: UDP
-          - containerPort: 5778
-            protocol: TCP
-          - containerPort: 16686
-            protocol: TCP
-          - containerPort: 14268 
-            protocol: TCP
-          - containerPort: 9411
-            protocol: TCP
-          - containerPort: 14250
-            protocol: TCP
+        - name: jaeger
+          image: "jaegertracing/all-in-one:latest"
+          args:
+            - "--memory.max-traces"
+            - "10000"
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 4317
+              protocol: TCP
+            - containerPort: 16686
+              protocol: TCP

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -13,11 +13,11 @@ metadata:
 data:
   relay: |
     exporters:
-      jaeger:
-        endpoint: 'example-jaeger:14250'
+      logging: {}
+      otlp:
+        endpoint: 'example-jaeger:4317'
         tls:
           insecure: true
-      logging: {}
     extensions:
       health_check: {}
       memory_ballast: {}
@@ -77,7 +77,7 @@ data:
         traces:
           exporters:
           - logging
-          - jaeger
+          - otlp
           processors:
           - memory_limiter
           - batch

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 59fbf04012114dd6c404237dc0e7ea8a88470269b81d65a975360203004fb1ef
+        checksum/config: 2dfa18b082c0461ac9da6ffb3dee5660781a100f2727fc9d1479b5214949481f
         
       labels:
         app.kubernetes.io/name: otelcol

--- a/charts/opentelemetry-demo/templates/jaeger.yaml
+++ b/charts/opentelemetry-demo/templates/jaeger.yaml
@@ -18,28 +18,21 @@ spec:
         {{- include "otel-demo.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - env:
-        - name: COLLECTOR_ZIPKIN_HTTP_PORT
-          value: "9411"
-        image: "{{ .Values.observability.jaeger.image.repository }}:{{ .Values.observability.jaeger.image.tag }}"
-        name: jaeger
-        ports:
-          - containerPort: 5775
-            protocol: UDP
-          - containerPort: 6831
-            protocol: UDP
-          - containerPort: 6832
-            protocol: UDP
-          - containerPort: 5778
-            protocol: TCP
-          - containerPort: 16686
-            protocol: TCP
-          - containerPort: 14268 
-            protocol: TCP
-          - containerPort: 9411
-            protocol: TCP
-          - containerPort: 14250
-            protocol: TCP
+        - name: jaeger
+          image: "{{ .Values.observability.jaeger.image.repository }}:{{ .Values.observability.jaeger.image.tag }}"
+          args:
+            {{- range $arg := .Values.observability.jaeger.args }}
+            - "{{ $arg }}"
+            {{- end }}
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 4317
+              protocol: TCP
+            - containerPort: 16686
+              protocol: TCP
+
 ---
 apiVersion: v1
 kind: Service
@@ -54,9 +47,9 @@ spec:
       protocol: TCP
       targetPort: 16686
     - name: collector
-      port: 14250
+      port: 4317
       protocol: TCP
-      targetPort: 14250
+      targetPort: 4317
   selector:
       {{- include "otel-demo.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -300,9 +300,13 @@
             },
             "image": {
               "$ref": "#/definitions/Image"
+            },
+            "args": {
+              "type": "array",
+              "items": {}
             }
           }
-          
+
         }
       },
       "required": [

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -10,6 +10,7 @@ observability:
       tag: "latest"
       pullPolicy: IfNotPresent
       pullSecrets: []
+    args: ["--memory.max-traces", "10000"]
 
 default:
   env:
@@ -356,8 +357,8 @@ opentelemetry-collector:
   mode: deployment
   config:
     exporters:
-      jaeger:
-        endpoint: '{{ .Release.Name }}-jaeger:14250'
+      otlp:
+        endpoint: '{{ .Release.Name }}-jaeger:4317'
         tls:
           insecure: true
     service:
@@ -365,4 +366,4 @@ opentelemetry-collector:
         traces:
           exporters:
             - logging
-            - jaeger
+            - otlp


### PR DESCRIPTION
Updates the Jaeger config to be inline with what is used by the otel demo's docker setup

- Set max traces to 10000, this can also be configured by the user with a values.yaml setting.
- Use OTLP instead of Jaeger protocol
- Removed all unused ports

Because the default OpenTelemetry collector config changed, including the exporter used, a chart minor version bump was in order.