### PR TITLE
[demo]:  label and port.name align istio standard

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.20.4
+version: 0.21.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/UPGRADING.md
+++ b/charts/opentelemetry-demo/UPGRADING.md
@@ -1,5 +1,12 @@
 # Upgrade guidelines
 
+## To 0.21
+
+The deployment labelSelector `app.kubernetes.io/name` has been renamed to
+individual workload naming. If you upgrade it from charts <= 0.20, you
+will have to delete all existing opentelemetry-demo deployments before running
+`helm upgrade` command.
+
 ## To 0.20
 
 The `observability.<sub chart>.enabled` parameters have been moved to an

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,10 +5,12 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -16,12 +18,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -29,10 +30,12 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -40,12 +43,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -53,10 +55,12 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -64,12 +68,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -77,10 +80,12 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -88,12 +93,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -101,10 +105,12 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -112,12 +118,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -125,10 +130,12 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -142,9 +149,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: example-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -152,10 +158,12 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -166,9 +174,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: example-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -176,10 +183,12 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -187,12 +196,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -200,10 +208,12 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -211,12 +221,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -224,10 +233,12 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -241,9 +252,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -251,10 +261,12 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -262,12 +274,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -275,10 +286,12 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -286,12 +299,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -299,10 +311,12 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -310,12 +324,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -323,10 +336,12 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -334,12 +349,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -347,10 +361,12 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -358,12 +374,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -371,10 +386,12 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -385,9 +402,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: example-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -395,10 +411,12 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -406,12 +424,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -419,25 +436,28 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -498,25 +518,28 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
     spec:
       serviceAccountName: example
       containers:
@@ -577,25 +600,28 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -664,25 +690,28 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -761,25 +790,28 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -836,25 +868,28 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -913,25 +948,28 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: example-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-featureflagservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
     spec:
       serviceAccountName: example
       containers:
@@ -1010,25 +1048,28 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: example-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-ffspostgres
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
     spec:
       serviceAccountName: example
       containers:
@@ -1091,25 +1132,28 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1170,25 +1214,28 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1269,25 +1316,28 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1370,25 +1420,28 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1453,25 +1506,28 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1540,25 +1596,28 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1619,25 +1678,28 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1696,25 +1758,28 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1777,25 +1842,28 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1860,25 +1928,28 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: example-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-redis
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
     spec:
       serviceAccountName: example
       containers:
@@ -1935,25 +2006,28 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,9 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,10 +5,12 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -16,12 +18,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -29,10 +30,12 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -40,12 +43,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -53,10 +55,12 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -64,12 +68,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -77,10 +80,12 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -88,12 +93,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -101,10 +105,12 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -112,12 +118,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -125,10 +130,12 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -142,9 +149,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: example-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -152,10 +158,12 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -166,9 +174,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: example-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -176,10 +183,12 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -187,12 +196,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -200,10 +208,12 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -211,12 +221,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -224,10 +233,12 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -241,9 +252,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -251,10 +261,12 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -262,12 +274,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -275,10 +286,12 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -286,12 +299,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -299,10 +311,12 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -310,12 +324,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -323,10 +336,12 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -334,12 +349,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -347,10 +361,12 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -358,12 +374,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -371,10 +386,12 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -385,9 +402,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: example-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -395,10 +411,12 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -406,12 +424,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -419,25 +436,28 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -498,25 +518,28 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
     spec:
       serviceAccountName: example
       containers:
@@ -577,25 +600,28 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -664,25 +690,28 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -761,25 +790,28 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -836,25 +868,28 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -913,25 +948,28 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: example-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-featureflagservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
     spec:
       serviceAccountName: example
       containers:
@@ -1010,25 +1048,28 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: example-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-ffspostgres
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
     spec:
       serviceAccountName: example
       containers:
@@ -1091,25 +1132,28 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1170,25 +1214,28 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1269,25 +1316,28 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1370,25 +1420,28 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1453,25 +1506,28 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1540,25 +1596,28 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1619,25 +1678,28 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1696,25 +1758,28 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1777,25 +1842,28 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1860,25 +1928,28 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: example-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-redis
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
     spec:
       serviceAccountName: example
       containers:
