### PR TITLE
[demo] add miss config for opentelemetry-collector

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.9.6
+version: 0.9.7
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -500,6 +500,8 @@ opentelemetry-collector:
               allowed_origins:
                 - "http://*"
                 - "https://*"
+    processors:
+      batch: {}
     exporters:
       otlp:
         endpoint: '{{ .Release.Name }}-jaeger:4317'
@@ -508,6 +510,10 @@ opentelemetry-collector:
     service:
       pipelines:
         traces:
+          receivers:
+            - otlp
+          processors:
+            - batch
           exporters:
             - logging
             - otlp


### PR DESCRIPTION
I find a bug in demo chart's values, it miss receiver config.