### PR TITLE
[demo] simplify default values

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.14.3
+version: 0.14.4
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.14.1
+version: 0.14.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.14.2
+version: 0.14.3
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -85,7 +85,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -133,7 +133,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 50053
       name: grpc
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 5432
       name: postgres
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -208,7 +208,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -232,7 +232,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 9092
       name: plaintext
@@ -259,7 +259,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8089
       name: service
@@ -283,7 +283,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -307,7 +307,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 6379
       name: redis
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: 
+  type: ClusterIP
   ports:
     - port: 8080
       name: service

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -85,7 +85,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -133,7 +133,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 50053
       name: grpc
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 5432
       name: postgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -208,7 +208,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -259,7 +259,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8089
       name: service
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -283,7 +283,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -307,7 +307,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: ClusterIP
+  type: 
   ports:
     - port: 8080
       name: service
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -482,7 +482,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -547,7 +547,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -616,7 +616,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -695,7 +695,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -762,7 +762,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -833,7 +833,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -906,7 +906,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -975,7 +975,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1038,7 +1038,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1121,7 +1121,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1210,7 +1210,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1334,7 +1334,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1399,7 +1399,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1466,7 +1466,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1539,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1612,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1673,7 +1673,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -482,7 +482,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -547,7 +547,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -616,7 +616,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -695,7 +695,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -762,7 +762,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -833,7 +833,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -906,7 +906,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -975,7 +975,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1038,7 +1038,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1121,7 +1121,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1210,7 +1210,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1334,7 +1334,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1399,7 +1399,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1466,7 +1466,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1539,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1612,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1673,7 +1673,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.3
+    helm.sh/chart: opentelemetry-demo-0.14.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.2.1"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.14.1
+    helm.sh/chart: opentelemetry-demo-0.14.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.2.1"

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -63,7 +63,7 @@ metadata:
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
-  type: {{.serviceType}}
+  type: {{ .serviceType | default "ClusterIP" }}
   ports:
     {{- if .ports }}
     {{- range $port := .ports }}

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -19,9 +19,9 @@ spec:
         {{- toYaml .podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- if or .defaultValues.image.pullSecrets .imageOverride.pullSecrets }}
+      {{- if or .defaultValues.image.pullSecrets ((.imageOverride).pullSecrets) }}
       imagePullSecrets:
-        {{- .imageOverride.pullSecrets | default .defaultValues.image.pullSecrets | toYaml | nindent 8}}
+        {{- ((.imageOverride).pullSecrets) | default .defaultValues.image.pullSecrets | toYaml | nindent 8}}
       {{- end }}
       {{- with .serviceAccountName }}
       serviceAccountName: {{ .serviceAccountName}}
@@ -42,8 +42,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ .name }}
-          image: '{{ .imageOverride.repository | default .defaultValues.image.repository }}:{{ .imageOverride.tag | default (printf "v%s-%s" (default .Chart.AppVersion .defaultValues.image.tag) (replace "-" "" .name)) }}'
-          imagePullPolicy: {{ .imageOverride.pullPolicy | default .defaultValues.image.pullPolicy }}
+          image: '{{ ((.imageOverride).repository) | default .defaultValues.image.repository }}:{{ ((.imageOverride).tag) | default (printf "v%s-%s" (default .Chart.AppVersion .defaultValues.image.tag) (replace "-" "" .name)) }}'
+          imagePullPolicy: {{ ((.imageOverride).pullPolicy) | default .defaultValues.image.pullPolicy }}
           {{- if or .ports .servicePort}}
           ports:
             {{- include "otel-demo.pod.ports" . | nindent 10 }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -126,11 +126,20 @@
             "env"
           ]
         },
