### PR TITLE
improve prometheus scrape

### DIFF
--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -81,6 +81,10 @@ metadata:
   name: {{ include "otel-demo.name" . }}-{{ .name }}
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
+  {{- if .serviceAnnotations }}
+  annotations:
+    {{- toYaml .serviceAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .serviceType | default "ClusterIP" }}
   ports:

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -172,6 +172,9 @@
         "securityContext": {
           "type": "object"
         },
+        "serviceAnnotations": {
+          "type": "object"
+        },
         "ingress": {
           "$ref": "#/definitions/Ingress"
         }

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -56,6 +56,8 @@ components:
   #   serviceType: ClusterIP
   ## Service Port to use to expose this component. Default is nil
   #   servicePort: 8080
+  ## Service Annotations to add to this component
+  #   serviceAnnotations: {}
   ## Additional service ports to use to expose this component
   #   ports:
   #     - name: extraServicePort
@@ -550,6 +552,9 @@ opentelemetry-collector:
       memory: 125Mi
   service:
     type: ClusterIP
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9464"
   ports:
     metrics:
       enabled: true
@@ -558,10 +563,6 @@ opentelemetry-collector:
       containerPort: 9464
       servicePort: 9464
       protocol: TCP
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9464"
-    opentelemetry_community_demo: "true"
   config:
     receivers:
       otlp:
@@ -639,15 +640,47 @@ prometheus:
   serverFiles:
     prometheus.yml:
       scrape_configs:
-        - job_name: 'opentelemetry-community-demo'
+
+        - job_name: 'kubernetes-service-endpoints'
+          honor_labels: true
+
           kubernetes_sd_configs:
-            - role: pod
-              namespaces:
-                own_namespace: true
+            - role: endpoints
+
           relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_annotation_opentelemetry_community_demo]
+            - source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_scrape ]
               action: keep
               regex: true
+            - source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_scrape_slow ]
+              action: drop
+              regex: true
+            - source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_scheme ]
+              action: replace
+              target_label: __scheme__
+              regex: (https?)
+            - source_labels: [ __meta_kubernetes_service_annotation_prometheus_io_path ]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels: [ __address__, __meta_kubernetes_service_annotation_prometheus_io_port ]
+              action: replace
+              target_label: __address__
+              regex: (.+?)(?::\d+)?;(\d+)
+              replacement: $1:$2
+            - action: labelmap
+              regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+              replacement: __param_$1
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels: [ __meta_kubernetes_namespace ]
+              action: replace
+              target_label: namespace
+            - source_labels: [ __meta_kubernetes_service_name ]
+              action: replace
+              target_label: service
+            - source_labels: [ __meta_kubernetes_pod_node_name ]
+              action: replace
+              target_label: node
 
 grafana:
   grafana.ini:


### PR DESCRIPTION
part of #571 

When I just modify value.yaml to enable `prometheus-node-exporter` and `kube-state-metrics`. prometheus doesn't have the data I expected.
After a brief research, I found out that the prometheus helm chart is scrape through service annotation.
https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L764-L803

So submit this PR
1. prometheus defaults to scrape via service annotation
2. modify the otel-col configuration so that it is configured with the correct service annotation
3. demo component supports serviceAnnotations