### PR TITLE
Make health check port configurable

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.38.2
+version: 0.38.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -19,7 +19,8 @@ data:
         tls:
           insecure: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast:
         size_mib: "78"
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast: {}
     processors:
       batch: {}

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 04c8e7d358aeb9a395c3ee9c8fbb06a8cb69741deca1f2ed6a7f67d6cc647a54
+        checksum/config: b7626dadd596f190faa35ba82a9fb543e5446c41b440faadb6495f052fcf3b91
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -76,11 +76,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 100m

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94e38539a5aac832bbf871314b1f366faca442233814810313ded5d38bda7d99
+        checksum/config: 3e5c186aeaea6e738cc50c08a406ba0df8b04f32bc679cd2eab98e6efd5091ce
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -71,11 +71,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 100m

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast:
         size_mib: "204"
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4e908d96a28d47071673e51cb6d2412b6c85b8be1fc319ddb6d9bc458e262823
+        checksum/config: ad1c5f650d5f83d1caa276a0e2f88f8835a473aebe7d2242e0618809198362aa
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -76,11 +76,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 256m

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast:
         size_mib: "204"
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 884a1e48623eff80fba2fb7c8448e7091136eecdb00b7b1643e0cbc8e11b2a6f
+        checksum/config: 5da3ce9497153d749944795fdce2cd392af90137d265b8ca3e2679cf3c1a3a77
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -88,11 +88,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 256m

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast:
         size_mib: "204"
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d324cec4cf546efaeaeca65055de6153a73076299c7bca82faa4cf6416333157
+        checksum/config: 4f3c90cdb99cfdc4f7771bfddbc2d11dc63fffdeaee47fded26deb97d5cd7bff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -82,11 +82,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 256m

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast:
         size_mib: "204"
     processors:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d324cec4cf546efaeaeca65055de6153a73076299c7bca82faa4cf6416333157
+        checksum/config: 4f3c90cdb99cfdc4f7771bfddbc2d11dc63fffdeaee47fded26deb97d5cd7bff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -76,11 +76,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 256m

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast: {}
     processors:
       batch: {}

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2810210050bd2ad2e2d8a6949286e7313e4b65760e8220c49f47c2f422384b7f
+        checksum/config: faa2e7004112078816d0980037d6d784a0acd3ef9fb8cb8d20715564b04c5936
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -71,11 +71,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 2

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast: {}
     processors:
       batch: {}

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56a0e5150b93d40e2b084b36a69a52a7c98dfc036f1a2998d9a2f76b105b5e95
+        checksum/config: 039722c47b6c706d42bd42fcc2606dfc5e58aceb4a0dfb06cf4aa01e3a91e842
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -59,11 +59,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 256m

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -71,11 +71,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 100m

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -15,7 +15,8 @@ data:
     exporters:
       logging: {}
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: '0.0.0.0:13134'
       memory_ballast: {}
     processors:
       batch: {}

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.2
+    helm.sh/chart: opentelemetry-collector-0.38.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.63.1"
@@ -73,11 +73,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: 13134
           resources:
             limits:
               cpu: 100m

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -58,7 +58,7 @@ containers:
             fieldPath: spec.nodeName
       {{- end }}
       {{- with .Values.extraEnvs }}
-      {{- . | toYaml | nindent 6 }}
+        {{- . | toYaml | nindent 6 }}
       {{- end }}
     {{- if .Values.lifecycleHooks }}
     lifecycle:
@@ -67,11 +67,11 @@ containers:
     livenessProbe:
       httpGet:
         path: /
-        port: 13133
+        port: {{ .Values.healthCheck.port }}
     readinessProbe:
       httpGet:
         path: /
-        port: 13133
+        port: {{ .Values.healthCheck.port }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}
     volumeMounts:

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -40,6 +40,24 @@
         ""
       ]
     },
+    "healthCheck": {
+      "description": "Health Check url and port configuration",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Health check URL"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Health check port"
+        }
+      }
+    },
+    "healthCheckUrl": {
+      "description": "Health Check url template",
+      "type": "string"
+    },
     "presets": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -6,7 +6,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Valid values are "daemonset", "deployment", and "statefulset".
-mode: ""
+mode: "daemonset"
 
 # Handles basic configuration of components that
 # also require k8s modifications to work correctly.
@@ -53,7 +53,10 @@ presets:
 configMap:
   # Specifies whether a configMap should be created (true by default)
   create: true
-
+healthCheck:
+  port: 13134
+  url: "0.0.0.0"
+healthCheckUrl: "{{.d.url}}:{{.d.port}}"
 # Base collector configuration.
 # Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
 # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
@@ -64,7 +67,8 @@ config:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
     # The health_check extension can be modified, but should never be removed.
-    health_check: {}
+    # URL is templatized to allow multiple chart deployments to exist in a single cluster
+    health_check: {"endpoint": "{{ tpl .Values.healthCheckUrl (dict \"d\" .Values.healthCheck \"Template\" $.Template) }}"}
     memory_ballast: {}
   processors:
     batch: {}


### PR DESCRIPTION
In scenarios where we are looking to deploy multiple helm charts in a single cluster - to allow different configurations, there is a conflict with healthCheck port causing one of the charts to fail. 

This conflict is observed only when running multiple charts - all with hostMode enabled. 

This PR allows easier configuration of this health check port while templatising the url for the extension configuration. 