@@ -1935,25 +2006,28 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,9 +5,11 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,9 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,10 +5,12 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -16,12 +18,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -29,10 +30,12 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -40,12 +43,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -53,10 +55,12 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -64,12 +68,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -77,10 +80,12 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -88,12 +93,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -101,10 +105,12 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -112,12 +118,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -125,10 +130,12 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -142,9 +149,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: example-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -152,10 +158,12 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -166,9 +174,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: example-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -176,10 +183,12 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -187,12 +196,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -200,10 +208,12 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -211,12 +221,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -224,10 +233,12 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -241,9 +252,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -251,10 +261,12 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -262,12 +274,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -275,10 +286,12 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -286,12 +299,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -299,10 +311,12 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -310,12 +324,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -323,10 +336,12 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -334,12 +349,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -347,10 +361,12 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -358,12 +374,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -371,10 +386,12 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -385,9 +402,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: example-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -395,10 +411,12 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -406,12 +424,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -419,25 +436,28 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -500,25 +520,28 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
     spec:
       serviceAccountName: example
       containers:
@@ -581,25 +604,28 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -670,25 +696,28 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -769,25 +798,28 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -846,25 +878,28 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -925,25 +960,28 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: example-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-featureflagservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
     spec:
       serviceAccountName: example
       containers:
@@ -1024,25 +1062,28 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: example-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-ffspostgres
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
     spec:
       serviceAccountName: example
       containers:
@@ -1105,25 +1146,28 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1186,25 +1230,28 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1287,25 +1334,28 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1388,25 +1438,28 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1471,25 +1524,28 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1560,25 +1616,28 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1641,25 +1700,28 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1720,25 +1782,28 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1803,25 +1868,28 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1888,25 +1956,28 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: example-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-redis
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
     spec:
       serviceAccountName: example
       containers:
@@ -1963,25 +2034,28 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,9 +5,11 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,9 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,10 +5,12 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -16,12 +18,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -29,10 +30,12 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -40,12 +43,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -53,10 +55,12 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -64,12 +68,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -77,10 +80,12 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -88,12 +93,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -101,10 +105,12 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -112,12 +118,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -125,10 +130,12 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -142,9 +149,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: example-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -152,10 +158,12 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -166,9 +174,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: example-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -176,10 +183,12 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -187,12 +196,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -200,10 +208,12 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -211,12 +221,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -224,10 +233,12 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -241,9 +252,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -251,10 +261,12 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -262,12 +274,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -275,10 +286,12 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -286,12 +299,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -299,10 +311,12 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -310,12 +324,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -323,10 +336,12 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -334,12 +349,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -347,10 +361,12 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -358,12 +374,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -371,10 +386,12 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -385,9 +402,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: example-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -395,10 +411,12 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -406,12 +424,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -419,25 +436,28 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -498,25 +518,28 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
     spec:
       serviceAccountName: example
       containers:
@@ -577,25 +600,28 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -664,25 +690,28 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -761,25 +790,28 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -836,25 +868,28 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -913,25 +948,28 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: example-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-featureflagservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
     spec:
       serviceAccountName: example
       containers:
@@ -1010,25 +1048,28 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: example-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-ffspostgres
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
     spec:
       serviceAccountName: example
       containers:
@@ -1091,25 +1132,28 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1170,25 +1214,28 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1269,25 +1316,28 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1370,25 +1420,28 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1453,25 +1506,28 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1540,25 +1596,28 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1619,25 +1678,28 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1696,25 +1758,28 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1777,25 +1842,28 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1860,25 +1928,28 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: example-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-redis
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
     spec:
       serviceAccountName: example
       containers:
@@ -1935,25 +2006,28 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,9 +5,11 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,9 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,10 +5,12 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -16,12 +18,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: adservice
+    
+    opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -29,10 +30,12 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -40,12 +43,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: cartservice
+    
+    opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -53,10 +55,12 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -64,12 +68,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: checkoutservice
+    
+    opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -77,10 +80,12 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -88,12 +93,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: currencyservice
+    
+    opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -101,10 +105,12 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -112,12 +118,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: emailservice
+    
+    opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -125,10 +130,12 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -142,9 +149,8 @@ spec:
       name: http
       targetPort: 8081
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: featureflagservice
+    
+    opentelemetry.io/name: example-featureflagservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -152,10 +158,12 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -166,9 +174,8 @@ spec:
       name: postgres
       targetPort: 5432
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: ffspostgres
+    
+    opentelemetry.io/name: example-ffspostgres
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -176,10 +183,12 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -187,12 +196,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontend
+    
+    opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -200,10 +208,12 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -211,12 +221,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: frontendproxy
+    
+    opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -224,10 +233,12 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -241,9 +252,8 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: kafka
+    
+    opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -251,10 +261,12 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -262,12 +274,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8089
-      name: service
+      name: tcp-service
       targetPort: 8089
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: loadgenerator
+    
+    opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -275,10 +286,12 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -286,12 +299,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: paymentservice
+    
+    opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -299,10 +311,12 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -310,12 +324,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: productcatalogservice
+    
+    opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -323,10 +336,12 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -334,12 +349,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: quoteservice
+    
+    opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -347,10 +361,12 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -358,12 +374,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: recommendationservice
+    
+    opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -371,10 +386,12 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -385,9 +402,8 @@ spec:
       name: redis
       targetPort: 6379
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
+    
+    opentelemetry.io/name: example-redis
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -395,10 +411,12 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -406,12 +424,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      name: service
+      name: tcp-service
       targetPort: 8080
   selector:
