### PR TITLE
Support frontend-web for web client service name

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -309,7 +309,7 @@ components:
       - name: WEB_OTEL_SERVICE_NAME
         value: frontend-web
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`      
+        value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`
     resources:
       limits:
         memory: 200Mi

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -306,8 +306,10 @@ components:
         value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: FRONTEND_PORT
         value: "8080"
+      - name: WEB_OTEL_SERVICE_NAME
+        value: frontend-web
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`
+        value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`      
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
* use frontend-web for web client service name

Per commit: https://github.com/open-telemetry/opentelemetry-demo/commit/a5668ad637f29ca40a9aa5b4ea07a2412e0fcd10
