### PR TITLE
Add support for adding annotations to the cert-manager cert and issuer objects

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.26.1
+version: 0.26.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -219,7 +219,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.1
+    helm.sh/chart: opentelemetry-operator-0.26.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -2,6 +2,10 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  {{- if .Values.admissionWebhooks.certManager.certificateAnnotations }}
+  annotations:
+  {{- toYaml .Values.admissionWebhooks.certManager.certificateAnnotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
@@ -27,6 +31,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- if .Values.admissionWebhooks.certManager.issuerAnnotations }}
+  annotations:
+  {{- toYaml .Values.admissionWebhooks.certManager.issuerAnnotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1178,7 +1178,9 @@
                     "title": "The certManager Schema",
                     "required": [
                         "enabled",
-                        "issuerRef"
+                        "issuerRef",
+                        "certificateAnnotations",
+                        "issuerAnnotations"
                     ],
                     "properties": {
                         "enabled": {
@@ -1196,11 +1198,29 @@
                             "required": [],
                             "properties": {},
                             "examples": [{}]
+                        },
+                        "certificateAnnotations": {
+                          "type": "object",
+                          "default": {},
+                          "title": "The certificateAnnotations Schema",
+                          "required": [],
+                          "properties": {},
+                          "examples": [{}]
+                        },
+                        "issuerAnnotations": {
+                          "type": "object",
+                          "default": {},
+                          "title": "The issuerAnnotations Schema",
+                          "required": [],
+                          "properties": {},
+                          "examples": [{}]
                         }
                     },
                     "examples": [{
                         "enabled": true,
-                        "issuerRef": {}
+                        "issuerRef": {},
+                        "certificateAnnotations": {},
+                        "issuerAnnotations": {}
                     }]
                 }
             },
@@ -1214,7 +1234,9 @@
                 "objectSelector": {},
                 "certManager": {
                     "enabled": true,
-                    "issuerRef": {}
+                    "issuerRef": {},
+                    "certificateAnnotations": {},
+                    "issuerAnnotations": {}
                 }
             }]
         },
@@ -1536,7 +1558,9 @@
             "objectSelector": {},
             "certManager": {
                 "enabled": true,
-                "issuerRef": {}
+                "issuerRef": {},
+                "certificateAnnotations": {},
+                "issuerAnnotations": {}
             }
         },
         "role": {

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -174,6 +174,9 @@ admissionWebhooks:
     issuerRef: {}
       # kind:
       # name:
+    # Annotations for the cert and issuer if cert-manager is enabled.
+    certificateAnnotations: {}
+    issuerAnnotations: {}
 
 ## Create the provided Roles and RoleBindings
 ##


### PR DESCRIPTION
Description:
My company has a use case where adding annotations to the cert and issuer created by the cert-manager would be very useful. This shouldn't affect previous behavior. Let me know if I missed anything.

Testing:
Tested manually against a Kubernetes 1.26 cluster.