### PR TITLE
[operator] - BUMP opentelemetry-operator to 0.61.0

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.15.0
+version: 0.16.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.60.0
+appVersion: 0.61.0

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,10 @@
 # Upgrade guidelines
 
+## 0.15.0 to 0.16.0
+
+Jaeger receiver no longer supports remote sampling. To be able to perform an update, it must be deactivated or replaced by a configuration of the [jaegerremotesampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/extension/jaegerremotesampling) extension.<br/>
+It is important that the `jaegerremotesampling` extension and the `jaegerreceiver` do not use the same port.<br/>To increase the collector version afterwards, the update must be triggered again by restarting the operator. Alternatively, the `OpenTelemetryCollector` CRD can be re-created. [otel-contrib#14707](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14707)
+
 ## 0.13.0 to 0.14.0
 
 [Allow byo webhooks and cert](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/411)

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -180,6 +180,12 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  targetCPUUtilization:
+                    description: TargetCPUUtilization sets the target average CPU
+                      used across all replicas. If average CPU exceeds this value,
+                      the HPA will scale up. Defaults to 90 percent.
+                    format: int32
+                    type: integer
                 type: object
               config:
                 description: Config is the raw JSON to be used as the collector's
@@ -346,6 +352,52 @@ spec:
                 description: ImagePullPolicy indicates the pull policy to be used
                   for retrieving the container image (Always, Never, IfNotPresent)
                 type: string
+              ingress:
+                description: 'Ingress is used to specify how OpenTelemetry Collector
+                  is exposed. This functionality is only available if one of the valid
+                  modes is set. Valid modes are: deployment, daemonset and statefulset.'
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
+                      "letsencrypt"'''
+                    type: object
+                  hostname:
+                    description: Hostname by which the ingress proxy can be reached.
+                    type: string
+                  tls:
+                    description: TLS configuration.
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an Ingress.
+                      properties:
+                        hosts:
+                          description: Hosts are a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        secretName:
+                          description: SecretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the Host header is used for routing.
+                          type: string
+                      type: object
+                    type: array
+                  type:
+                    description: 'Type default value is: "" Supported types are: ingress'
+                    enum:
+                    - ingress
+                    type: string
+                type: object
               maxReplicas:
                 description: MaxReplicas sets an upper bound to the autoscaling feature.
                   If MaxReplicas is set autoscaling is enabled.
@@ -548,7 +600,7 @@ spec:
                 description: Ports allows a set of ports to be exposed by the underlying
                   v1.Service. By default, the operator will attempt to infer the required
                   ports by parsing the .Spec.Config property but this property can
-                  be used to open aditional ports that can't be inferred by the operator,
+                  be used to open additional ports that can't be inferred by the operator,
                   like for custom receivers.
                 items:
                   description: ServicePort contains information on service's port.
@@ -606,6 +658,10 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              priorityClassName:
+                description: If specified, indicates the pod's priority. If not specified,
+                  the pod priority will be default or zero if there is no default.
+                type: string
               replicas:
                 description: Replicas is the number of pod instances for the underlying
                   OpenTelemetry Collector. Set this if your are not using autoscaling

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -124,6 +124,18 @@ rules:
       - list
       - update
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - opentelemetry.io
     resources:
       - instrumentations

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.60.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.61.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.15.0
+    helm.sh/chart: opentelemetry-operator-0.16.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.60.0"
+    app.kubernetes.io/version: "0.61.0"
     app.kubernetes.io/managed-by: Helm
     control-plane: controller-manager
   name: opentelemetry-operator-controller-manager-metrics-service

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -123,6 +123,18 @@ rules:
       - list
       - update
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - opentelemetry.io
     resources:
       - instrumentations

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -16,7 +16,7 @@ imagePullSecrets: []
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.60.0
+    tag: v0.61.0
   collectorImage:
     repository: otel/opentelemetry-collector
     tag: 0.62.1


### PR DESCRIPTION
BUMP [opentelemetry-operator to 0.61.0](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.61.0)
There is a documented breaking change related to `Jaeger receiver no longer supports remote sampling`. See release notes