### PR TITLE
[demo] - release 1.2.1

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.14.0
+version: 0.14.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -11,7 +11,7 @@ maintainers:
   - name: puckpuck
   - name: tylerhelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 dependencies:
   - name: opentelemetry-collector
     version: 0.40.7

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1524,7 +1524,7 @@ spec:
           - name: OTEL_PHP_TRACES_PROCESSOR
             value: simple
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: 'example-otelcol:4318'
+            value: http://example-otelcol:4318
           - name: QUOTE_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,11 +29,11 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -53,11 +53,11 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -77,11 +77,11 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,11 +101,11 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -125,11 +125,11 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -152,11 +152,11 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -176,11 +176,11 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -200,11 +200,11 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,11 +224,11 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -251,11 +251,11 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -275,11 +275,11 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -299,11 +299,11 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -323,11 +323,11 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -347,11 +347,11 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -371,11 +371,11 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -395,11 +395,11 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -419,11 +419,11 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -441,7 +441,7 @@ spec:
     spec:
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -482,11 +482,11 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -504,7 +504,7 @@ spec:
     spec:
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -547,11 +547,11 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -569,7 +569,7 @@ spec:
     spec:
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -616,11 +616,11 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -638,7 +638,7 @@ spec:
     spec:
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -695,11 +695,11 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -717,7 +717,7 @@ spec:
     spec:
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -762,11 +762,11 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -784,7 +784,7 @@ spec:
     spec:
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -833,11 +833,11 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -855,7 +855,7 @@ spec:
     spec:
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -898,7 +898,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
-              memory: 160Mi
+              memory: 175Mi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -906,11 +906,11 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -975,11 +975,11 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -997,7 +997,7 @@ spec:
     spec:
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1038,11 +1038,11 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1060,7 +1060,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1121,11 +1121,11 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1143,7 +1143,7 @@ spec:
     spec:
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1189,7 +1189,7 @@ spec:
           - name: JAEGER_SERVICE_PORT
             value: "16686"
           - name: JAEGER_SERVICE_HOST
-            value: 'example-jaeger'
+            value: 'example-jaeger-query'
           - name: OTEL_COLLECTOR_PORT
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
@@ -1202,7 +1202,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
-              memory: 20Mi
+              memory: 30Mi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1210,11 +1210,11 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1232,7 +1232,7 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1253,11 +1253,11 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1334,11 +1334,11 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1356,7 +1356,7 @@ spec:
     spec:
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1399,11 +1399,11 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1421,7 +1421,7 @@ spec:
     spec:
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1466,11 +1466,11 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1488,7 +1488,7 @@ spec:
     spec:
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1531,7 +1531,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
             limits:
-              memory: 30Mi
+              memory: 40Mi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1539,11 +1539,11 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1561,7 +1561,7 @@ spec:
     spec:
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1612,11 +1612,11 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1673,11 +1673,11 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1695,7 +1695,7 @@ spec:
     spec:
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:v1.2.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:v1.2.1-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.0
+    helm.sh/chart: opentelemetry-demo-0.14.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.2.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -91,6 +91,9 @@ spec:
             httpGet:
               path: /api/health
               port: 3000
+          resources:
+            limits:
+              memory: 75Mi
       volumes:
         - name: config
           configMap:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           resources:
             limits:
               cpu: 256m
-              memory: 100Mi
+              memory: 125Mi
           volumeMounts:
             - mountPath: /conf
               name: opentelemetry-collector-configmap

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -30,7 +30,9 @@ data:
     scrape_configs:
     - job_name: opentelemetry-community-demo
       kubernetes_sd_configs:
-      - role: pod
+      - namespaces:
+          own_namespace: true
+        role: pod
       relabel_configs:
       - action: keep
         regex: true

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -436,6 +436,37 @@ components:
       limits:
         memory: 20Mi
 
