### PR TITLE
[demo] update subcharts

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.49.1
+  version: 0.52.1
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.67.6
+  version: 0.69.1
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 19.7.2
+  version: 20.2.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.51.2
-digest: sha256:f57abba37767e7496e246d1cd6515033c3af053cb879c7055c6465dc77c2d6fc
-generated: "2023-03-24T19:41:18.7604-04:00"
+  version: 6.52.8
+digest: sha256:19380941f9b79c9d9e7e6551e2cdface457fed4015daf45e6cfc3c7c2e8b6ac3
+generated: "2023-04-05T22:50:13.454043-04:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.20.0
+version: 0.20.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -14,18 +14,18 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: "1.3.1"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.49.1
+    version: 0.52.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 0.67.6
+    version: 0.69.1
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 19.7.2
+    version: 20.2.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 6.51.2
+    version: 6.52.8
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -573,7 +573,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -658,7 +658,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -753,7 +753,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -828,7 +828,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -907,7 +907,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -1002,7 +1002,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1081,7 +1081,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1160,7 +1160,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1352,7 +1352,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1435,7 +1435,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1597,7 +1597,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1674,7 +1674,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1753,7 +1753,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1834,7 +1834,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1907,7 +1907,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -573,7 +573,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -658,7 +658,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -753,7 +753,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -828,7 +828,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -907,7 +907,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -1002,7 +1002,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1081,7 +1081,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1160,7 +1160,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1352,7 +1352,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1435,7 +1435,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1597,7 +1597,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1674,7 +1674,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1753,7 +1753,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1834,7 +1834,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1907,7 +1907,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: e401fce400556d795409fff3e2c4512775ab6ecabd1ee522be2b5115138c8eb7
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 6e45d5bca81e2e2cc5d1065d4a400c98155e14fbbbfebd17a17c396dcbc3199a
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -41,7 +41,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.3.8"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.39.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 388027929c77bf9f4e104683365c01fb14e6da86e49b8a860b9af1a1211550ca
+        checksum/config: e63f40a0b73d9efee53f06cc5c23f93a9b6b8aefdf8ff24de4ee8c9a1e132b5e
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.72.0"
+          image: "otel/opentelemetry-collector-contrib:0.75.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default
@@ -27,7 +27,7 @@ spec:
         component: "server"
         app: prometheus
         release: example
-        chart: prometheus-19.7.2
+        chart: prometheus-20.2.0
         heritage: Helm
     spec:
       enableServiceLinks: true
@@ -35,7 +35,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.41.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -577,7 +577,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -664,7 +664,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -761,7 +761,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -838,7 +838,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -919,7 +919,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -1016,7 +1016,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1095,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1176,7 +1176,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1271,7 +1271,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1370,7 +1370,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1544,7 +1544,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1619,7 +1619,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1698,7 +1698,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1779,7 +1779,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1862,7 +1862,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1935,7 +1935,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: e401fce400556d795409fff3e2c4512775ab6ecabd1ee522be2b5115138c8eb7
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 6e45d5bca81e2e2cc5d1065d4a400c98155e14fbbbfebd17a17c396dcbc3199a
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -41,7 +41,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.3.8"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.39.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 016a47da7693a4c87c5877562008085ffd0266a7f24f425cf48b17afcda4f9ce
+        checksum/config: 14cfe21ff0542b1d8c5451a6c89ad8c2b38d3616f13ba4e36496cbcb38767285
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.72.0"
+          image: "otel/opentelemetry-collector-contrib:0.75.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default
@@ -27,7 +27,7 @@ spec:
         component: "server"
         app: prometheus
         release: example
-        chart: prometheus-19.7.2
+        chart: prometheus-20.2.0
         heritage: Helm
     spec:
       enableServiceLinks: true
@@ -35,7 +35,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.41.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -573,7 +573,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -658,7 +658,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -753,7 +753,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -828,7 +828,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -907,7 +907,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -1002,7 +1002,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1081,7 +1081,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1160,7 +1160,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1352,7 +1352,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1435,7 +1435,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1597,7 +1597,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1674,7 +1674,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1753,7 +1753,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1834,7 +1834,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1907,7 +1907,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: e401fce400556d795409fff3e2c4512775ab6ecabd1ee522be2b5115138c8eb7
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 6e45d5bca81e2e2cc5d1065d4a400c98155e14fbbbfebd17a17c396dcbc3199a
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -41,7 +41,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.3.8"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.39.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 458b5d4bda6676d2570b3a5040c9491f243fa2c87481fe9e70631210f957c022
+        checksum/config: eb667ecca4c18a7251f7912efba2f0480b4f288331e3d968ae14d5745b2af64a
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.72.0"
+          image: "otel/opentelemetry-collector-contrib:0.75.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default
@@ -27,7 +27,7 @@ spec:
         component: "server"
         app: prometheus
         release: example
-        chart: prometheus-19.7.2
+        chart: prometheus-20.2.0
         heritage: Helm
     spec:
       enableServiceLinks: true
@@ -35,7 +35,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.41.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -573,7 +573,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -658,7 +658,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -753,7 +753,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -828,7 +828,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -907,7 +907,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -1002,7 +1002,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1081,7 +1081,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1160,7 +1160,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1352,7 +1352,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1435,7 +1435,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1597,7 +1597,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1674,7 +1674,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1753,7 +1753,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1834,7 +1834,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1907,7 +1907,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1984,7 +1984,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: e401fce400556d795409fff3e2c4512775ab6ecabd1ee522be2b5115138c8eb7
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 6e45d5bca81e2e2cc5d1065d4a400c98155e14fbbbfebd17a17c396dcbc3199a
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -41,7 +41,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.3.8"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.51.2
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.3.8"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.39.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.67.6
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.39.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 458b5d4bda6676d2570b3a5040c9491f243fa2c87481fe9e70631210f957c022
+        checksum/config: eb667ecca4c18a7251f7912efba2f0480b4f288331e3d968ae14d5745b2af64a
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.72.0"
+          image: "otel/opentelemetry-collector-contrib:0.75.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.49.1
+    helm.sh/chart: opentelemetry-collector-0.52.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.72.0"
+    app.kubernetes.io/version: "0.75.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default
@@ -27,7 +27,7 @@ spec:
         component: "server"
         app: prometheus
         release: example
-        chart: prometheus-19.7.2
+        chart: prometheus-20.2.0
         heritage: Helm
     spec:
       enableServiceLinks: true
@@ -35,7 +35,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.41.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-19.7.2
+    chart: prometheus-20.2.0
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.0
+    helm.sh/chart: opentelemetry-demo-0.20.1
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -743,8 +743,6 @@ grafana:
       root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
       serve_from_sub_path: true
   adminPassword: admin
-  rbac:
-    pspEnabled: false
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
Updates all subcharts to latest version.

The Grafana chart now defaults PodSecurityPolicy to disabled, so we can remove the override parameter to disable this.