### PR TITLE
[opentelemetry-demo] Bump demo and collector version

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.38.0
+  version: 0.39.1
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.16.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.42.2
-digest: sha256:a053cc4c963d0e1e305a9719832073e000adfd2eccec3107e921067414e68c8a
-generated: "2022-11-01T22:54:12.017808-04:00"
+digest: sha256:1e865a4eeab047148522d810711c2869038a7eb2300193f50156c5e5aa63f68b
+generated: "2022-11-14T22:16:08.306967-07:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.11.1
+version: 0.12.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -11,10 +11,10 @@ maintainers:
   - name: puckpuck
   - name: tylerhelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.38.0
+    version: 0.39.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: observability.otelcol.enabled
   - name: prometheus

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,11 +29,11 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -53,11 +53,11 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -77,11 +77,11 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,11 +101,11 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -125,11 +125,11 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -152,11 +152,11 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -176,11 +176,11 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -200,11 +200,11 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,11 +224,11 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -248,11 +248,11 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -272,11 +272,11 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -296,11 +296,11 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -320,11 +320,11 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -344,11 +344,11 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -368,11 +368,11 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,11 +392,11 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -414,7 +414,7 @@ spec:
     spec:
       containers:
         - name: adservice
-          image: 'otel/demo:v1.0.0-adservice'
+          image: 'otel/demo:v1.1.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -458,11 +458,11 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -480,7 +480,7 @@ spec:
     spec:
       containers:
         - name: cartservice
-          image: 'otel/demo:v1.0.0-cartservice'
+          image: 'otel/demo:v1.1.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -528,11 +528,11 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -550,7 +550,7 @@ spec:
     spec:
       containers:
         - name: checkoutservice
-          image: 'otel/demo:v1.0.0-checkoutservice'
+          image: 'otel/demo:v1.1.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -606,11 +606,11 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -628,7 +628,7 @@ spec:
     spec:
       containers:
         - name: currencyservice
-          image: 'otel/demo:v1.0.0-currencyservice'
+          image: 'otel/demo:v1.1.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -674,11 +674,11 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -696,7 +696,7 @@ spec:
     spec:
       containers:
         - name: emailservice
-          image: 'otel/demo:v1.0.0-emailservice'
+          image: 'otel/demo:v1.1.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -746,11 +746,11 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -768,7 +768,7 @@ spec:
     spec:
       containers:
         - name: featureflagservice
-          image: 'otel/demo:v1.0.0-featureflagservice'
+          image: 'otel/demo:v1.1.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -820,11 +820,11 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -890,11 +890,11 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -912,7 +912,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: 'otel/demo:v1.0.0-frontend'
+          image: 'otel/demo:v1.1.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -974,11 +974,11 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -996,7 +996,7 @@ spec:
     spec:
       containers:
         - name: frontendproxy
-          image: 'otel/demo:v1.0.0-frontendproxy'
+          image: 'otel/demo:v1.1.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1060,11 +1060,11 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1082,7 +1082,7 @@ spec:
     spec:
       containers:
         - name: loadgenerator
-          image: 'otel/demo:v1.0.0-loadgenerator'
+          image: 'otel/demo:v1.1.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1140,11 +1140,11 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1162,7 +1162,7 @@ spec:
     spec:
       containers:
         - name: paymentservice
-          image: 'otel/demo:v1.0.0-paymentservice'
+          image: 'otel/demo:v1.1.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1206,11 +1206,11 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1228,7 +1228,7 @@ spec:
     spec:
       containers:
         - name: productcatalogservice
-          image: 'otel/demo:v1.0.0-productcatalogservice'
+          image: 'otel/demo:v1.1.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1274,11 +1274,11 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1296,7 +1296,7 @@ spec:
     spec:
       containers:
         - name: quoteservice
-          image: 'otel/demo:v1.0.0-quoteservice'
+          image: 'otel/demo:v1.1.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1348,11 +1348,11 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1370,7 +1370,7 @@ spec:
     spec:
       containers:
         - name: recommendationservice
-          image: 'otel/demo:v1.0.0-recommendationservice'
+          image: 'otel/demo:v1.1.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1422,11 +1422,11 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1484,11 +1484,11 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1506,7 +1506,7 @@ spec:
     spec:
       containers:
         - name: shippingservice
-          image: 'otel/demo:v1.0.0-shippingservice'
+          image: 'otel/demo:v1.1.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,11 +5,11 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -34,11 +34,11 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.11.1
+    helm.sh/chart: opentelemetry-demo-0.12.0
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.0
+    helm.sh/chart: opentelemetry-collector-0.39.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.63.1"
+    app.kubernetes.io/version: "0.64.1"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.0
+    helm.sh/chart: opentelemetry-collector-0.39.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.63.1"
+    app.kubernetes.io/version: "0.64.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f3e13a432d9a9b9234d72ccbed7697ddf50f16a90691dc70c178abc64568e96d
+        checksum/config: e5f109652435656a1bb3afa873ce9059b1346a27d66a7c2d6cfd0cca261b20ae
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.63.1"
+          image: "otel/opentelemetry-collector-contrib:0.64.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact
@@ -98,3 +98,4 @@ spec:
             items:
               - key: relay
                 path: relay.yaml
+      hostNetwork: false

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.0
+    helm.sh/chart: opentelemetry-collector-0.39.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.63.1"
+    app.kubernetes.io/version: "0.64.1"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.38.0
+    helm.sh/chart: opentelemetry-collector-0.39.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.63.1"
+    app.kubernetes.io/version: "0.64.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Bumps demo images to 1.1.0 which fixes issues using the chart locally on Apple Silicon.

Bumps collector dependency to 0.39.1