### PR TITLE
fix: add opentelemetry-operator.labels template to deployment

### DIFF
--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -34,6 +34,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "opentelemetry-operator.labels" -}}
+control-plane: controller-manager
 helm.sh/chart: {{ include "opentelemetry-operator.chart" . }}
 {{ include "opentelemetry-operator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -2,8 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: opentelemetry-operator
-    control-plane: controller-manager
+    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
   name: {{ template "opentelemetry-operator.name" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
This commit moves the labels that were in the main template for the operator deployment manifest file into the existing named template in the _helpers.tpl file. It then uses that named template in the original deployment file. This fixes an issue where the operator chart would create a deployment object that didn't follow helm best practices.