### PR TITLE
[opentelemetry-collector] add zpages extension

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.39.3
+version: 0.39.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,6 +22,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -55,6 +57,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -51,6 +53,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb6aaf9b1e2c6fdf4a523b33f650c8bf3bde6ebe5c3badf5d2cab95fb6b46a5
+        checksum/config: cc79b82a69b1b686c74db5f5fe0d349e122abc21124df2a99498203dfcd9999a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 60402afa2b01744d6f222568d318a109e0ba2d87be1d1725704c064d4a11b101
+        checksum/config: 50a3394f1003e43dec8c47a1565aa0637e8cd64e1d10af6da5cf26669254abf4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -114,6 +116,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05880e0600395d682909b9963ae862a6b5751eae6d496478efba69d9cf413479
+        checksum/config: c336bd3737d4354400128361981754116decd3ae9357e6ea84eb5036caab1bc0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -60,6 +62,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f170acd2f82388e61a18d145846fcdbbcd38781539f65065449aaafa94928845
+        checksum/config: 36208a3f7ed49dae15639cdfe9f34578c96804cd4c8b8783086b5d738c8f7b4c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -51,6 +53,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dd445658d99992f09473df068cb70c636a6378f93d632c4084403daf6789995e
+        checksum/config: 84c1942178fe9b0b087cccc3f7594bc7abe68aeb800f29ca775dcd46b412d16e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -51,6 +53,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dd445658d99992f09473df068cb70c636a6378f93d632c4084403daf6789995e
+        checksum/config: 84c1942178fe9b0b087cccc3f7594bc7abe68aeb800f29ca775dcd46b412d16e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -51,6 +53,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 60402afa2b01744d6f222568d318a109e0ba2d87be1d1725704c064d4a11b101
+        checksum/config: 50a3394f1003e43dec8c47a1565aa0637e8cd64e1d10af6da5cf26669254abf4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -33,6 +35,7 @@ data:
             endpoint: 0.0.0.0:4318
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 652da71f88cd6d30af03bea73510c914b7b120dd92b8fbb3a690b594f127336b
+        checksum/config: fe7956c0c3af71615c892786f2d000c3f22e3bd0e326ff06d1ea4077eed61be0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"
@@ -18,6 +18,8 @@ data:
       health_check: {}
       memory_ballast:
         size_in_percentage: 40
+      zpages:
+        endpoint: localhost:55679
     processors:
       batch: {}
       memory_limiter:
@@ -51,6 +53,7 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - zpages
       - health_check
       - memory_ballast
       pipelines:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.3
+    helm.sh/chart: opentelemetry-collector-0.39.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.64.1"

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -66,6 +66,8 @@ config:
     # The health_check extension can be modified, but should never be removed.
     health_check: {}
     memory_ballast: {}
+    zpages:
+      endpoint: localhost:55679
   processors:
     batch: {}
     # If set to null, will be overridden with values based on k8s resource limits
@@ -100,6 +102,7 @@ config:
       metrics:
         address: 0.0.0.0:8888
     extensions:
+      - zpages
       - health_check
       - memory_ballast
     pipelines:


### PR DESCRIPTION
hey :)

I think we should by default add zpages extension, I used it today to debug a slow exporter:


Tested with:
```
helm install --set "mode=daemonset" --set "presets.logsCollection.enabled=true" --generate-name .

kubectl port-forward chart-1669198614-opentelemetry-collector-agent-4jnnb 55679
```

Example UI:
![image](https://user-images.githubusercontent.com/22289110/203523000-e0d22811-2ef0-48e3-bee5-7df6e06aac76.png)
