### PR TITLE
fix: Enable Service creation on DaemonSet

### DIFF
--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if or (eq .Values.mode "deployment") (eq .Values.mode "statefulset") (.Values.ingress.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,4 +29,4 @@ spec:
   selector:
     {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
     {{- include "opentelemetry-collector.component" . | nindent 4 }}
-{{- end }}
+


### PR DESCRIPTION
**Description:**
This change enable Service creation for all the cases, included DaemonSets

**Use case:**
When OTEL Collector is deployed to collect metrics from /metrics using the prometheusreceiver, it is better for performance to be deployed as a DaemonSet. This way you can configure relabel_configs in a way where each OTEL's pod process only targets on its node.

At the same time, you can configure otlp receiver for the metrics too, in the same OTEL Collector. In this case, we need a Service to point the SDKs, even when it is a daemonset

Deployment mode is not suitable in most cases due to all the pods would scrappe all the metrics, so they all suffer the same pressure and consume much more resources in terms of memory
