### PR TITLE
[demo] support demo 1.3.1 release

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.19.5
+version: 0.19.6
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -11,7 +11,7 @@ maintainers:
   - name: puckpuck
   - name: tylerhelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 dependencies:
   - name: opentelemetry-collector
     version: 0.49.1

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,11 +29,11 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -53,11 +53,11 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -77,11 +77,11 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,11 +101,11 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -125,11 +125,11 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -152,11 +152,11 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -176,11 +176,11 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -200,11 +200,11 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,11 +224,11 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -251,11 +251,11 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -275,11 +275,11 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -299,11 +299,11 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -323,11 +323,11 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -347,11 +347,11 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -371,11 +371,11 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -395,11 +395,11 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -419,11 +419,11 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -490,11 +490,11 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -513,7 +513,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -565,11 +565,11 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -588,7 +588,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -642,11 +642,11 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -665,7 +665,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -729,11 +729,11 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -752,7 +752,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -804,11 +804,11 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -827,7 +827,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -883,11 +883,11 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -906,7 +906,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -970,11 +970,11 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1049,11 +1049,11 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1072,7 +1072,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1120,11 +1120,11 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1143,7 +1143,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1213,11 +1213,11 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1236,7 +1236,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1312,11 +1312,11 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1335,7 +1335,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1366,11 +1366,11 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1389,7 +1389,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1455,11 +1455,11 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1478,7 +1478,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1528,11 +1528,11 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1551,7 +1551,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1605,11 +1605,11 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1628,7 +1628,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1684,11 +1684,11 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1707,7 +1707,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1765,11 +1765,11 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1838,11 +1838,11 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1861,7 +1861,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,11 +29,11 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -53,11 +53,11 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -77,11 +77,11 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -101,11 +101,11 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -125,11 +125,11 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -152,11 +152,11 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -176,11 +176,11 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -200,11 +200,11 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -224,11 +224,11 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -251,11 +251,11 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -275,11 +275,11 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -299,11 +299,11 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -323,11 +323,11 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -347,11 +347,11 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -371,11 +371,11 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -395,11 +395,11 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -419,11 +419,11 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -490,11 +490,11 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -513,7 +513,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -565,11 +565,11 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -588,7 +588,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -642,11 +642,11 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -665,7 +665,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -729,11 +729,11 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -752,7 +752,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -804,11 +804,11 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -827,7 +827,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -883,11 +883,11 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -906,7 +906,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -970,11 +970,11 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1049,11 +1049,11 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1072,7 +1072,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1120,11 +1120,11 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1143,7 +1143,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1213,11 +1213,11 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1236,7 +1236,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1312,11 +1312,11 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1335,7 +1335,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1366,11 +1366,11 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1389,7 +1389,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1455,11 +1455,11 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1478,7 +1478,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1528,11 +1528,11 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1551,7 +1551,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1605,11 +1605,11 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1628,7 +1628,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1684,11 +1684,11 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1707,7 +1707,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1765,11 +1765,11 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1838,11 +1838,11 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1861,7 +1861,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.3.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.3.1-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1915,11 +1915,11 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.19.5
+    helm.sh/chart: opentelemetry-demo-0.19.6
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
This supports to recently released 1.3.1 version of the demo.  More importantly, it adds arm64 support so the demo can run locally on M1/M2 macs.