### PR TITLE
[operator] secrets name mismatch when setting nameOverride or secretName

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.18.0
+version: 0.18.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/ci/cert-manager-disable-nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-disable-nameoverride-values.yaml
@@ -1,0 +1,5 @@
+nameOverride: no-cert-manager
+
+admissionWebhooks:
+  certManager:
+    enabled: false

--- a/charts/opentelemetry-operator/ci/cert-manager-disable-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-disable-values.yaml
@@ -1,0 +1,3 @@
+admissionWebhooks:
+  certManager:
+    enabled: false

--- a/charts/opentelemetry-operator/ci/nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/nameoverride-values.yaml
@@ -1,0 +1,1 @@
+nameOverride: foobar

--- a/charts/opentelemetry-operator/ci/secret-name-nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/secret-name-nameoverride-values.yaml
@@ -1,0 +1,4 @@
+nameOverride: secret-name
+
+admissionWebhooks:
+  secretName: random-name

--- a/charts/opentelemetry-operator/ci/secret-name-values.yaml
+++ b/charts/opentelemetry-operator/ci/secret-name-values.yaml
@@ -1,0 +1,2 @@
+admissionWebhooks:
+  secretName: random-name

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
-  name: opentelemetry-operator-controller-manager-service-cert
+  name: {{ default (printf "%s-controller-manager-service-cert" (include "opentelemetry-operator.name" .)) .Values.admissionWebhooks.secretName }}
   namespace: {{ .Release.Namespace }}
 data:
   tls.crt: {{ $cert.Cert | b64enc }}

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -17,7 +17,7 @@ spec:
     kind: Issuer
     name: {{ template "opentelemetry-operator.name" . }}-selfsigned-issuer
     {{- end }}
-  secretName: {{ template "opentelemetry-operator.name" . }}-controller-manager-service-cert
+  secretName: {{ default (printf "%s-controller-manager-service-cert" (include "opentelemetry-operator.name" .)) .Values.admissionWebhooks.secretName }}
   subject:
     organizationalUnits:
       - {{ template "opentelemetry-operator.name" . }}


### PR DESCRIPTION
The current chart fails to install when using `nameOverride` due to a mismatch in secret name.  

BUT, I have found a problem while doing my little tests against `main` (that is not part of this PR and a bug in general).  If I install using
```shell
helm install otel open-telemetry/opentelemetry-operator --version 0.18.0 --set nameOverride=foobar --set admissionWebhooks.certManager.enabled=false
```

then the chart fails because volume mount for secret in the deployment is now `foobar-controller-manager-service-cert` where the secret created is actually called `opentelemetry-operator-controller-manager-service-cert` due to [operator-webhook.yaml#L14](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-operator-0.18.0/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml#L14)

On the other hand, if we install 
```shell
helm install otel open-telemetry/opentelemetry-operator --version 0.18.0 --set nameOverride=foobar --set admissionWebhooks.secretName=random-name
```

then the deployment tries to mount secret `random-name` due to this line [deployment.yaml#L119](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-operator-0.18.0/charts/opentelemetry-operator/templates/deployment.yaml#L119) but the secret name is not passed onto the [cert manager #L20](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-operator-0.18.0/charts/opentelemetry-operator/templates/certmanager.yaml#L20).

Also added some tests for `ct` even though I am not sure how beneficial they are as they take quite some time to run.  The tests were added for myself to see the failures in main more than anything else.