### PR TITLE
debug operator tests

### DIFF
--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -37,8 +37,7 @@ jobs:
 
       - name: Get opentelemetry-operator repository
         run: |
-          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
-          git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
+          git clone -b mohosman/issue-1574/resolve-autoscale-e2e-issues --single-branch https://github.com/moh-osman3/opentelemetry-operator.git ./opentelemetry-operator
 
       - name: Use public target-allocator image in tests
         run: |


### PR DESCRIPTION
[DO NOT MERGE] This branch is just to debug why operator tests fail (have not been able to run locally)