+  quoteService:
+    enabled: true
+    useDefault:
+      env: true
+
+    imageOverride: {}
+    schedulingRules:
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
+    serviceType: ClusterIP
+    servicePort: 8080
+    env:
+      - name: OTEL_TRACES_SAMPLER
+        value: "parentbased_always_on"
+      - name: OTEL_TRACES_EXPORTER
+        value: "otlp"
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: "http/protobuf"
+      - name: OTEL_PHP_TRACES_PROCESSOR
+        value: "simple"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318'
+      - name: QUOTE_SERVICE_PORT
+        value: "8080"
+    envOverrides: []
+    podAnnotations: {}
+    resources:
+      limits:
+        memory: 40Mi
+
   recommendationService:
     enabled: true
     useDefault:
@@ -495,37 +526,6 @@ components:
     resources:
       limits:
         memory: 20Mi
-
-  quoteService:
-    enabled: true
-    useDefault:
-      env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
-    servicePort: 8080
-    env:
-      - name: OTEL_TRACES_SAMPLER
-        value: "parentbased_always_on"
-      - name: OTEL_TRACES_EXPORTER
-        value: "otlp"
-      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-        value: "http/protobuf"
-      - name: OTEL_PHP_TRACES_PROCESSOR
-        value: "simple"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: '{{ include "otel-demo.name" . }}-otelcol:4318'
-      - name: QUOTE_SERVICE_PORT
-        value: "8080"
-    envOverrides: []
-    podAnnotations: {}
-    resources:
-      limits:
-        memory: 40Mi
 
   ffsPostgres:
     enabled: true

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -237,7 +237,7 @@ components:
     podAnnotations: {}
     resources:
       limits:
-        memory: 160Mi
+        memory: 175Mi
 
   frauddetectionService:
     enabled: true
@@ -335,7 +335,7 @@ components:
       - name: JAEGER_SERVICE_PORT
         value: "16686"
       - name: JAEGER_SERVICE_HOST
-        value: '{{ include "otel-demo.name" . }}-jaeger'
+        value: '{{ include "otel-demo.name" . }}-jaeger-query'
       - name: OTEL_COLLECTOR_PORT
         value: "4317"
       - name: OTEL_COLLECTOR_HOST
@@ -347,7 +347,7 @@ components:
     podAnnotations: {}
     resources:
       limits:
-        memory: 20Mi
+        memory: 30Mi
 
   loadgenerator:
     enabled: true
@@ -525,7 +525,7 @@ components:
     podAnnotations: {}
     resources:
       limits:
-        memory: 30Mi
+        memory: 40Mi
 
   ffsPostgres:
     enabled: true
@@ -615,7 +615,7 @@ opentelemetry-collector:
   mode: deployment
   resources:
     limits:
-      memory: 100Mi
+      memory: 125Mi
   service:
     type: ClusterIP
   ports:
@@ -705,6 +705,8 @@ prometheus:
         - job_name: 'opentelemetry-community-demo'
           kubernetes_sd_configs:
             - role: pod
+              namespaces:
+                own_namespace: true
           relabel_configs:
             - source_labels: [__meta_kubernetes_pod_annotation_opentelemetry_community_demo]
               action: keep
@@ -752,3 +754,6 @@ grafana:
             path: /var/lib/grafana/dashboards/default
   dashboardsConfigMaps:
     default: '{{ include "otel-demo.name" . }}-grafana-dashboards'
+  resources:
+    limits:
+      memory: 75Mi


### PR DESCRIPTION
The demo 1.2 release had some issues, that needed to get fixed.  This picks up those changes (v1.2.1)

Also cleans up a few small things that were causing pain (exasperated by the issue in the demo 1.2 release).

- Prometheus will now only scrape in its own namespace
- Quote service properly routes OTLP data
- Jaeger routing from frontendproxy is fixed
- Adjusts memory limits for several components

This PR depends on the Demo 1.2.1 release images being created.