### PR TITLE
[opentelemetry-operator] change collector image to contrib

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.16.0
+version: 0.17.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,9 @@
 # Upgrade guidelines
 
+## 0.16.0 to 0.17.0
+
+The v0.17.0 helm chart version changes OpenTelemetry Collector image to the contrib version. If you want to use the core version, set `manager.collectorImage.repository` to `otel/opentelemetry-collector`.
+
 ## 0.15.0 to 0.16.0
 
 Jaeger receiver no longer supports remote sampling. To be able to perform an update, it must be deactivated or replaced by a configuration of the [jaegerremotesampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/extension/jaegerremotesampling) extension.<br/>

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector:0.62.1
+            - --collector-image=otel/opentelemetry-collector-contrib:0.62.1
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.16.0
+    helm.sh/chart: opentelemetry-operator-0.17.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.61.0"

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -2,3 +2,5 @@
   kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ $.Release.Name }}"
 
 Visit https://github.com/open-telemetry/opentelemetry-operator for instructions on how to create & configure OpenTelemetryCollector and Instrumentation custom resources by using the Operator.
+
+[Important] The v0.17.0 helm chart version changes OpenTelemetry Collector image to the contrib version. If you want to use the core version, set `manager.collectorImage.repository` to `otel/opentelemetry-collector`.

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -18,7 +18,7 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: v0.61.0
   collectorImage:
-    repository: otel/opentelemetry-collector
+    repository: otel/opentelemetry-collector-contrib
     tag: 0.62.1
   ports:
     metricsPort: 8080


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/446

Not sure how do we approach this breaking change?

I added a notice, is it good enough? Or should we roll-out this by first adding a Notice and then after some time making the change?

Example of it rendered:
```                                                           
helm install opentelemetry-operator --set "admissionWebhooks.certManager.enabled=false" .

NAME: opentelemetry-operator
LAST DEPLOYED: Wed Oct 26 11:24:31 2022
NAMESPACE: sys-mon
STATUS: deployed
REVISION: 1
NOTES:
opentelemetry-operator has been installed. Check its status by running:
  kubectl --namespace sys-mon get pods -l "release=opentelemetry-operator"

Visit https://github.com/open-telemetry/opentelemetry-operator for instructions on how to create & configure OpenTelemetryCollector and Instrumentation custom resources by using the Operator.

[Important] The v0.17.0 helm chart version changes OpenTelemetry Collector image to the contrib version. If you want to use the core version, set `manager.collectorImage.repository` to `otel/opentelemetry-collector`.
```
