### PR TITLE
[operator] Update operator-webhook.yaml

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.21.2
+version: 0.21.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator-controller-manager
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-cert-manager-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "opentelemetry-operator-controller-manager-metrics-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "opentelemetry-operator-webhook-test-connection"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.21.2
+    helm.sh/chart: opentelemetry-operator-0.21.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.67.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.admissionWebhooks.create) (not .Values.admissionWebhooks.certManager.enabled) }}
-{{- $altNames := list ( printf "%s.%s" "opentelemetry-operator-webhook-service" .Release.Namespace ) ( printf "%s.%s.svc" "opentelemetry-operator-webhook-service" .Release.Namespace ) -}}
+{{- $altNames := list ( printf "%s-webhook-service.%s" (include "opentelemetry-operator.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "opentelemetry-operator.name" .) .Release.Namespace ) -}}
 {{- $ca := genCA "opentelemetry-operator-operator-ca" 365 -}}
 {{- $cert := genSignedCert (include "opentelemetry-operator.fullname" .) nil $altNames 365 $ca -}}
 apiVersion: v1


### PR DESCRIPTION
Problem I need to solve:
Change the kubernetes opentelemetry webhook name so that it is called before other webhooks, as kubernetes calls the webhooks in alphabetical order.

Issue:
- When using nameOverride, to set the operator name to, say "aa-opentelemetry-operator";
- When setting certManager.enabled to false (in my org, we don't use a cert-manager);
- When applying applying a `kind: Instrumentation` ```kubectl apply -f instr.yaml ```
I get this error:
```
Error from server (InternalError): error when creating "instr.yaml": Internal error occurred: failed calling webhook "minstrumentation.kb.io": failed to call webhook: Post "https://aa-opentelemetry-operator-webhook-service.tracing.svc:443/mutate-opentelemetry-io-v1alpha1-instrumentation?timeout=10s": x509: certificate is valid for opentelemetry-operator-webhook-service.tracing, opentelemetry-operator-webhook-service.tracing.svc, not aa-opentelemetry-operator-webhook-service.tracing.svc
```

Solution:
This pull request uses the actual `opentelemetry-operator.name` to generate the self-signed certificate.