### PR TITLE
Specify grpc endpoint in otlp receiver config

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.12.4
+version: 0.12.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -248,7 +248,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -296,7 +296,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -320,7 +320,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -344,7 +344,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -368,7 +368,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -392,7 +392,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -457,7 +457,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -526,7 +526,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -603,7 +603,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -670,7 +670,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -741,7 +741,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -814,7 +814,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -883,7 +883,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -966,7 +966,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1051,7 +1051,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1130,7 +1130,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1195,7 +1195,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1262,7 +1262,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1335,7 +1335,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1408,7 +1408,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1469,7 +1469,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.4
+    helm.sh/chart: opentelemetry-demo-0.12.5
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -578,8 +578,6 @@ opentelemetry-collector:
     receivers:
       otlp:
         protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317          
           http:
             cors:
               allowed_origins:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -579,6 +579,7 @@ opentelemetry-collector:
       otlp:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:4317          
           http:
             cors:
               allowed_origins:


### PR DESCRIPTION
Fixes #530 

To fix this, I first rendered the k8s manifests for each scenario as follows:

```
helm template my-otel-demo open-telemetry/opentelemetry-demo -n otel-demo -f charts/opentelemetry-demo/values.yaml > otel-demo.yaml
```
and

```
helm template my-otel-demo open-telemetry/opentelemetry-demo -n otel-demo > otel-demo-2.yaml
```

I ran a diff of the 2 files, and noticed that `otel-demo.yaml` was missing the OTLP gRPC endpoint configuration:

```yaml
      otlp:
        protocols:
          grpc:
            endpoint: 0.0.0.0:4317
```

After adding this configuration to `values.yaml`, it appeared to fix the issue.