### PR TITLE
[demo] support overriding of env variables

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.11.0
+version: 0.11.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -248,7 +248,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -296,7 +296,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -320,7 +320,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -344,7 +344,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -368,7 +368,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -392,7 +392,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -458,7 +458,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -528,7 +528,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -606,7 +606,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -674,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -746,7 +746,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -820,7 +820,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -890,7 +890,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1060,7 +1060,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1140,7 +1140,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1206,7 +1206,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1274,7 +1274,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1348,7 +1348,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1422,7 +1422,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1484,7 +1484,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.0
+    helm.sh/chart: opentelemetry-demo-0.11.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -35,3 +35,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: {{ .name}}
 {{- end}}
 {{- end }}
+
+{{- define "otel-demo.envOverriden" -}}
+{{- $mergedEnvs := list }}
+{{- $envOverrides := default (list) .envOverrides }}
+
+{{- range .env }}
+{{-   $currentEnv := . }}
+{{-   $hasOverride := false }}
+{{-   range $envOverrides }}
+{{-     if eq $currentEnv.name .name }}
+{{-       $mergedEnvs = append $mergedEnvs . }}
+{{-       $envOverrides = without $envOverrides . }}
+{{-       $hasOverride = true }}
+{{-     end }}
+{{-   end }}
+{{-   if not $hasOverride }}
+{{-     $mergedEnvs = append $mergedEnvs $currentEnv }}
+{{-   end }}
+{{- end }}
+{{- $mergedEnvs = concat $mergedEnvs $envOverrides }}
+{{- tpl (toYaml $mergedEnvs) . }}
+{{- end }}

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -1,14 +1,102 @@
 {{/*
 Get Pod Env
-Note: Consider that dependent variables need to be declared before the referenced env varibale.
+Note: Consider that dependent variables need to be declared before the referenced env variable.
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- if .useDefault.env  }}
-{{ toYaml .defaultValues.env }}
+{{ include "otel-demo.envOverriden" (dict "env" .defaultValues.env "envOverrides" .defaultValues.envOverrides "Template" $.Template) }}
 {{- end }}
+
+{{- if .env  }}
+{{ include "otel-demo.envOverriden" . }}
+{{- end }}
+
+{{- end }}
+
+{{/*
+Get Pod Env
+Note: Consider that dependent variables need to be declared before the referenced env variable.
+*/}}
+{{- define "otel-demo.pod.env3" -}}
+  {{- $mergedDefaultEnvs := list }}
+  {{- $defaultEnvOverrides := default (list) .defaultValues.envOverrides }}
+
+  {{- if .useDefault.env  }}
+    {{- range .defaultValues.env }}
+      {{- $currentEnv := . }}
+      {{- $hasOverride := false }}
+      {{- range $defaultEnvOverrides }}
+        {{- if eq $currentEnv.name .name }}
+          {{- $mergedDefaultEnvs = append $mergedDefaultEnvs . }}
+          {{- $defaultEnvOverrides = without $defaultEnvOverrides . }}
+          {{- $hasOverride = true }}
+        {{- end }}
+      {{- end }}
+      {{- if not $hasOverride }}
+        {{- $mergedDefaultEnvs = append $mergedDefaultEnvs $currentEnv }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- $mergedDefaultEnvs = concat $mergedDefaultEnvs $defaultEnvOverrides }}
+
+  {{- $mergedEnvs := list }}
+  {{- $envOverrides := default (list) .envOverrides }}
+
+  {{- if .env  }}
+    {{- range concat $mergedDefaultEnvs .env }}
+      {{- $currentEnv := . }}
+      {{- $hasOverride := false }}
+      {{- range default (list) $envOverrides }}
+        {{- if eq $currentEnv.name .name }}
+          {{- $mergedEnvs = append $mergedEnvs . }}
+          {{- $envOverrides = without $envOverrides . }}
+          {{- $hasOverride = true }}
+        {{- end }}
+      {{- end }}
+      {{- if not $hasOverride }}
+        {{- $mergedEnvs = append $mergedEnvs $currentEnv }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- $mergedEnvs = concat $mergedEnvs $envOverrides }}
+
+  {{- tpl (toYaml $mergedEnvs) . }}
+{{- end }}
+
+{{/*
+Get Pod Env
+Note: Consider that dependent variables need to be declared before the referenced env variable.
+*/}}
+{{- define "otel-demo.pod.env2" -}}
+{{- $mergedDefaultEnvs := list }}
+{{- if .useDefault.env  }}
+{{- $copyMap := dict }}
+{{- range .defaultValues.env }}
+{{- $_ := set $copyMap .name . }}
+{{- end }}
+{{- range .defaultValues.envOverrides }}
+{{- $_ := set $copyMap .name . }}
+{{- end }}
+{{- range $key, $value := $copyMap }}
+{{- $mergedDefaultEnvs = append $mergedDefaultEnvs $value }}
+{{- end }}
+{{- end }}
+
+{{- $mergedEnvs := list }}
 {{- if .env }}