-    app.kubernetes.io/name: example
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: shippingservice
+    
+    opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -419,25 +436,28 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: accountingservice
+      
+      opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -498,25 +518,28 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: adservice
+      
+      opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
     spec:
       serviceAccountName: example
       containers:
@@ -577,25 +600,28 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: cartservice
+      
+      opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -664,25 +690,28 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: checkoutservice
+      
+      opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -761,25 +790,28 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: currencyservice
+      
+      opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -836,25 +868,28 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: emailservice
+      
+      opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -913,25 +948,28 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: featureflagservice
+      
+      opentelemetry.io/name: example-featureflagservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-featureflagservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
     spec:
       serviceAccountName: example
       containers:
@@ -1010,25 +1048,28 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: ffspostgres
+      
+      opentelemetry.io/name: example-ffspostgres
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-ffspostgres
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
     spec:
       serviceAccountName: example
       containers:
@@ -1091,25 +1132,28 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frauddetectionservice
+      
+      opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1170,25 +1214,28 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontend
+      
+      opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1269,25 +1316,28 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: frontendproxy
+      
+      opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1370,25 +1420,28 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: kafka
+      
+      opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1453,25 +1506,28 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: loadgenerator
+      
+      opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1540,25 +1596,28 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: paymentservice
+      
+      opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1619,25 +1678,28 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: productcatalogservice
+      
+      opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1696,25 +1758,28 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: quoteservice
+      
+      opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1777,25 +1842,28 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: recommendationservice
+      
+      opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1860,25 +1928,28 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: redis
+      
+      opentelemetry.io/name: example-redis
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-redis
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
     spec:
       serviceAccountName: example
       containers:
@@ -1935,25 +2006,28 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: example
-      app.kubernetes.io/instance: example
-      app.kubernetes.io/component: shippingservice
+      
+      opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: example
+        
+        opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -2012,10 +2086,12 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,9 +5,11 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,9 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.4
-    app.kubernetes.io/name: example
+    helm.sh/chart: opentelemetry-demo-0.21.0
+    
+    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.3.1"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -17,7 +17,7 @@ Common labels
 */}}
 {{- define "otel-demo.labels" -}}
 helm.sh/chart: {{ include "otel-demo.chart" . }}
-{{ include "otel-demo.selectorLabels" . }}
+{{ include "otel-demo.workloadLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -25,15 +25,33 @@ app.kubernetes.io/part-of: opentelemetry-demo
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+
+
+{{/*
+Workload (Pod) labels
+*/}}
+{{- define "otel-demo.workloadLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .name }}
+app.kubernetes.io/component: {{ .name}}
+app.kubernetes.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
+{{- else }}
+app.kubernetes.io/name: {{ include "otel-demo.name" . }}
+{{- end }}
+{{- end }}
+
+
+
+
 {{/*
 Selector labels
 */}}
 {{- define "otel-demo.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "otel-demo.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .name }}
-app.kubernetes.io/component: {{ .name}}
-{{- end}}
+opentelemetry.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
+{{- else }}
+opentelemetry.io/name: {{ include "otel-demo.name" . }}
+{{- end }}
 {{- end }}
 
 {{- define "otel-demo.envOverriden" -}}

--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -17,6 +17,7 @@ Common labels
 */}}
 {{- define "otel-demo.labels" -}}
 helm.sh/chart: {{ include "otel-demo.chart" . }}
+{{ include "otel-demo.selectorLabels" . }}
 {{ include "otel-demo.workloadLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         {{- include "otel-demo.selectorLabels" . | nindent 8 }}
+        {{- include "otel-demo.workloadLabels" . | nindent 8 }}
       {{- if .podAnnotations }}
       annotations:
         {{- toYaml .podAnnotations | nindent 8 }}
@@ -103,7 +104,7 @@ spec:
 
     {{- if $service.port }}
     - port: {{ $service.port}}
-      name: service
+      name: tcp-service
       targetPort: {{ $service.port }}
       {{- if $service.nodePort }}
       nodePort: {{ $service.nodePort }}


### PR DESCRIPTION
fix https://github.com/open-telemetry/opentelemetry-helm-charts/issues/714

    

    1. service port.name to align istio naming standard
    2. adjust pod app.kubernetes.io/name to make istio happy