### PR TITLE
[operator] polish securityContext default values.

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.20.0
+version: 0.20.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -181,7 +181,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -199,7 +199,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -100,7 +100,7 @@ spec:
             defaultMode: 420
             secretName: opentelemetry-operator-controller-manager-service-cert
       securityContext:
-        fsGroup: 65534
-        runAsGroup: 65534
+        fsGroup: 65532
+        runAsGroup: 65532
         runAsNonRoot: true
-        runAsUser: 65534
+        runAsUser: 65532

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator-controller-manager
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-cert-manager-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-controller-manager-metrics-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "opentelemetry-operator-webhook-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.20.0
+    helm.sh/chart: opentelemetry-operator-0.20.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -154,10 +154,10 @@ priorityClassName: ""
 ## SecurityContext holds pod-level security attributes and common container settings.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
-  runAsGroup: 65534
+  runAsGroup: 65532
   runAsNonRoot: true
-  runAsUser: 65534
-  fsGroup: 65534
+  runAsUser: 65532
+  fsGroup: 65532
 
 testFramework:
   image:


### PR DESCRIPTION
related issue: 

https://github.com/open-telemetry/opentelemetry-operator/issues/1286#issuecomment-1342400471

and refs: 
https://github.com/open-telemetry/opentelemetry-operator/blob/0cf9da2620f96f269fede30b866fd679901d8155/Dockerfile#L38

I think change `runAsUser`  to `65532` is more appropriate