### PR TITLE
As kubelet gives us container fs usage we don't need to scrape this

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.39.1
+version: 0.39.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -156,6 +156,13 @@ receivers:
         memory:
         disk:
         filesystem:
+          exclude_mount_points:
+            mount_points:
+            - /snap/*
+            - /boot/*
+            - /var/lib/kubelet/pods/*
+            - /var/lib/kubelet/plugins/*
+            match_type: regexp
         network:
 {{- end }}
 


### PR DESCRIPTION
mount points

We might consider checking if the preset for kubelete is enabled, but with this PR I used the naive approach.