-{{ tpl (toYaml .env) . }}
+{{- $copyMap := dict}}
+{{- range (concat $mergedDefaultEnvs .env) }}
+{{- $_ := set $copyMap .name . }}
 {{- end }}
+{{- range .envOverrides }}
+{{- $_ := set $copyMap .name . }}
+{{- end }}
+{{- range $key, $value := $copyMap }}
+{{- $mergedEnvs = append $mergedEnvs $value }}
+{{- end }}
+{{- end }}
+
+{{- tpl (toYaml $mergedEnvs) . }}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -6,7 +6,7 @@ Note: Consider that dependent variables need to be declared before the reference
 {{- if .useDefault.env  }}
 {{ include "otel-demo.envOverriden" (dict "env" .defaultValues.env "envOverrides" .defaultValues.envOverrides "Template" $.Template) }}
 {{- end }}
-{{- if .env  }}
+{{- if .env }}
 {{ include "otel-demo.envOverriden" . }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -6,97 +6,9 @@ Note: Consider that dependent variables need to be declared before the reference
 {{- if .useDefault.env  }}
 {{ include "otel-demo.envOverriden" (dict "env" .defaultValues.env "envOverrides" .defaultValues.envOverrides "Template" $.Template) }}
 {{- end }}
-
 {{- if .env  }}
 {{ include "otel-demo.envOverriden" . }}
 {{- end }}
-
-{{- end }}
-
-{{/*
-Get Pod Env
-Note: Consider that dependent variables need to be declared before the referenced env variable.
-*/}}
-{{- define "otel-demo.pod.env3" -}}
-  {{- $mergedDefaultEnvs := list }}
-  {{- $defaultEnvOverrides := default (list) .defaultValues.envOverrides }}
-
-  {{- if .useDefault.env  }}
-    {{- range .defaultValues.env }}
-      {{- $currentEnv := . }}
-      {{- $hasOverride := false }}
-      {{- range $defaultEnvOverrides }}
-        {{- if eq $currentEnv.name .name }}
-          {{- $mergedDefaultEnvs = append $mergedDefaultEnvs . }}
-          {{- $defaultEnvOverrides = without $defaultEnvOverrides . }}
-          {{- $hasOverride = true }}
-        {{- end }}
-      {{- end }}
-      {{- if not $hasOverride }}
-        {{- $mergedDefaultEnvs = append $mergedDefaultEnvs $currentEnv }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- $mergedDefaultEnvs = concat $mergedDefaultEnvs $defaultEnvOverrides }}
-
-  {{- $mergedEnvs := list }}
-  {{- $envOverrides := default (list) .envOverrides }}
-
-  {{- if .env  }}
-    {{- range concat $mergedDefaultEnvs .env }}
-      {{- $currentEnv := . }}
-      {{- $hasOverride := false }}
-      {{- range default (list) $envOverrides }}
-        {{- if eq $currentEnv.name .name }}
-          {{- $mergedEnvs = append $mergedEnvs . }}
-          {{- $envOverrides = without $envOverrides . }}
-          {{- $hasOverride = true }}
-        {{- end }}
-      {{- end }}
-      {{- if not $hasOverride }}
-        {{- $mergedEnvs = append $mergedEnvs $currentEnv }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- $mergedEnvs = concat $mergedEnvs $envOverrides }}
-
-  {{- tpl (toYaml $mergedEnvs) . }}
-{{- end }}
-
-{{/*
-Get Pod Env
-Note: Consider that dependent variables need to be declared before the referenced env variable.
-*/}}
-{{- define "otel-demo.pod.env2" -}}
-{{- $mergedDefaultEnvs := list }}
-{{- if .useDefault.env  }}
-{{- $copyMap := dict }}
-{{- range .defaultValues.env }}
-{{- $_ := set $copyMap .name . }}
-{{- end }}
-{{- range .defaultValues.envOverrides }}
-{{- $_ := set $copyMap .name . }}
-{{- end }}
-{{- range $key, $value := $copyMap }}
-{{- $mergedDefaultEnvs = append $mergedDefaultEnvs $value }}
-{{- end }}
-{{- end }}
-
-{{- $mergedEnvs := list }}
-{{- if .env }}
-{{- $copyMap := dict}}
-{{- range (concat $mergedDefaultEnvs .env) }}
-{{- $_ := set $copyMap .name . }}
-{{- end }}
-{{- range .envOverrides }}
-{{- $_ := set $copyMap .name . }}
-{{- end }}
-{{- range $key, $value := $copyMap }}
-{{- $mergedEnvs = append $mergedEnvs $value }}
-{{- end }}
-{{- end }}
-
-{{- tpl (toYaml $mergedEnvs) . }}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -126,6 +126,12 @@
             "$ref": "#/definitions/Env"
           }
         },
