### PR TITLE
[operator] add a prefix for ordering MutatingWebhookConfiguration

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.24.3
+version: 0.24.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.3
+    helm.sh/chart: opentelemetry-operator-0.24.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -72,3 +72,10 @@ Create the name of the service account to use
 {{- .Values.manager.podLabels | toYaml }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create an ordered name of the MutatingWebhookConfiguration
+*/}}
+{{- define "opentelemetry-operator.MutatingWebhookName" -}}
+{{- printf "%s-%s" (.Values.admissionWebhooks.orderPrefix | toString) (include "opentelemetry-operator.fullname" .) | trimPrefix "-" }}
+{{- end }}

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -77,5 +77,5 @@ Create the name of the service account to use
 Create an ordered name of the MutatingWebhookConfiguration
 */}}
 {{- define "opentelemetry-operator.MutatingWebhookName" -}}
-{{- printf "%s-%s" (.Values.admissionWebhooks.orderPrefix | toString) (include "opentelemetry-operator.fullname" .) | trimPrefix "-" }}
+{{- printf "%s-%s" (.Values.admissionWebhooks.namePrefix | toString) (include "opentelemetry-operator.fullname" .) | trimPrefix "-" }}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
-  name: {{ template "opentelemetry-operator.fullname" . }}-mutation
+  name: {{ template "opentelemetry-operator.MutatingWebhookName" . }}-mutation
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -24,7 +24,7 @@ metadata:
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
-  name: {{ template "opentelemetry-operator.fullname" . }}-mutation
+  name: {{ template "opentelemetry-operator.MutatingWebhookName" . }}-mutation
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1095,6 +1095,7 @@
                 "create",
                 "failurePolicy",
                 "secretName",
+                "namePrefix",
                 "timeoutSeconds",
                 "namespaceSelector",
                 "objectSelector",
@@ -1123,6 +1124,15 @@
                     "title": "The secretName Schema",
                     "examples": [
                         ""
+                    ]
+                },
+                "namePrefix": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The namePrefix Schema",
+                    "examples": [
+                        "10",
+                        "99"
                     ]
                 },
                 "timeoutSeconds": {

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -155,7 +155,7 @@ admissionWebhooks:
 
   ## Adds a prefix to the mutating webook name.
   ## This can be used to order this mutating webhook with all your cluster's mutating webhooks.
-  orderPrefix: ""
+  namePrefix: ""
 
   ## Customize webhook timeout duration
   timeoutSeconds: 10

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -153,6 +153,10 @@ admissionWebhooks:
   failurePolicy: Fail
   secretName: ""
 
+  ## Mutating webhooks are called sequentially. In some cases you would like your MutatingWebhooks
+  ## to run in specific order. In such case, add a prefix to all of them to sort alphabetically.
+  orderPrefix: ""
+
   ## Customize webhook timeout duration
   timeoutSeconds: 10
 

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -153,8 +153,8 @@ admissionWebhooks:
   failurePolicy: Fail
   secretName: ""
 
-  ## Mutating webhooks are called sequentially. In some cases you would like your MutatingWebhooks
-  ## to run in specific order. In such case, add a prefix to all of them to sort alphabetically.
+  ## Adds a prefix to the mutating webook name.
+  ## This can be used to order this mutating webhook with all your cluster's mutating webhooks.
   orderPrefix: ""
 
   ## Customize webhook timeout duration


### PR DESCRIPTION
Hi there.

Mutating webhooks are called sequentially in alphabetical order, whereas validating webhooks are called independently in parallel.

In some cases MutatingWebhooks should run in specific order. For example, when using Opentelemetry Operator and [Gatekeeper Mutations](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation), I want to modify securityContext for auto-instrumentation initContainer.

But, because of ordered sequential calling of mutating webhooks, gatekeeper mutation is called first, and does nothing, because auto-instrumentation initContainer is not created yet.

This MR implements optional ordering prefix for MutatingWebhookConfiguration. By default, prefix value is empty, and webhook name doesn't change during upgrade from previous chart versions. When set, prefix value is added to webhook name with a hyphen.

MutationWebhookConfiguration list before:
```
$ kubectl get MutatingWebhookConfiguration
NAME                                        WEBHOOKS
gatekeeper-mutating-webhook-configuration   1
opentelemetry-operator-mutation             3
```
After:
```
$ kubectl get MutatingWebhookConfiguration
NAME                                           WEBHOOKS
10-opentelemetry-operator-mutation             3
20-gatekeeper-mutating-webhook-configuration   1
```
