### PR TITLE
Add a judgement while creating the admissionWebhooks' secret

### DIFF
--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -2,6 +2,7 @@
 {{- $altNames := list ( printf "%s.%s" "opentelemetry-operator-webhook-service" .Release.Namespace ) ( printf "%s.%s.svc" "opentelemetry-operator-webhook-service" .Release.Namespace ) -}}
 {{- $ca := genCA "opentelemetry-operator-operator-ca" 365 -}}
 {{- $cert := genSignedCert (include "opentelemetry-operator.fullname" .) nil $altNames 365 $ca -}}
+{{- if (not .Values.admissionWebhooks.secretName) }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -16,6 +17,7 @@ metadata:
 data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
If we have set up the `admissionWebhooks.secretName`, it looks like no need to install the secret.