### PR TITLE
Add Pierre Tessier as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 Approvers ([@open-telemetry/helm-approvers](https://github.com/orgs/open-telemetry/teams/helm-approvers)):
 
 - [Alex Birca](https://github.com/Allex1), Adobe
+- [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 
 Emeritus Approvers:
 


### PR DESCRIPTION
@puckpuck is a maintainer of https://github.com/open-telemetry/opentelemetry-demo and an active contributor to the demo chart.