### PR TITLE
[chore] [collector] Revert otlp port renaming

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.43.3
+version: 0.43.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e591feae6c4add6e4d49f6d3c3f9ab175040bf2fd32fe5be1e897519649919a2
+        checksum/config: 2880d9145b970d0b07165478eee952f5382231b13d5158cf841b207387badf9c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,10 +43,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
-              hostPort: 4317
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -59,6 +55,10 @@ spec:
               containerPort: 14268
               protocol: TCP
               hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a74be8fcd7695098d92306b94aa1697e3be52b8489a35d807c8eff08b3d6c3b8
+        checksum/config: 9fd8638595615bf6028e9179231fe34bc2451e5d34ab1fc17f6987a773e91517
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,9 +44,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -55,6 +52,9 @@ spec:
               protocol: TCP
             - name: jaeger-thrift
               containerPort: 14268
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
               protocol: TCP
             - name: otlp-http
               containerPort: 4318

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -15,10 +15,6 @@ spec:
   type: ClusterIP
   ports: 
     
-    - name: grpc-otlp
-      port: 4317
-      targetPort: 4317
-      protocol: TCP
     - name: jaeger-compact
       port: 6831
       targetPort: 6831
@@ -30,6 +26,10 @@ spec:
     - name: jaeger-thrift
       port: 14268
       targetPort: 14268
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
       protocol: TCP
     - name: otlp-http
       port: 4318

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d47a0e4c8a1b64ecfd30d1bde5de083218582ca9d8032969074f1e43ec920eef
+        checksum/config: 06ad3c8f3adbd196ef7655c844a727b06343ba6e3f22d43c438cab8de7f5f0e6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,10 +43,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
-              hostPort: 4317
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -59,6 +55,10 @@ spec:
               containerPort: 14268
               protocol: TCP
               hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 04c2b5f3f435b58d881a6adea20a7c511b8f891be3d14d01f81fd158f3afb1f4
+        checksum/config: a6788e2eb122532880acd421bd1c27e78ccc1d0a4ef8ec292732c0d547e8511d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,10 +43,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
-              hostPort: 4317
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -59,6 +55,10 @@ spec:
               containerPort: 14268
               protocol: TCP
               hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fa63ce83d8bd37329db68d434b927d4ccb07608b4cb59e41ab30568007a1400d
+        checksum/config: fea9a2840d7da755486d2f48ac4eaf036ad17baf6d1f477fd34cd87b519cbf8f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,10 +43,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
-              hostPort: 4317
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -59,6 +55,10 @@ spec:
               containerPort: 14268
               protocol: TCP
               hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fa63ce83d8bd37329db68d434b927d4ccb07608b4cb59e41ab30568007a1400d
+        checksum/config: fea9a2840d7da755486d2f48ac4eaf036ad17baf6d1f477fd34cd87b519cbf8f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,10 +43,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
-              hostPort: 4317
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -59,6 +55,10 @@ spec:
               containerPort: 14268
               protocol: TCP
               hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
             - name: otlp-http
               containerPort: 4318
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a74be8fcd7695098d92306b94aa1697e3be52b8489a35d807c8eff08b3d6c3b8
+        checksum/config: 9fd8638595615bf6028e9179231fe34bc2451e5d34ab1fc17f6987a773e91517
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,9 +44,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -55,6 +52,9 @@ spec:
               protocol: TCP
             - name: jaeger-thrift
               containerPort: 14268
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
               protocol: TCP
             - name: otlp-http
               containerPort: 4318

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -15,10 +15,6 @@ spec:
   type: ClusterIP
   ports: 
     
-    - name: grpc-otlp
-      port: 4317
-      targetPort: 4317
-      protocol: TCP
     - name: jaeger-compact
       port: 6831
       targetPort: 6831
@@ -30,6 +26,10 @@ spec:
     - name: jaeger-thrift
       port: 14268
       targetPort: 14268
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
       protocol: TCP
     - name: otlp-http
       port: 4318

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 958564a878cf3f65dd68636268f3d6ef18856556cab9589749504ea30657aca0
+        checksum/config: df04d17b77847c4e2f8f7a1e705d5d223aa1f63887f0706bf7dc2103260c909f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
+            - name: otlp
               containerPort: 4317
               protocol: TCP
             - name: otlp-http

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -15,7 +15,7 @@ spec:
   type: ClusterIP
   ports: 
     
-    - name: grpc-otlp
+    - name: otlp
       port: 4317
       targetPort: 4317
       protocol: TCP

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -44,9 +44,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -55,6 +52,9 @@ spec:
               protocol: TCP
             - name: jaeger-thrift
               containerPort: 14268
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
               protocol: TCP
             - name: otlp-http
               containerPort: 4318

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -15,10 +15,6 @@ spec:
   type: ClusterIP
   ports: 
     
-    - name: grpc-otlp
-      port: 4317
-      targetPort: 4317
-      protocol: TCP
     - name: jaeger-compact
       port: 6831
       targetPort: 6831
@@ -30,6 +26,10 @@ spec:
     - name: jaeger-thrift
       port: 14268
       targetPort: 14268
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
       protocol: TCP
     - name: otlp-http
       port: 4318

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -15,10 +15,6 @@ spec:
   type: ClusterIP
   ports: 
     
-    - name: grpc-otlp
-      port: 4317
-      targetPort: 4317
-      protocol: TCP
     - name: jaeger-compact
       port: 6831
       targetPort: 6831
@@ -30,6 +26,10 @@ spec:
     - name: jaeger-thrift
       port: 14268
       targetPort: 14268
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
       protocol: TCP
     - name: otlp-http
       port: 4318

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.43.3
+    helm.sh/chart: opentelemetry-collector-0.43.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.67.0"
@@ -46,9 +46,6 @@ spec:
           image: "otel/opentelemetry-collector-contrib:0.67.0"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: grpc-otlp
-              containerPort: 4317
-              protocol: TCP
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP
@@ -57,6 +54,9 @@ spec:
               protocol: TCP
             - name: jaeger-thrift
               containerPort: 14268
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
               protocol: TCP
             - name: otlp-http
               containerPort: 4318

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -199,7 +199,7 @@ extraVolumeMounts: []
 
 # Configuration for ports
 ports:
-  grpc-otlp:
+  otlp:
     enabled: true
     containerPort: 4317
     servicePort: 4317


### PR DESCRIPTION
To avoid introducing breaking changes. If we want to update the naming to work well with istio, we need to do it in a backward compatible way with along with `otlp-http` for consistency.

The renaming was introduced in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/577 which I accidentally merged