### PR TITLE
[collector] - use percentage for memory limits

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.39.2
+version: 0.39.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,13 +21,13 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_mib: "78"
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 156
-        spike_limit_mib: 48
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -21,7 +21,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -16,13 +16,14 @@ data:
       logging: {}
     extensions:
       health_check: {}
-      memory_ballast: {}
+      memory_ballast:
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 156
-        spike_limit_mib: 48
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bcd20d62fe80b9cb8dd8910d3174242332a964a07bd009948ba5514f7f6de624
+        checksum/config: 260dfff326ee6273f076f8cf99dfbe31ff34420f2a11085d822a1a19aa3e4695
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 260dfff326ee6273f076f8cf99dfbe31ff34420f2a11085d822a1a19aa3e4695
+        checksum/config: 5cb6aaf9b1e2c6fdf4a523b33f650c8bf3bde6ebe5c3badf5d2cab95fb6b46a5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7026fc2d4691db6b2f3ce94c64863092d5820329c7b0956abe4983755fef0fe
+        checksum/config: 60402afa2b01744d6f222568d318a109e0ba2d87be1d1725704c064d4a11b101
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9a109af2f5ef2e139f4813cd9f18a3a6f1e099bbd91a9ce77c18b97ec77cd39a
+        checksum/config: b7026fc2d4691db6b2f3ce94c64863092d5820329c7b0956abe4983755fef0fe
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -17,13 +17,13 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_mib: "204"
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 409
-        spike_limit_mib: 128
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       filelog:
         exclude: []

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e0f5de3efedf7adf706b3c98f74ffed70ab5c528cfad279b7ce7d53204841ec1
+        checksum/config: 05880e0600395d682909b9963ae862a6b5751eae6d496478efba69d9cf413479
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d091182d357b241ed2fa986933caa1e8ea92380797ed4a5aeee0cb9637dd23e8
+        checksum/config: e0f5de3efedf7adf706b3c98f74ffed70ab5c528cfad279b7ce7d53204841ec1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -17,13 +17,13 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_mib: "204"
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 409
-        spike_limit_mib: 128
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 833d6af0f39d0542ed86f5ad580bdb7d02aaf601992eea46274d1ab02b04918a
+        checksum/config: f170acd2f82388e61a18d145846fcdbbcd38781539f65065449aaafa94928845
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5e7c618ec51e35030eba9ae599e660ad18b4a8ad57ab6d18d7e1b45a7f2bfde4
+        checksum/config: 833d6af0f39d0542ed86f5ad580bdb7d02aaf601992eea46274d1ab02b04918a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -17,13 +17,13 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_mib: "204"
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 409
-        spike_limit_mib: 128
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ec2f7e5f902296ce475b05f5d2b7d96c3b2a13cb9cbd76a37638e72b22a1790
+        checksum/config: dd445658d99992f09473df068cb70c636a6378f93d632c4084403daf6789995e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5af634b3148f253301412e52328419989451e8142d7781ee11fc37a06ad0c982
+        checksum/config: 6ec2f7e5f902296ce475b05f5d2b7d96c3b2a13cb9cbd76a37638e72b22a1790
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -17,13 +17,13 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_mib: "204"
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 409
-        spike_limit_mib: 128
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ec2f7e5f902296ce475b05f5d2b7d96c3b2a13cb9cbd76a37638e72b22a1790
+        checksum/config: dd445658d99992f09473df068cb70c636a6378f93d632c4084403daf6789995e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5af634b3148f253301412e52328419989451e8142d7781ee11fc37a06ad0c982
+        checksum/config: 6ec2f7e5f902296ce475b05f5d2b7d96c3b2a13cb9cbd76a37638e72b22a1790
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -16,13 +16,14 @@ data:
       logging: {}
     extensions:
       health_check: {}
-      memory_ballast: {}
+      memory_ballast:
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 3276
-        spike_limit_mib: 1024
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7026fc2d4691db6b2f3ce94c64863092d5820329c7b0956abe4983755fef0fe
+        checksum/config: 60402afa2b01744d6f222568d318a109e0ba2d87be1d1725704c064d4a11b101
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 845a0a2897e6b6dea34e3f3549fc84da91c20991f3501e972211f2f71bf61ca2
+        checksum/config: b7026fc2d4691db6b2f3ce94c64863092d5820329c7b0956abe4983755fef0fe
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -16,13 +16,14 @@ data:
       logging: {}
     extensions:
       health_check: {}
