### PR TITLE
[demo] abstract collector name from demo components

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.18.0
+version: 0.18.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -469,8 +469,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
@@ -487,7 +489,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -541,8 +543,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
@@ -559,7 +563,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -613,12 +617,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: ASPNETCORE_URLS
             value: http://*:8080
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CART_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -633,7 +639,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -687,6 +693,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
@@ -700,7 +708,7 @@ spec:
           - name: EMAIL_SERVICE_ADDR
             value: http://example-emailservice:8080
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CHECKOUT_SERVICE_PORT
             value: "8080"
           - name: KAFKA_SERVICE_ADDR
@@ -717,7 +725,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -771,10 +779,12 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -789,7 +799,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -843,14 +853,16 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: APP_ENV
             value: production
           - name: PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318/v1/traces
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: EMAIL_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -865,7 +877,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -921,6 +933,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FEATURE_FLAG_GRPC_SERVICE_PORT
             value: "50053"
           - name: FEATURE_FLAG_SERVICE_PORT
@@ -930,7 +944,7 @@ spec:
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -949,7 +963,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1003,14 +1017,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: POSTGRES_DB
             value: ffs
           - name: POSTGRES_PASSWORD
             value: ffs
           - name: POSTGRES_USER
             value: ffs
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1027,7 +1041,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1077,8 +1091,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
@@ -1095,7 +1111,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1149,6 +1165,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1166,7 +1184,7 @@ spec:
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
           - name: FRONTEND_PORT
@@ -1185,7 +1203,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1239,6 +1257,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1262,7 +1282,7 @@ spec:
           - name: OTEL_COLLECTOR_PORT
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
-            value: 'example-otelcol'
+            value: $(OTEL_COLLECTOR_NAME)
           - name: ENVOY_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1281,7 +1301,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1315,7 +1335,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_HEAP_OPTS
@@ -1334,7 +1354,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1388,6 +1408,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_ADDR
             value: 'example-frontend:8080'
           - name: LOCUST_WEB_PORT
@@ -1405,7 +1427,7 @@ spec:
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318/v1/traces
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: LOADGENERATOR_PORT
             value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1420,7 +1442,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1474,8 +1496,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1490,7 +1514,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1544,8 +1568,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
@@ -1564,7 +1590,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1618,8 +1644,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_PHP_AUTOLOAD_ENABLED
             value: "true"
           - name: QUOTE_SERVICE_PORT
@@ -1640,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1694,12 +1722,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: RECOMMENDATION_SERVICE_PORT
@@ -1718,7 +1748,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1772,6 +1802,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1788,7 +1820,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1842,12 +1874,12 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: PORT
             value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -469,8 +469,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
@@ -487,7 +489,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -541,8 +543,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
@@ -559,7 +563,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -613,12 +617,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: ASPNETCORE_URLS
             value: http://*:8080
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CART_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -633,7 +639,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -687,6 +693,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
@@ -700,7 +708,7 @@ spec:
           - name: EMAIL_SERVICE_ADDR
             value: http://example-emailservice:8080
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CHECKOUT_SERVICE_PORT
             value: "8080"
           - name: KAFKA_SERVICE_ADDR
@@ -717,7 +725,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -771,10 +779,12 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -789,7 +799,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -843,14 +853,16 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: APP_ENV
             value: production
           - name: PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318/v1/traces
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: EMAIL_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -865,7 +877,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -921,6 +933,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FEATURE_FLAG_GRPC_SERVICE_PORT
             value: "50053"
           - name: FEATURE_FLAG_SERVICE_PORT
@@ -930,7 +944,7 @@ spec:
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -949,7 +963,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1003,14 +1017,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: POSTGRES_DB
             value: ffs
           - name: POSTGRES_PASSWORD
             value: ffs
           - name: POSTGRES_USER
             value: ffs
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1027,7 +1041,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1077,8 +1091,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
@@ -1095,7 +1111,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1149,6 +1165,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1166,7 +1184,7 @@ spec:
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
           - name: FRONTEND_PORT
@@ -1185,7 +1203,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1239,6 +1257,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1262,7 +1282,7 @@ spec:
           - name: OTEL_COLLECTOR_PORT
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
-            value: 'example-otelcol'
+            value: $(OTEL_COLLECTOR_NAME)
           - name: ENVOY_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1281,7 +1301,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1315,7 +1335,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_HEAP_OPTS
@@ -1334,7 +1354,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1388,6 +1408,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: FRONTEND_ADDR
             value: 'example-frontend:8080'
           - name: LOCUST_WEB_PORT
@@ -1405,7 +1427,7 @@ spec:
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318/v1/traces
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: LOADGENERATOR_PORT
             value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1420,7 +1442,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1474,8 +1496,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1490,7 +1514,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1544,8 +1568,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
@@ -1564,7 +1590,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1618,8 +1644,10 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4318
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_PHP_AUTOLOAD_ENABLED
             value: "true"
           - name: QUOTE_SERVICE_PORT