+        "envOverrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Env"
+          }
+        },
         "ports": {
           "type": "array",
           "items": {
@@ -193,6 +199,12 @@
           "type": "boolean"
         },
         "env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Env"
+          }
+        },
+        "envOverrides": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Env"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -21,6 +21,7 @@ observability:
     enabled: true
 
 default:
+  # list of environment variables applied to all components
   env:
     - name: OTEL_SERVICE_NAME
       valueFrom:
@@ -44,6 +45,11 @@ default:
           fieldPath: metadata.name
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
+  # list of environment variables which get applied to all components additional to the list provided with the "env" section.
+  # Use this section to override or add environment variables selectively 
+  envOverrides: []
+  #  - name: OTEL_K8S_NODE_NAME
+  #    value: "someConstantValue"
   image:
     repository: otel/demo
     # Overrides the image tag whose default is the chart appVersion.
@@ -96,6 +102,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: AD_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -122,6 +129,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CART_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -156,6 +164,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CHECKOUT_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -180,6 +189,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CURRENCY_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -209,6 +219,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
       - name: EMAIL_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -235,6 +246,7 @@ components:
         value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffspostgres:5432/ffs'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+    envOverrides: []
     serviceType: ClusterIP
     ports:
       - name: grpc
@@ -268,6 +280,7 @@ components:
         value: ffs
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+    envOverrides: []
     serviceType: ClusterIP
     ports:
       - name: postgres
@@ -313,6 +326,7 @@ components:
         value: "8080"
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -392,6 +406,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: LOADGENERATOR_PORT
         value: "8089"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -414,6 +429,7 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -438,6 +454,7 @@ components:
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -468,6 +485,7 @@ components:
         value: "8080"
       - name: PRODUCT_CATALOG_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -496,6 +514,7 @@ components:
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
         value: 'http://{{ include "otel-demo.name" . }}-quoteservice:8080'
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:
@@ -526,6 +545,7 @@ components:
         value: '{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: QUOTE_SERVICE_PORT
         value: "8080"
+    envOverrides: []
     podAnnotations: {}
     resources:
       limits:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -45,8 +45,7 @@ default:
           fieldPath: metadata.name
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
-  # list of environment variables which get applied to all components additional to the list provided with the "env" section.
-  # Use this section to override or add environment variables selectively 
+  # Allows overriding and additions to .Values.default.env
   envOverrides: []
   #  - name: OTEL_K8S_NODE_NAME
   #    value: "someConstantValue"


### PR DESCRIPTION
**Description**
Enables https://github.com/open-telemetry/opentelemetry-helm-charts/issues/438 by adding new properties to override environment variables. It supports to overwrite and/or add variables to the default section or to every individual component without the need of repeating the whole env lists.

It indirectly also adds support for templated default envs, so using templates in the env variable of the default section.

It adds only new properties and with that the approach is fully compatible.

The merge logic for the environment variables is implemented in a dedicated helper template which gets applied twice; for generating the default envs and the component specific ones.

The PR does not support to override in the component an environment variable defined in the default section. That will require to print the env variables all together (default and component specific) and would not allow to have a re-usable template for the merge logic.
You would need a way to first merge the default envs, then append the result of that to the component env list, then merge that with the component overrides and then print it all together. That is possible and worked out but had repeating logic and the overall template looked very complex. So I decided for now to take a more clean approach but not having the capability supported.

**Changes**
- Introduced new "envOverrides" properties for the default section and for every component
- Extracted env generation logic into another template which is now doing the merge logic
- Re-generated example components.yaml
- Updated chart version