+        "imageOverride": {
+          "$ref": "#/definitions/Image"
+        },
         "serviceType": {
           "type": "string"
         },
         "servicePort": {
           "type": "integer"
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Port"
+          }
         },
         "env": {
           "type": "array",
@@ -143,15 +152,6 @@
           "items": {
             "$ref": "#/definitions/Env"
           }
-        },
-        "ports": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Port"
-          }
-        },
-        "imageOverride": {
-          "$ref": "#/definitions/Image"
         },
         "schedulingRules": {
           "$ref": "#/definitions/SchedulingRules"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -42,16 +42,42 @@ default:
 serviceAccount: ""
 
 components:
+  ## Demo Components are named objects (services) with several properties
+  # demoService:
+  ## Enable the component (service)
+  #   enabled: true
+  #   useDefault:
+  ## Use default environment variables
+  #     env: true
+  ## Override Image repository and Tag. Tag will use appVersion as default.
+  ## Service's name will be applied to end of this value.
+  #   imageOverride: {}
+  ## Service Type to use for this component. Default is ClusterIP.
+  #   serviceType: ClusterIP
+  ## Service Port to use to expose this component. Default is nil
+  #   servicePort: 8080
+  ## Additional service ports to use to expose this component
+  #   ports:
+  #     - name: extraServicePort
+  #       value: 8081
+  ## Environment variables to add to the component's pod
+  #   env:
+  ## Environment variables that upsert (append + merge) into the `env` specification for this component.
+  #   envOverrides:
+  ## Pod Scheduling rules for nodeSelector, affinity, or tolerations.
+  #   schedulingRules:
+  #     nodeSelector: {}
+  #     affinity: {}
+  #     tolerations: []
+  ## Pod Annotations to add to this component
+  #   podAnnotations: {}
+  ## Resources for this component
+  #   resources: {}
+
   accountingService:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
@@ -59,8 +85,6 @@ components:
         value: cumulative
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 20Mi
@@ -69,21 +93,12 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    serviceType: ClusterIP
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: AD_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 300Mi
@@ -92,13 +107,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    serviceType: ClusterIP
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     servicePort: 8080
     env:
       - name: ASPNETCORE_URLS
@@ -109,8 +117,6 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CART_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 160Mi
@@ -119,13 +125,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    serviceType: ClusterIP
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     servicePort: 8080
     env:
       - name: CART_SERVICE_ADDR
@@ -146,8 +145,6 @@ components:
         value: "8080"
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 20Mi
@@ -156,13 +153,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: PORT
@@ -171,8 +161,6 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: CURRENCY_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 20Mi
@@ -181,13 +169,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    serviceType: ClusterIP
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     servicePort: 8080
     env:
       - name: APP_ENV
@@ -200,8 +181,6 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
       - name: EMAIL_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 100Mi
@@ -210,12 +189,11 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
+    ports:
+      - name: grpc
+        value: 50053
+      - name: http
+        value: 8081
     env:
       - name: FEATURE_FLAG_GRPC_SERVICE_PORT
         value: "50053"
@@ -227,14 +205,6 @@ components:
         value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffspostgres:5432/ffs'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
-    envOverrides: []
-    serviceType: ClusterIP
-    ports:
-      - name: grpc
-        value: 50053
-      - name: http
-        value: 8081
-    podAnnotations: {}
     resources:
       limits:
         memory: 175Mi
@@ -243,12 +213,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
@@ -256,8 +220,6 @@ components:
         value: cumulative
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 200Mi
@@ -266,13 +228,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: FRONTEND_ADDR
@@ -297,8 +252,6 @@ components:
         value: "8080"
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 200Mi
@@ -307,13 +260,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: FRONTEND_PORT
@@ -344,7 +290,6 @@ components:
         value: "8080"
       - name: ENVOY_UID
         value: "0"
-    podAnnotations: {}
     resources:
       limits:
         memory: 30Mi
@@ -353,13 +298,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8089
     env:
       - name: FRONTEND_ADDR
@@ -382,8 +320,6 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: LOADGENERATOR_PORT
         value: "8089"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 120Mi
@@ -392,21 +328,12 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 70Mi
@@ -415,13 +342,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -430,8 +350,6 @@ components:
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 20Mi
@@ -440,13 +358,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: OTEL_TRACES_SAMPLER
@@ -461,8 +372,6 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318'
       - name: QUOTE_SERVICE_PORT
         value: "8080"
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 40Mi
@@ -471,13 +380,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: OTEL_PYTHON_LOG_CORRELATION
@@ -492,8 +394,6 @@ components:
         value: "8080"
       - name: PRODUCT_CATALOG_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 500Mi            # This is high to enable supporting the recommendationCache feature flag use case
@@ -502,13 +402,6 @@ components:
     enabled: true
     useDefault:
       env: true
-
-    imageOverride: {}
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-    serviceType: ClusterIP
     servicePort: 8080
     env:
       - name: PORT
@@ -521,8 +414,6 @@ components:
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
         value: 'http://{{ include "otel-demo.name" . }}-quoteservice:8080'
-    envOverrides: []
-    podAnnotations: {}
     resources:
       limits:
         memory: 20Mi
@@ -531,14 +422,12 @@ components:
     enabled: true
     useDefault:
       env: true
-
     imageOverride:
       repository: "postgres"
       tag: "14"
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
+    ports:
+      - name: postgres
+        value: 5432
     env:
       - name: POSTGRES_DB
         value: ffs
@@ -548,12 +437,6 @@ components:
         value: ffs
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
-    envOverrides: []
-    serviceType: ClusterIP
-    ports:
-      - name: postgres
-        value: 5432
-    podAnnotations: {}
     resources:
       limits:
         memory: 120Mi
@@ -562,29 +445,22 @@ components:
     enabled: true
     useDefault:
       env: false
-    imageOverride: {}
-    env:
-      - name: KAFKA_ADVERTISED_LISTENERS
-        value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
     ports:
       - name: plaintext
         value: 9092
       - name: controller
         value: 9093
+    env:
+      - name: KAFKA_ADVERTISED_LISTENERS
+        value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
     resources:
       limits:
         memory: 600Mi
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
 
   redis:
     enabled: true
     useDefault:
       env: true
-
-    # Options to override the default image settings.
     imageOverride:
       repository: "redis"
       tag: "alpine"
@@ -594,13 +470,8 @@ components:
     resources:
       limits:
         memory: 20Mi
-    schedulingRules:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
 
 observability:
-  # collector settings are configured in the opentelemetry-collector section.
   otelcol:
     enabled: true
   jaeger:
@@ -635,20 +506,25 @@ opentelemetry-collector:
       otlp:
         protocols:
           http:
+            # Since this collector needs to receive data from the web, enable cors for all origins
+            # `allowed_origins` can be refined for your deployment domain
             cors:
               allowed_origins:
                 - "http://*"
                 - "https://*"
 
     exporters:
+      ## Create an exporter to Jaeger using the standard `otlp` export format
       otlp:
         endpoint: '{{ include "otel-demo.name" . }}-jaeger-collector:4317'
         tls:
           insecure: true
+      # Create an exporter to Prometheus (metrics)
       prometheus:
         endpoint: '0.0.0.0:9464'
 
     processors:
+      # Make use of the spanmetrics processor to compute RED metrics from all tracing spans
       spanmetrics:
         metrics_exporter: prometheus
 


### PR DESCRIPTION
Given the large number of components in the demo, the values file was expanding unnecessarily for unused parameters.  

This PR removes all unused (default) parameters from each demo component. Only parameters that override defaults are included. At the top of the `components` section is a commented sample for a component with all available parameters specified and documented.

This change reduces the number of lines in the values.yaml files by 16% (635 vs 759)