### PR TITLE
Added DNS Config attribute to allow use of custom dns configuration

### DIFF
--- a/charts/opentelemetry-collector/templates/daemonset.yaml
+++ b/charts/opentelemetry-collector/templates/daemonset.yaml
@@ -39,4 +39,7 @@ spec:
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig: {{ . }}
+      {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- include "opentelemetry-collector.component" . | nindent 8 }}
         {{- include "opentelemetry-collector.podLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.dnsConfig }}
+      dnsConfig: {{ . }}
+      {{- end }}
       {{- $podValues := deepCopy .Values }}
       {{- $podData := dict "Values" $podValues "configmapSuffix" "" "isAgent" false }}
       {{- include "opentelemetry-collector.pod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -250,6 +250,9 @@ hostNetwork: false
 # Pod DNS policy ClusterFirst, ClusterFirstWithHostNet, None, Default, None
 dnsPolicy: ""
 
+# DNS configuration to allow custom nameservers and rules
+dnsConfig: {}
+
 # only used with deployment mode
 replicaCount: 1
 

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/name: opentelemetry-operator
         control-plane: controller-manager
     spec:
+      {{- with .Values.dnsConfig }}
+      dnsConfig: {{ . }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -122,6 +122,8 @@ affinity: {}
 tolerations: []
 nodeSelector: {}
 hostNetwork: false
+# DNS configuration to allow custom nameservers and rules
+dnsConfig: {}
 
 # Allows for pod scheduler prioritisation
 priorityClassName: ""


### PR DESCRIPTION
Sample DNS Configuration. 
```
dnsConfig:
    nameservers:
    - 169.254.20.10
    searches:
    - svc.cluster.local
    - cluster.local
    - {{ .Values.region }}.compute.internal
    options:
    - name: ndots
      value: '2'
```

DNS Config allows us to provide custom DNS routing rules to enable Pods with Host network to search Kubernetes services and endpoints. 