### PR TITLE
[demo] update env variables

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.20.1
+version: 0.20.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1598,7 +1598,7 @@ spec:
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317e
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -472,12 +472,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -555,12 +555,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -573,7 +577,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -630,14 +634,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -658,7 +664,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -715,24 +721,26 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'example-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'example-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://example-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -753,7 +761,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -810,12 +818,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -828,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -885,16 +893,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -907,7 +913,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -966,16 +972,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1002,7 +1010,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1059,11 +1067,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
@@ -1081,7 +1091,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1134,12 +1144,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1160,7 +1170,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1217,6 +1227,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1237,8 +1251,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://localhost:4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1253,7 +1265,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1310,6 +1322,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1334,8 +1350,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1352,7 +1366,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1411,12 +1425,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
             value: -Xmx400M -Xms400M
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1435,7 +1449,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1492,8 +1506,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: FRONTEND_ADDR
-            value: 'example-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -1501,7 +1515,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://example-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -1510,8 +1524,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1524,7 +1536,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1581,10 +1593,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317e
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1597,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1654,14 +1668,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1674,7 +1688,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1731,12 +1745,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1753,7 +1769,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1810,18 +1826,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'example-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'example-productcatalogservice:8080'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1834,7 +1852,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1891,6 +1909,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1907,7 +1927,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1964,14 +1984,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: my-otel-collector.opentelemetry-ns
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -1598,7 +1598,7 @@ spec:
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317e
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -472,12 +472,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -555,12 +555,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -573,7 +577,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -630,14 +634,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -658,7 +664,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -715,24 +721,26 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'example-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'example-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://example-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -753,7 +761,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -810,12 +818,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -828,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -885,16 +893,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -907,7 +913,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -966,16 +972,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1002,7 +1010,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1059,11 +1067,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
@@ -1081,7 +1091,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1134,12 +1144,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1160,7 +1170,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1217,6 +1227,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1237,8 +1251,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://localhost:4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1253,7 +1265,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1310,6 +1322,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1334,8 +1350,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1352,7 +1366,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1411,12 +1425,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
             value: -Xmx400M -Xms400M
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1435,7 +1449,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1492,8 +1506,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: FRONTEND_ADDR
-            value: 'example-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -1501,7 +1515,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://example-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -1510,8 +1524,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1524,7 +1536,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1581,10 +1593,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317e
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1597,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1654,14 +1668,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1674,7 +1688,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1731,12 +1745,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1753,7 +1769,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1810,18 +1826,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'example-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'example-productcatalogservice:8080'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1834,7 +1852,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1891,6 +1909,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1907,7 +1927,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1964,14 +1984,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: $(OTEL_K8S_NODE_NAME)
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1618,7 +1618,7 @@ spec:
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317e
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -472,12 +472,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -557,12 +557,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: TEAM_NAME
             value: helix
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -577,7 +581,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -634,14 +638,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: TEAM_NAME
             value: ring
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -664,7 +670,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -721,24 +727,26 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'example-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'example-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://example-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -761,7 +769,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -818,12 +826,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -838,7 +846,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -895,16 +903,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -919,7 +925,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -978,16 +984,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: TEAM_NAME
             value: crab
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1016,7 +1024,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1073,11 +1081,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
@@ -1095,7 +1105,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1148,12 +1158,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1176,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1233,6 +1243,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1253,8 +1267,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://localhost:4318/v1/traces
           - name: TEAM_NAME