-      memory_ballast: {}
+      memory_ballast:
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 409
-        spike_limit_mib: 128
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       otlp:
         protocols:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 16579549102e502bade7c83acdc95eb0b97a26aaef8ff949cd03b5f80eec8aea
+        checksum/config: eec7434faff347af31d5bbdbf82da980746a0994d1c807c525a8d3b09bfe4be2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: eec7434faff347af31d5bbdbf82da980746a0994d1c807c525a8d3b09bfe4be2
+        checksum/config: 652da71f88cd6d30af03bea73510c914b7b120dd92b8fbb3a690b594f127336b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -17,7 +17,7 @@ data:
     extensions:
       health_check: {}
       memory_ballast:
-        size_percentage: 40
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -16,13 +16,14 @@ data:
       logging: {}
     extensions:
       health_check: {}
-      memory_ballast: {}
+      memory_ballast:
+        size_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 156
-        spike_limit_mib: 48
+        limit_percentage: 80
+        spike_limit_percentage: 25
     receivers:
       jaeger:
         protocols:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.2
+    helm.sh/chart: opentelemetry-collector-0.39.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -28,8 +28,8 @@ Merge user supplied config into memory ballast config.
 */}}
 {{- define "opentelemetry-collector.ballastConfig" -}}
 {{- $memoryBallastConfig := get .Values.config.extensions "memory_ballast" }}
-{{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_percentage) }}
-{{-   $_ := set $memoryBallastConfig "size_percentage" 40 }}
+{{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_in_percentage) }}
+{{-   $_ := set $memoryBallastConfig "size_in_percentage" 40 }}
 {{- end }}
 {{- .Values.config | toYaml }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -20,13 +20,6 @@ Merge user supplied config into memory limiter config.
 {{- if not $processorsConfig.memory_limiter }}
 {{-   $_ := set $processorsConfig "memory_limiter" (include "opentelemetry-collector.memoryLimiter" . | fromYaml) }}
 {{- end }}
-{{- .Values.config | toYaml }}
-{{- end }}
-
-{{/*
-Merge user supplied config into memory ballast config.
-*/}}
-{{- define "opentelemetry-collector.ballastConfig" -}}
 {{- $memoryBallastConfig := get .Values.config.extensions "memory_ballast" }}
 {{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_in_percentage) }}
 {{-   $_ := set $memoryBallastConfig "size_in_percentage" 40 }}
@@ -41,7 +34,6 @@ Build config file for daemonset OpenTelemetry Collector
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
-{{- $config = include "opentelemetry-collector.ballastConfig" $data | fromYaml | mustMergeOverwrite $config }}
 {{- if eq (include "opentelemetry-collector.logsCollectionEnabled" .) "true" }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -67,7 +59,6 @@ Build config file for deployment OpenTelemetry Collector
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
-{{- $config = include "opentelemetry-collector.ballastConfig" $data | fromYaml | mustMergeOverwrite $config }}
 {{- if eq (include "opentelemetry-collector.logsCollectionEnabled" .) "true" }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -6,10 +6,10 @@ Default memory limiter configuration for OpenTelemetry Collector based on k8s re
 check_interval: 5s
 
 # By default limit_mib is set to 80% of ".Values.resources.limits.memory"
-limit_mib: {{ include "opentelemetry-collector.getMemLimitMib" .Values.resources.limits.memory }}
+limit_percentage: 80
 
 # By default spike_limit_mib is set to 25% of ".Values.resources.limits.memory"
-spike_limit_mib: {{ include "opentelemetry-collector.getMemSpikeLimitMib" .Values.resources.limits.memory }}
+spike_limit_percentage: 25
 {{- end }}
 
 {{/*
@@ -18,7 +18,7 @@ Merge user supplied config into memory limiter config.
 {{- define "opentelemetry-collector.baseConfig" -}}
 {{- $processorsConfig := get .Values.config "processors" }}
 {{- if not $processorsConfig.memory_limiter }}
-{{- $_ := set $processorsConfig "memory_limiter" (include "opentelemetry-collector.memoryLimiter" . | fromYaml) }}
+{{-   $_ := set $processorsConfig "memory_limiter" (include "opentelemetry-collector.memoryLimiter" . | fromYaml) }}
 {{- end }}
 {{- .Values.config | toYaml }}
 {{- end }}
@@ -28,8 +28,8 @@ Merge user supplied config into memory ballast config.
 */}}
 {{- define "opentelemetry-collector.ballastConfig" -}}
 {{- $memoryBallastConfig := get .Values.config.extensions "memory_ballast" }}
-{{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_mib) }}
-{{- $_ := set $memoryBallastConfig "size_mib" (include "opentelemetry-collector.getMemBallastSizeMib" .Values.resources.limits.memory) }}
+{{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_percentage) }}
+{{-   $_ := set $memoryBallastConfig "size_percentage" 40 }}
 {{- end }}
 {{- .Values.config | toYaml }}
 {{- end }}
