### PR TITLE
Bump kube-rbac-proxy v0.14.0

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.24.4
+version: 0.24.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -193,7 +193,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -211,7 +211,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -77,7 +77,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0"
+          image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.24.4
+    helm.sh/chart: opentelemetry-operator-0.24.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.70.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -942,13 +942,13 @@
                             "default": "",
                             "title": "The tag Schema",
                             "examples": [
-                                "v0.13.0"
+                                "v0.14.0"
                             ]
                         }
                     },
                     "examples": [{
                         "repository": "gcr.io/kubebuilder/kube-rbac-proxy",
-                        "tag": "v0.13.0"
+                        "tag": "v0.14.0"
                     }]
                 },
                 "ports": {
@@ -1069,7 +1069,7 @@
                 "enabled": true,
                 "image": {
                     "repository": "gcr.io/kubebuilder/kube-rbac-proxy",
-                    "tag": "v0.13.0"
+                    "tag": "v0.14.0"
                 },
                 "ports": {
                     "proxyPort": 8443
@@ -1494,7 +1494,7 @@
             "enabled": true,
             "image": {
                 "repository": "gcr.io/kubebuilder/kube-rbac-proxy",
-                "tag": "v0.13.0"
+                "tag": "v0.14.0"
             },
             "ports": {
                 "proxyPort": 8443

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -131,7 +131,7 @@ kubeRBACProxy:
   enabled: true
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
-    tag: v0.13.0
+    tag: v0.14.0
   ports:
     proxyPort: 8443
   resources:


### PR DESCRIPTION
Bump the kube-rbac-proxy to v0.14.0 that fixes some CVEs as noted in these [release notes](https://github.com/brancz/kube-rbac-proxy/releases)