@@ -1271,7 +1283,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1328,6 +1340,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1352,8 +1368,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
@@ -1370,7 +1384,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1429,12 +1443,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
             value: -Xmx400M -Xms400M
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1453,7 +1467,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1510,8 +1524,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FRONTEND_ADDR
-            value: 'example-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -1519,7 +1533,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://example-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -1528,8 +1542,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: TEAM_NAME
             value: ring
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1544,7 +1556,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1601,10 +1613,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317e
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1619,7 +1633,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1676,14 +1690,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: TEAM_NAME
             value: helix
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1698,7 +1712,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1755,12 +1769,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1779,7 +1795,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1836,18 +1852,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'example-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'example-productcatalogservice:8080'
           - name: TEAM_NAME
             value: helix
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1862,7 +1880,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1919,6 +1937,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
@@ -1935,7 +1955,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1992,14 +2012,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1598,7 +1598,7 @@ spec:
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317e
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -472,12 +472,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -555,12 +555,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -573,7 +577,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -630,14 +634,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -658,7 +664,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -715,24 +721,26 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'example-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'example-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://example-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -753,7 +761,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -810,12 +818,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -828,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -885,16 +893,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -907,7 +913,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -966,16 +972,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1002,7 +1010,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1059,11 +1067,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
@@ -1081,7 +1091,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1134,12 +1144,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1160,7 +1170,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1217,6 +1227,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1237,8 +1251,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://localhost:4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1253,7 +1265,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1310,6 +1322,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1334,8 +1350,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1352,7 +1366,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1411,12 +1425,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
             value: -Xmx400M -Xms400M
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1435,7 +1449,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1492,8 +1506,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FRONTEND_ADDR
-            value: 'example-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -1501,7 +1515,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://example-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -1510,8 +1524,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1524,7 +1536,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1581,10 +1593,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317e
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1597,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1654,14 +1668,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1674,7 +1688,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1731,12 +1745,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1753,7 +1769,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1810,18 +1826,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'example-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'example-productcatalogservice:8080'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1834,7 +1852,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1891,6 +1909,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1907,7 +1927,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1964,14 +1984,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -251,7 +251,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -275,7 +275,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -323,7 +323,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -347,7 +347,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -371,7 +371,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -395,7 +395,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -419,7 +419,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -472,12 +472,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -555,12 +555,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: AD_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTLP_LOGS_EXPORTER
+            value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -573,7 +577,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -630,14 +634,16 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
           - name: ASPNETCORE_URLS
-            value: http://*:8080
+            value: http://*:$(CART_SERVICE_PORT)
           - name: REDIS_ADDR
             value: 'example-redis:6379'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CART_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -658,7 +664,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -715,24 +721,26 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
           - name: CART_SERVICE_ADDR
             value: 'example-cartservice:8080'
           - name: CURRENCY_SERVICE_ADDR
             value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
           - name: PAYMENT_SERVICE_ADDR
             value: 'example-paymentservice:8080'
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: 'example-productcatalogservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://example-emailservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -753,7 +761,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -810,12 +818,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -828,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -885,16 +893,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: APP_ENV
-            value: production
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: EMAIL_SERVICE_PORT
             value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -907,7 +913,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -966,16 +972,18 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-            value: "50053"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: FEATURE_FLAG_SERVICE_PORT
             value: "8081"
-          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-            value: grpc
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
           - name: DATABASE_URL
             value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1002,7 +1010,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -1059,11 +1067,13 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: POSTGRES_DB
             value: ffs
-          - name: POSTGRES_PASSWORD
-            value: ffs
           - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
             value: ffs
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
@@ -1081,7 +1091,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -1134,12 +1144,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1160,7 +1170,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1217,6 +1227,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
           - name: FRONTEND_ADDR
             value: :8080
           - name: AD_SERVICE_ADDR
@@ -1237,8 +1251,6 @@ spec:
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
             value: frontend-web
-          - name: FRONTEND_PORT
-            value: "8080"
           - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: https://otel-demo-collector.example.com/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1253,7 +1265,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1310,6 +1322,10 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
           - name: FRONTEND_PORT
             value: "8080"
           - name: FRONTEND_HOST
@@ -1334,8 +1350,6 @@ spec:
             value: "4317"
           - name: OTEL_COLLECTOR_HOST
             value: $(OTEL_COLLECTOR_NAME)
-          - name: ENVOY_PORT
-            value: "8080"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1352,7 +1366,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1411,12 +1425,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
           - name: KAFKA_HEAP_OPTS
             value: -Xmx400M -Xms400M
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1435,7 +1449,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1492,8 +1506,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: FRONTEND_ADDR
-            value: 'example-frontend:8080'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: LOCUST_WEB_PORT
             value: "8089"
           - name: LOCUST_USERS
@@ -1501,7 +1515,7 @@ spec:
           - name: LOCUST_SPAWN_RATE
             value: "1"
           - name: LOCUST_HOST
-            value: http://$(FRONTEND_ADDR)
+            value: http://example-frontend:8080
           - name: LOCUST_HEADLESS
             value: "false"
           - name: LOCUST_AUTOSTART
@@ -1510,8 +1524,6 @@ spec:
             value: python
           - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: LOADGENERATOR_PORT