@@ -1640,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1694,12 +1722,14 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: RECOMMENDATION_SERVICE_PORT
@@ -1718,7 +1748,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1772,6 +1802,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1788,7 +1820,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1842,12 +1874,12 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
           - name: PORT
             value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://example-otelcol:4317
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://example-otelcol:4317
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
@@ -1864,7 +1896,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.18.0
+    helm.sh/chart: opentelemetry-demo-0.18.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.0"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -26,6 +26,8 @@ default:
         fieldRef:
           apiVersion: v1
           fieldPath: metadata.uid
+    - name: OTEL_COLLECTOR_NAME
+      value: '{{ include "otel-demo.name" . }}-otelcol'
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
   # Allows overriding and additions to .Values.default.env
@@ -136,7 +138,7 @@ components:
       env: true
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
         value: cumulative
       - name: KAFKA_SERVICE_ADDR
@@ -153,7 +155,7 @@ components:
       port: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: AD_SERVICE_PORT
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
@@ -174,7 +176,7 @@ components:
       - name: REDIS_ADDR
         value: '{{ include "otel-demo.name" . }}-redis:6379'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: CART_SERVICE_PORT
         value: "8080"
     resources:
@@ -201,7 +203,7 @@ components:
       - name: EMAIL_SERVICE_ADDR
         value: 'http://{{ include "otel-demo.name" . }}-emailservice:8080'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: CHECKOUT_SERVICE_PORT
         value: "8080"
       - name: KAFKA_SERVICE_ADDR
@@ -220,7 +222,7 @@ components:
       - name: PORT
         value: "8080"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: CURRENCY_SERVICE_PORT
         value: "8080"
     resources:
@@ -239,9 +241,9 @@ components:
       - name: PORT
         value: "8080"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
+        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
       - name: EMAIL_SERVICE_PORT
         value: "8080"
     resources:
@@ -267,7 +269,7 @@ components:
       - name: DATABASE_URL
         value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffspostgres:5432/ffs'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 175Mi
@@ -284,7 +286,7 @@ components:
       env: true
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
         value: cumulative
       - name: KAFKA_SERVICE_ADDR
@@ -317,7 +319,7 @@ components:
       - name: SHIPPING_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-shippingservice:8080'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: WEB_OTEL_SERVICE_NAME
         value: frontend-web
       - name: FRONTEND_PORT
@@ -358,7 +360,7 @@ components:
       - name: OTEL_COLLECTOR_PORT
         value: "4317"
       - name: OTEL_COLLECTOR_HOST
-        value: '{{ include "otel-demo.name" . }}-otelcol'
+        value: $(OTEL_COLLECTOR_NAME)
       - name: ENVOY_PORT
         value: "8080"
     resources:
@@ -393,7 +395,7 @@ components:
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318/v1/traces'
+        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
       - name: LOADGENERATOR_PORT
         value: "8089"
     resources:
@@ -408,7 +410,7 @@ components:
       port: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
     resources:
@@ -423,7 +425,7 @@ components:
       port: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
         value: cumulative
       - name: PRODUCT_CATALOG_SERVICE_PORT
@@ -442,7 +444,7 @@ components:
       port: 8080
     env:
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4318'
+        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
       - name: OTEL_PHP_AUTOLOAD_ENABLED
         value: "true"
       - name: QUOTE_SERVICE_PORT
@@ -467,7 +469,7 @@ components:
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
       - name: RECOMMENDATION_SERVICE_PORT
@@ -487,10 +489,8 @@ components:
     env:
       - name: PORT
         value: "8080"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
       - name: SHIPPING_SERVICE_PORT
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
@@ -516,8 +516,6 @@ components:
         value: ffs
       - name: POSTGRES_USER
         value: ffs
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
     resources:
       limits:
         memory: 120Mi
@@ -539,7 +537,7 @@ components:
       - name: KAFKA_ADVERTISED_LISTENERS
         value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: 'http://{{ include "otel-demo.name" . }}-otelcol:4317'
+        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
         value: cumulative
       - name: KAFKA_HEAP_OPTS


### PR DESCRIPTION
Fixes: #624 and Closes #623

The PR will abstract the name of the OpenTelemetry Collector away from the components into a higher-level default environment variable `OTEL_COLLECTOR_NAME` pushed into all components. The components will then leverage this variable with Kubernetes environment variable expansion as needed using the `$(OTEL_COLLECTOR_NAME)` syntax.

With this change users can now deploy the collector in daemonset mode, and only change 1 environment variable override to have it working. This also opens up possibilities for uers that have the OpenTelemetry collector installed outside of the demo.

Tested and works with the following specified in a values file
```
default:
  envOverrides:
    - name: OTEL_COLLECTOR_NAME
      value: $(OTEL_K8S_NODE_NAME)

opentelemetry-collector:
  mode: daemonset
```