### PR TITLE
[operator] Update operator-webhook.yaml

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.45.1
+version: 0.45.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cbe25daa1f846c4dd8bb8fe767768e26ff4c3ff5bf8f529b2e9ec7b351c3f631
+        checksum/config: 754e62f00829a75c4183b4f309564b0466f7235f8804ebd9630aba3394be78a6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 60124d303a04a532c7ef74b31db648ce927b5b9c36b4ebbfdcafa092ad585c22
+        checksum/config: fc84ea364eab39cb0595634057c20bce7c9b4ad2989f4ed8cadee218673aa93a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -31,6 +31,7 @@ spec:
       port: 4317
       targetPort: 4317
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: 4318

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c747ad861bfa2b910c435acf7182ccfb7ba78706b659a100cb9bb805ca1def2
+        checksum/config: 00c879b79a24f092497da5258dae03b5760ea882c21461a3f1761ba99ef55af8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 55b2e74668b76f95f152e0942cff05b04a3368452b33477c29b6b1e3fd7cf0b2
+        checksum/config: f6b3921cd0be24b3f84cabc3a5e26636579c89a1c68aa89c85fbb616c643bef4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c4e5157feaaca3def8d302e4cfed0aa6188824ac3289e6b8eadc66ecf206c00
+        checksum/config: 6a3cc04893d112e04030e7cddaca74f96b2844d4a02b1b5c0ede6a4999b8d8d9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c4e5157feaaca3def8d302e4cfed0aa6188824ac3289e6b8eadc66ecf206c00
+        checksum/config: 6a3cc04893d112e04030e7cddaca74f96b2844d4a02b1b5c0ede6a4999b8d8d9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 60124d303a04a532c7ef74b31db648ce927b5b9c36b4ebbfdcafa092ad585c22
+        checksum/config: fc84ea364eab39cb0595634057c20bce7c9b4ad2989f4ed8cadee218673aa93a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -31,6 +31,7 @@ spec:
       port: 4317
       targetPort: 4317
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: 4318

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d490edbcc7cd0ab45649b7347348f417164094bd311069df790d61fc6fce4942
+        checksum/config: 1b433932e8037fccdd9636addc3dafa185bdd791ba9636ca726b3a203572ea5c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -19,6 +19,7 @@ spec:
       port: 4317
       targetPort: 4317
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: 4318

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -31,6 +31,7 @@ spec:
       port: 4317
       targetPort: 4317
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: 4318

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"
@@ -31,6 +31,7 @@ spec:
       port: 4317
       targetPort: 4317
       protocol: TCP
+      appProtocol: grpc
     - name: otlp-http
       port: 4318
       targetPort: 4318

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.45.1
+    helm.sh/chart: opentelemetry-collector-0.45.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.69.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -300,6 +300,9 @@ processors:
   port: {{ $port.servicePort }}
   targetPort: {{ $port.containerPort }}
   protocol: {{ $port.protocol }}
+  {{- if $port.appProtocol }}
+  appProtocol: {{ $port.appProtocol }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -35,9 +35,6 @@ containers:
       - name: {{ $key }}
         containerPort: {{ $port.containerPort }}
         protocol: {{ $port.protocol }}
-        {{- if $port.appProtocol }}
-        appProtocol: {{ $port.appProtocol }}
-        {{- end }}
         {{- if and $.isAgent $port.hostPort }}
         hostPort: {{ $port.hostPort }}
         {{- end }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -308,6 +308,9 @@
             },
             "protocol": {
               "type": "string"
+            },
+            "appProtocol": {
+              "type": "string"
             }
           },
           "required": ["enabled"]

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -214,6 +214,7 @@ ports:
     servicePort: 4317
     hostPort: 4317
     protocol: TCP
+    appProtocol: grpc
   otlp-http:
     enabled: true
     containerPort: 4318