@@ -41,7 +41,7 @@ Build config file for daemonset OpenTelemetry Collector
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
-{{- $config := include "opentelemetry-collector.ballastConfig" $data | fromYaml | mustMergeOverwrite $config }}
+{{- $config = include "opentelemetry-collector.ballastConfig" $data | fromYaml | mustMergeOverwrite $config }}
 {{- if eq (include "opentelemetry-collector.logsCollectionEnabled" .) "true" }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -67,6 +67,7 @@ Build config file for deployment OpenTelemetry Collector
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
+{{- $config = include "opentelemetry-collector.ballastConfig" $data | fromYaml | mustMergeOverwrite $config }}
 {{- if eq (include "opentelemetry-collector.logsCollectionEnabled" .) "true" }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -84,61 +85,6 @@ Build config file for deployment OpenTelemetry Collector
 {{- end }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
-
-{{/*
-Convert memory value from resources.limit to numeric value in MiB to be used by otel memory_limiter processor.
-*/}}
-{{- define "opentelemetry-collector.convertMemToMib" -}}
-{{- $mem := lower . -}}
-{{- if hasSuffix "e" $mem -}}
-{{- trimSuffix "e" $mem | atoi | mul 1000 | mul 1000 | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "ei" $mem -}}
-{{- trimSuffix "ei" $mem | atoi | mul 1024 | mul 1024 | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "p" $mem -}}
-{{- trimSuffix "p" $mem | atoi | mul 1000 | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "pi" $mem -}}
-{{- trimSuffix "pi" $mem | atoi | mul 1024 | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "t" $mem -}}
-{{- trimSuffix "t" $mem | atoi | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "ti" $mem -}}
-{{- trimSuffix "ti" $mem | atoi | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "g" $mem -}}
-{{- trimSuffix "g" $mem | atoi | mul 1000 -}}
-{{- else if hasSuffix "gi" $mem -}}
-{{- trimSuffix "gi" $mem | atoi | mul 1024 -}}
-{{- else if hasSuffix "m" $mem -}}
-{{- div (trimSuffix "m" $mem | atoi | mul 1000) 1024 -}}
-{{- else if hasSuffix "mi" $mem -}}
-{{- trimSuffix "mi" $mem | atoi -}}
-{{- else if hasSuffix "k" $mem -}}
-{{- div (trimSuffix "k" $mem | atoi) 1000 -}}
-{{- else if hasSuffix "ki" $mem -}}
-{{- div (trimSuffix "ki" $mem | atoi) 1024 -}}
-{{- else -}}
-{{- div (div ($mem | atoi) 1024) 1024 -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get otel memory_limiter limit_mib value based on 80% of resources.memory.limit.
-*/}}
-{{- define "opentelemetry-collector.getMemLimitMib" -}}
-{{- div (mul (include "opentelemetry-collector.convertMemToMib" .) 80) 100 }}
-{{- end -}}
-
-{{/*
-Get otel memory_limiter spike_limit_mib value based on 25% of resources.memory.limit.
-*/}}
-{{- define "opentelemetry-collector.getMemSpikeLimitMib" -}}
-{{- div (mul (include "opentelemetry-collector.convertMemToMib" .) 25) 100 }}
-{{- end -}}
-
-{{/*
-Get otel memory_limiter ballast_size_mib value based on 40% of resources.memory.limit.
-*/}}
-{{- define "opentelemetry-collector.getMemBallastSizeMib" }}
-{{- div (mul (include "opentelemetry-collector.convertMemToMib" .) 40) 100 }}
-{{- end -}}
 
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
@@ -297,7 +243,7 @@ processors:
     - sources:
       - from: connection
     extract:
-      metadata: 
+      metadata:
         - "k8s.namespace.name"
         - "k8s.deployment.name"
         - "k8s.statefulset.name"


### PR DESCRIPTION
This uses percentage limits for the `memory_limiter` processor and the `memory_ballast` extension instead of computing limits from defined pod resources.

I also noticed the `memory_ballast` extension was not getting configured for `deployment` mode collectors, so I added that in as well.