### PR TITLE
[demo] - expose collector to browser spans

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.9.5
+version: 0.9.6
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.9.2
+version: 0.9.3
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -93,7 +93,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -115,7 +115,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -140,7 +140,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -162,7 +162,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -184,7 +184,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -206,7 +206,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -250,7 +250,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -294,7 +294,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -316,7 +316,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -338,7 +338,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -403,7 +403,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -472,7 +472,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -549,7 +549,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -616,7 +616,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -687,7 +687,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -760,7 +760,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -829,7 +829,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -989,7 +989,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1054,7 +1054,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1121,7 +1121,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1194,7 +1194,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1265,7 +1265,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1326,7 +1326,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -28,7 +28,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -51,7 +51,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -74,7 +74,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -97,7 +97,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -120,7 +120,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -146,7 +146,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -169,7 +169,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -192,7 +192,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -215,7 +215,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -238,7 +238,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -307,7 +307,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -330,7 +330,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -353,7 +353,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -418,7 +418,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -487,7 +487,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -631,7 +631,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -702,7 +702,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -844,7 +844,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -925,7 +925,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1004,7 +1004,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1069,7 +1069,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1209,7 +1209,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1343,7 +1343,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -28,7 +28,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -51,7 +51,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -74,7 +74,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -97,7 +97,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -120,7 +120,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -146,7 +146,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -169,7 +169,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -192,7 +192,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -215,7 +215,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -238,7 +238,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -307,7 +307,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -330,7 +330,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -353,7 +353,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -418,7 +418,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -487,7 +487,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -631,7 +631,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -702,7 +702,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -844,7 +844,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -925,7 +925,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1004,7 +1004,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1069,7 +1069,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1209,7 +1209,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1280,7 +1280,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1341,7 +1341,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -33,7 +33,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.4
+    helm.sh/chart: opentelemetry-demo-0.9.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.2
+    helm.sh/chart: opentelemetry-demo-0.9.3
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -33,7 +33,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.9.5
+    helm.sh/chart: opentelemetry-demo-0.9.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -41,6 +41,10 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
+            cors:
+              allowed_origins:
+              - http://*
+              - https://*
             endpoint: 0.0.0.0:4318
       prometheus:
         config:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 23369d4a5bad1906d96deb3b4879f8661ac75952a13842ac45902b4cfd843014
+        checksum/config: 03ae28054f184189b8d061c21691f51d1dcefd78533dc6bdc8ba3f57b6184652
         
       labels:
         app.kubernetes.io/name: otelcol

--- a/charts/opentelemetry-demo/templates/NOTES.txt
+++ b/charts/opentelemetry-demo/templates/NOTES.txt
@@ -1,18 +1,18 @@
 =======================================================================================
 
 
- ██████╗ ████████╗███████╗██╗         ██████╗ ███████╗███╗   ███╗ ██████╗ 
+ ██████╗ ████████╗███████╗██╗         ██████╗ ███████╗███╗   ███╗ ██████╗
 ██╔═══██╗╚══██╔══╝██╔════╝██║         ██╔══██╗██╔════╝████╗ ████║██╔═══██╗
 ██║   ██║   ██║   █████╗  ██║         ██║  ██║█████╗  ██╔████╔██║██║   ██║
 ██║   ██║   ██║   ██╔══╝  ██║         ██║  ██║██╔══╝  ██║╚██╔╝██║██║   ██║
 ╚██████╔╝   ██║   ███████╗███████╗    ██████╔╝███████╗██║ ╚═╝ ██║╚██████╔╝
- ╚═════╝    ╚═╝   ╚══════╝╚══════╝    ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝ 
-                                                                          
+ ╚═════╝    ╚═╝   ╚══════╝╚══════╝    ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝
+
 
 - Frontend UI: http://localhost:8080
   by running these commands:
      kubectl port-forward svc/{{ include "otel-demo.name" . }}-frontend 8080:8080
-      
+
 
 {{- if $.Values.observability.jaeger.enabled }}
 
@@ -21,6 +21,14 @@
      kubectl port-forward svc/{{ include "otel-demo.name" . }}-jaeger 16686:16686
 {{- end }}
 
-- Locust UI: http://localhost:8089
+- Locust (load generator) UI: http://localhost:8089
   by running these commands:
       kubectl port-forward svc/{{ include "otel-demo.name" . }}-loadgenerator 8089:8089
+
+- Feature Flag Service UI: http://localhost:8081
+  by running these commands:
+      kubectl port-forward svc/{{ include "otel-demo.name" . }}-featureflagservice 8081:8081
+
+- OpenTelemetry Collector OTLP/HTTP receiver (required for browser spans to be emitted):
+  by running these commands:
+      kubectl port-forward svc/{{ include "otel-demo.name" . }}-otelcol 4318:4318

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -471,6 +471,15 @@ opentelemetry-collector:
     limits:
       memory: 100Mi
   config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+            cors:
+              allowed_origins:
+                - "http://*"
+                - "https://*"
     exporters:
       otlp:
         endpoint: '{{ .Release.Name }}-jaeger:4317'


### PR DESCRIPTION
This adds CORS rules to allow any `http://` or `https://` origin to send OTLP over HTTP data into the collector.

Since the browser/ui when exposed will try to send traces to `http://localhost:4318`. If the user exposes the collector on this port using `kubectl port-forward` and has the proper CORS rules setup they can make it work and see the trace originate from the web browser.
