### PR TITLE
Following opentelemetry security best practices Users SHOULD bind rec…

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.39.1
+version: 0.39.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -74,17 +74,17 @@ config:
     jaeger:
       protocols:
         grpc:
-          endpoint: 0.0.0.0:14250
+          endpoint: ${MY_POD_IP}:14250
         thrift_http:
-          endpoint: 0.0.0.0:14268
+          endpoint: ${MY_POD_IP}:14268
         thrift_compact:
-          endpoint: 0.0.0.0:6831
+          endpoint: ${MY_POD_IP}:6831
     otlp:
       protocols:
         grpc:
-          endpoint: 0.0.0.0:4317
+          endpoint: ${MY_POD_IP}:4317
         http:
-          endpoint: 0.0.0.0:4318
+          endpoint: ${MY_POD_IP}:4318
     prometheus:
       config:
         scrape_configs:
@@ -94,11 +94,11 @@ config:
               - targets:
                   - ${MY_POD_IP}:8888
     zipkin:
-      endpoint: 0.0.0.0:9411
+      endpoint: ${MY_POD_IP}:9411
   service:
     telemetry:
       metrics:
-        address: 0.0.0.0:8888
+        address: ${MY_POD_IP}:8888
     extensions:
       - health_check
       - memory_ballast


### PR DESCRIPTION
…eivers' servers to addresses that limit connections to authorized users

Setting chart defaults to the pod.ip should guarantee that.

https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md

Signed-off-by: Oded David <oded@coralogix.com>