-            value: "8089"
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1524,7 +1536,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1581,10 +1593,12 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317e
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1597,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1654,14 +1668,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             value: cumulative
           - name: PRODUCT_CATALOG_SERVICE_PORT
             value: "8080"
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1674,7 +1688,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1731,12 +1745,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: QUOTE_SERVICE_PORT
             value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1753,7 +1769,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1810,18 +1826,20 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
           - name: OTEL_PYTHON_LOG_CORRELATION
             value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: 'example-featureflagservice:50053'
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'example-productcatalogservice:8080'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1834,7 +1852,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1891,6 +1909,8 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1907,7 +1927,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1964,14 +1984,14 @@ spec:
                 fieldPath: metadata.uid
           - name: OTEL_COLLECTOR_NAME
             value: 'example-otelcol'
-          - name: PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
           - name: SHIPPING_SERVICE_PORT
             value: "8080"
           - name: QUOTE_SERVICE_ADDR
             value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:
@@ -1984,7 +2004,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1598,7 +1598,7 @@ spec:
           - name: PAYMENT_SERVICE_PORT
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317e
+            value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.20.1
+    helm.sh/chart: opentelemetry-demo-0.20.2
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.3.1"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -28,6 +28,8 @@ default:
           fieldPath: metadata.uid
     - name: OTEL_COLLECTOR_NAME
       value: '{{ include "otel-demo.name" . }}-otelcol'
+    - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      value: cumulative
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)
   # Allows overriding and additions to .Values.default.env
@@ -149,12 +151,10 @@ components:
     useDefault:
       env: true
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        value: cumulative
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 20Mi
@@ -170,12 +170,14 @@ components:
     service:
       port: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: AD_SERVICE_PORT
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
+      - name: OTLP_LOGS_EXPORTER
+        value: otlp
     resources:
       limits:
         memory: 300Mi
@@ -187,14 +189,14 @@ components:
     service:
       port: 8080
     env:
+      - name: CART_SERVICE_PORT
+        value: "8080"
       - name: ASPNETCORE_URLS
-        value: http://*:8080
+        value: http://*:$(CART_SERVICE_PORT)
       - name: REDIS_ADDR
         value: '{{ include "otel-demo.name" . }}-redis:6379'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: CART_SERVICE_PORT
-        value: "8080"
     resources:
       limits:
         memory: 160Mi
@@ -210,24 +212,24 @@ components:
     service:
       port: 8080
     env:
+      - name: CHECKOUT_SERVICE_PORT
+        value: "8080"
       - name: CART_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-cartservice:8080'
       - name: CURRENCY_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-currencyservice:8080'
+      - name: EMAIL_SERVICE_ADDR
+        value: 'http://{{ include "otel-demo.name" . }}-emailservice:8080'
       - name: PAYMENT_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-paymentservice:8080'
       - name: PRODUCT_CATALOG_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
       - name: SHIPPING_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-shippingservice:8080'
-      - name: EMAIL_SERVICE_ADDR
-        value: 'http://{{ include "otel-demo.name" . }}-emailservice:8080'
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: CHECKOUT_SERVICE_PORT
-        value: "8080"
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 20Mi
@@ -243,12 +245,10 @@ components:
     service:
       port: 8080
     env:
-      - name: PORT
+      - name: CURRENCY_SERVICE_PORT
         value: "8080"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: CURRENCY_SERVICE_PORT
-        value: "8080"
     resources:
       limits:
         memory: 20Mi
@@ -260,16 +260,12 @@ components:
     service:
       port: 8080
     env:
-      - name: APP_ENV
-        value: production
-      - name: PORT
-        value: "8080"
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
       - name: EMAIL_SERVICE_PORT
         value: "8080"
+      - name: APP_ENV
+        value: production
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
     resources:
       limits:
         memory: 100Mi
@@ -284,16 +280,16 @@ components:
       - name: http
         value: 8081
     env:
-      - name: FEATURE_FLAG_GRPC_SERVICE_PORT
-        value: "50053"
       - name: FEATURE_FLAG_SERVICE_PORT
         value: "8081"
-      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-        value: grpc
+      - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+        value: "50053"
       - name: DATABASE_URL
         value: 'ecto://ffs:ffs@{{ include "otel-demo.name" . }}-ffspostgres:5432/ffs'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: grpc
     resources:
       limits:
         memory: 175Mi
@@ -313,12 +309,10 @@ components:
     useDefault:
       env: true
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        value: cumulative
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 200Mi
@@ -334,6 +328,8 @@ components:
     service:
       port: 8080
     env:
+      - name: FRONTEND_PORT
+        value: "8080"
       - name: FRONTEND_ADDR
         value: :8080
       - name: AD_SERVICE_ADDR
@@ -354,8 +350,6 @@ components:
         value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: WEB_OTEL_SERVICE_NAME
         value: frontend-web
-      - name: FRONTEND_PORT
-        value: "8080"
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://localhost:4318/v1/traces             # This expects users to use `kubectl port-forward ...`
     resources:
@@ -369,6 +363,8 @@ components:
     service:
       port: 8080
     env:
+      - name: ENVOY_PORT
+        value: "8080"
       - name: FRONTEND_PORT
         value: "8080"
       - name: FRONTEND_HOST
@@ -393,8 +389,6 @@ components:
         value: "4317"
       - name: OTEL_COLLECTOR_HOST
         value: $(OTEL_COLLECTOR_NAME)
-      - name: ENVOY_PORT
-        value: "8080"
     resources:
       limits:
         memory: 50Mi
@@ -410,8 +404,6 @@ components:
     service:
       port: 8089
     env:
-      - name: FRONTEND_ADDR
-        value: '{{ include "otel-demo.name" . }}-frontend:8080'
       - name: LOCUST_WEB_PORT
         value: "8089"
       - name: LOCUST_USERS
@@ -419,7 +411,7 @@ components:
       - name: LOCUST_SPAWN_RATE
         value: "1"
       - name: LOCUST_HOST
-        value: "http://$(FRONTEND_ADDR)"
+        value: 'http://{{ include "otel-demo.name" . }}-frontend:8080'
       - name: LOCUST_HEADLESS
         value: "false"
       - name: LOCUST_AUTOSTART
@@ -428,8 +420,6 @@ components:
         value: python
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-      - name: LOADGENERATOR_PORT
-        value: "8089"
     resources:
       limits:
         memory: 120Mi
@@ -441,10 +431,10 @@ components:
     service:
       port: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 120Mi
@@ -456,14 +446,12 @@ components:
     service:
       port: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        value: cumulative
       - name: PRODUCT_CATALOG_SERVICE_PORT
         value: "8080"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
         memory: 20Mi
@@ -475,12 +463,12 @@ components:
     service:
       port: 8080
     env:
-      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-      - name: OTEL_PHP_AUTOLOAD_ENABLED
-        value: "true"
       - name: QUOTE_SERVICE_PORT
         value: "8080"
+      - name: OTEL_PHP_AUTOLOAD_ENABLED
+        value: "true"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4318
     resources:
       limits:
         memory: 40Mi
@@ -496,18 +484,18 @@ components:
     service:
       port: 8080
     env:
+      - name: RECOMMENDATION_SERVICE_PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
+      - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+        value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
       - name: OTEL_PYTHON_LOG_CORRELATION
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
-      - name: RECOMMENDATION_SERVICE_PORT
-        value: "8080"
-      - name: PRODUCT_CATALOG_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
     resources:
       limits:
         memory: 500Mi            # This is high to enable supporting the recommendationCache feature flag use case
@@ -519,14 +507,12 @@ components:
     service:
       port: 8080
     env:
-      - name: PORT
-        value: "8080"
-      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
       - name: SHIPPING_SERVICE_PORT
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
         value: 'http://{{ include "otel-demo.name" . }}-quoteservice:8080'
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
     resources:
       limits:
         memory: 20Mi
@@ -544,9 +530,9 @@ components:
     env:
       - name: POSTGRES_DB
         value: ffs
-      - name: POSTGRES_PASSWORD
-        value: ffs
       - name: POSTGRES_USER
+        value: ffs
+      - name: POSTGRES_PASSWORD
         value: ffs
     resources:
       limits:
@@ -570,8 +556,6 @@ components:
         value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
-      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        value: cumulative
       - name: KAFKA_HEAP_OPTS
         value: "-Xmx400M -Xms400M"
     resources:


### PR DESCRIPTION
Updates the environment variables for all components to align with [this PR](https://github.com/open-telemetry/opentelemetry-demo/pull/809) from the Demo repo.

Added a new default level environment variable for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` since this will be consistent for all components as they adopt metrics.

Re-ordered how some variables are listed to align with how the Demo repo has them set up. Generally speaking, they will be in this order:
- Port for the component to bind to
- addresses for downstream components
- other specific component vars
- OTEL vars