--- a/charts/opentelemetry-operator/CONTRIBUTING.md
+++ b/charts/opentelemetry-operator/CONTRIBUTING.md
@@ -6,5 +6,6 @@
 2. Update the chart's `appVersion` to match the new operator version.
 3. In the values.yaml, update `manager.image.tag` to match the new operator release.
 4. In the values.yaml, update `manager.collectorImage.tag` to match the version of the collector managed by default by the operator.
-5. Run `make update-operator-crds` to update the CRDs in this chart to match the operator's.
-6. Review the [Operator release notes](https://github.com/open-telemetry/opentelemetry-operator/releases).  If any changes affect the helm chart, adjust the helm chart accordingly.
+5. Run `make generate-examples`.
+6. Run `make update-operator-crds` to update the CRDs in this chart to match the operator's.
+7. Review the [Operator release notes](https://github.com/open-telemetry/opentelemetry-operator/releases).  If any changes affect the helm chart, adjust the helm chart accordingly.

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.21.1
+version: 0.21.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.22.0
+version: 0.21.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.21.2
+version: 0.22.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -34,6 +34,7 @@ webhooks:
       resources:
         - instrumentations
     sideEffects: None
+    timeoutSeconds: 10
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -84,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator-controller-manager
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator-controller-manager
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator-controller-manager
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-cert-manager-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-cert-manager-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-cert-manager-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-controller-manager-metrics-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "opentelemetry-operator-webhook-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.1
+    helm.sh/chart: opentelemetry-operator-0.21.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-controller-manager-metrics-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "opentelemetry-operator-webhook-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.22.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-controller-manager-metrics-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "opentelemetry-operator-webhook-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.22.0
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -18,6 +18,14 @@ webhooks:
         path: /mutate-opentelemetry-io-v1alpha1-instrumentation
     failurePolicy: Fail
     name: minstrumentation.kb.io
+    {{- if .Values.admissionWebhooks.namespaceSelector }}
+    namespaceSelector:
+    {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.admissionWebhooks.objectSelector }}
+    objectSelector:
+    {{- toYaml .Values.admissionWebhooks.objectSelector | nindent 6 }}
+    {{- end }}
     rules:
     - apiGroups:
         - opentelemetry.io
@@ -29,6 +37,7 @@ webhooks:
       resources:
         - instrumentations
     sideEffects: None
+    timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
       - v1
     clientConfig:

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.admissionWebhooks.create) (not .Values.admissionWebhooks.certManager.enabled) }}
-{{- $altNames := list ( printf "%s.%s" "opentelemetry-operator-webhook-service" .Release.Namespace ) ( printf "%s.%s.svc" "opentelemetry-operator-webhook-service" .Release.Namespace ) -}}
+{{- $altNames := list ( printf "%s-webhook-service.%s" (include "opentelemetry-operator.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "opentelemetry-operator.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA "opentelemetry-operator-operator-ca" 365 -}}
 {{- $cert := genSignedCert (include "opentelemetry-operator.fullname" .) nil $altNames 365 $ca -}}
 apiVersion: v1


### PR DESCRIPTION
Problem I need to solve:
Change the kubernetes opentelemetry webhook name so that it is called before other webhooks, as kubernetes calls the webhooks in alphabetical order.

Issue:
- When using nameOverride, to set the operator name to, say "aa-opentelemetry-operator";
- When setting certManager.enabled to false (in my org, we don't use a cert-manager);
- When applying applying a `kind: Instrumentation` ```kubectl apply -f instr.yaml ```
I get this error:
```
Error from server (InternalError): error when creating "instr.yaml": Internal error occurred: failed calling webhook "minstrumentation.kb.io": failed to call webhook: Post "https://aa-opentelemetry-operator-webhook-service.tracing.svc:443/mutate-opentelemetry-io-v1alpha1-instrumentation?timeout=10s": x509: certificate is valid for opentelemetry-operator-webhook-service.tracing, opentelemetry-operator-webhook-service.tracing.svc, not aa-opentelemetry-operator-webhook-service.tracing.svc
```

Solution:
This pull request uses the actual `opentelemetry-operator.name` to generate the self-signed certificate.