### PR TITLE
Fix Grafana datasource for Jaeger.

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -737,7 +737,7 @@ grafana:
         - name: Jaeger
           uid: webstore-traces
           type: jaeger
-          url: 'http://{{ include "otel-demo.name" . }}-jaeger:16686'
+          url: 'http://{{ include "otel-demo.name" . }}-jaeger:16686/jaeger/ui'
           editable: true
           isDefault: false
   dashboardProviders:


### PR DESCRIPTION
Fixed the datasource URL for the Jaeger within Grafana configmap, missed /jaeger/ui.