### PR TITLE
[opentelemetry-collector] Allow to reach local collector

### DIFF
--- a/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/configmap-agent.yaml
@@ -1,0 +1,93 @@
+---
+# Source: opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-collector-agent
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.37.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.62.1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    exporters:
+      logging: {}
+      otlp:
+        endpoint: example-opentelemetry-collector:4317
+        tls:
+          insecure: true
+    extensions:
+      health_check: {}
+      memory_ballast:
+        size_mib: "78"
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 156
+        spike_limit_mib: 48
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_compact:
+            endpoint: 0.0.0.0:6831
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${MY_POD_IP}:8888
+      zipkin:
+        endpoint: 0.0.0.0:9411
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      pipelines:
+        logs:
+          exporters:
+          - otlp
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - otlp
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - prometheus
+        traces:
+          exporters:
+          - otlp
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8888

--- a/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/daemonset.yaml
@@ -1,0 +1,77 @@
+---
+# Source: opentelemetry-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-opentelemetry-collector-agent
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.37.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.62.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 5ea2b740b5bb75296a005bf5db655e25589ca3e00f00240f26f8e2f141f2f7da
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      
+      serviceAccountName: example-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "otel/opentelemetry-collector-contrib:0.62.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200M
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: example-opentelemetry-collector-agent
+            items:
+              - key: relay
+                path: relay.yaml
+      hostNetwork: false

--- a/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.37.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.62.1"
+    app.kubernetes.io/managed-by: Helm
+    component: agent-collector
+spec:
+  type: ClusterIP
+  ports: 
+    
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    component: agent-collector
+  internalTrafficPolicy: Local

--- a/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-localtraffic/rendered/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.37.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.62.1"
+    app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-localtraffic/values.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-localtraffic/values.yaml
@@ -1,0 +1,50 @@
+mode: daemonset
+
+config:
+  exporters:
+    otlp:
+      endpoint: example-opentelemetry-collector:4317
+      tls:
+        insecure: true
+  service:
+    pipelines:
+      logs:
+        exporters:
+         - otlp
+         - logging
+      metrics:
+        exporters:
+         - otlp
+         - logging
+      traces:
+        exporters:
+         - otlp
+         - logging
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+    hostPort: null
+  otlp-http:
+    enabled: false
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+  metrics:
+    enabled: false
+
+service:
+  enabledIfDaemonset: true
+  internalTrafficPolicy: Local

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.mode "deployment") (eq .Values.mode "statefulset") (.Values.ingress.enabled) -}}
+{{- if or (eq .Values.mode "deployment") (eq .Values.mode "statefulset") (.Values.ingress.enabled) (and (eq .Values.mode "daemonset") .Values.service.enabledIfDaemonset ) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +19,7 @@ spec:
   selector:
     {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
     {{- include "opentelemetry-collector.component" . | nindent 4 }}
+{{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+{{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -496,6 +496,17 @@
         },
         "annotations": {
           "type": "object"
+        },
+        "enabledIfDaemonset": {
+          "type": "boolean"
+        },
+        "internalTrafficPolicy": {
+          "type": [ "string", "null" ],
+          "enum": [
+            "Local",
+            "Cluster",
+            null
+          ]
         }
       }
     },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -279,8 +279,10 @@ lifecycleHooks: {}
 #       - "5"
 
 service:
+  enabledIfDaemonset: false
   type: ClusterIP
   annotations: {}
+  internalTrafficPolicy: null
 
 ingress:
   enabled: false


### PR DESCRIPTION
When host port is not available (Ex: gke autopilot).
We need to reach a local collector for k8attributes processor
Enabling local service internal traffic pollicy could solve this.

https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/