### PR TITLE
adjust pod app.kubernetes.io/name to make istio happy

### DIFF
--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -29,7 +29,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "otel-demo.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "otel-demo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .name }}
 app.kubernetes.io/component: {{ .name}}

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -10,10 +10,12 @@ spec:
   selector:
     matchLabels:
       {{- include "otel-demo.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
   template:
     metadata:
       labels:
         {{- include "otel-demo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
       {{- if .podAnnotations }}
       annotations:
         {{- toYaml .podAnnotations | nindent 8 }}


### PR DESCRIPTION
background:  it will be very glad that the demo works together with istio.

rational:

refer to https://github.com/istio/istio/issues/10724
istio tell workload by `app.kubernetes.io/name` label as first priority, then use `app` label.
for different deployment, the `app.kubernetes.io/name` should be different.

That's why I made this change.

@kebe7jun to help to clarify on istio side if any question.


