### PR TITLE
make generate-examples, force default namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TMP_DIRECTORY = ./tmp
 CHARTS ?= opentelemetry-collector opentelemetry-operator opentelemetry-demo
 
 .PHONY: generate-examples
-generate-examples: 
+generate-examples:
 	for chart_name in $(CHARTS); do \
 		EXAMPLES_DIR=charts/$${chart_name}/examples; \
 		EXAMPLES=$$(find $${EXAMPLES_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
@@ -11,7 +11,7 @@ generate-examples:
 			rm -rf "$${EXAMPLES_DIR}/$${example}/rendered"; \
 			for value in $${VALUES}; do \
 				helm dependency build charts/$${chart_name}; \
-				helm template example charts/$${chart_name} --values $${value} --output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
+				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
 				mv $${EXAMPLES_DIR}/$${example}/rendered/$${chart_name}/templates/* "$${EXAMPLES_DIR}/$${example}/rendered"; \
 				SUBCHARTS_DIR=$${EXAMPLES_DIR}/$${example}/rendered/$${chart_name}/charts; \
 				SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
@@ -34,7 +34,7 @@ check-examples:
 			VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name *values.yaml); \
 			for value in $${VALUES}; do \
 				helm dependency build charts/$${chart_name}; \
-				helm template example charts/$${chart_name} --values $${value} --output-dir "${TMP_DIRECTORY}/$${example}"; \
+				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "${TMP_DIRECTORY}/$${example}"; \
 				SUBCHARTS_DIR=${TMP_DIRECTORY}/$${example}/$${chart_name}/charts; \
 				SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
 				for subchart in $${SUBCHARTS}; do \


### PR DESCRIPTION
This is to make the dev experience better when using `make generate-examples`

A developer may not be in the `default` namespace as part of their kubeconfig, and the rendered examples have a `namespace: default` property. This will ensure that `default` is always used as the namespace.