### PR TITLE
[chore] Bump min k8s support to 1.24.

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: helm/kind-action@v1.5.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
       with:
-        node_image: kindest/node:v1.24.4
+        node_image: kindest/node:v1.24.12
 
     - name: Add Dependencies
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -13,16 +13,18 @@ runs:
       with:
         version: v3.9.0
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.3.0
+      uses: helm/chart-testing-action@v2.4.0
 
     - name: Create kind cluster
-      uses: helm/kind-action@v1.4.0
+      uses: helm/kind-action@v1.5.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
+      with:
+        node_image: kindest/node:v1.24.4
 
     - name: Add Dependencies
       shell: bash

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.54.0
+version: 0.54.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -5,7 +5,7 @@ in kubernetes cluster.
 
 ## Prerequisites
 
-- Kubernetes 1.23+
+- Kubernetes 1.24+
 - Helm 3.9+
 
 ## Installing the Chart

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1584e29c6c7140d087818526880a27e4bfaacc91066edccad94c76d8a7d123eb
+        checksum/config: 24dafb062b9bc855fa2147fc89df5ef3832b9c8eb53d05e051c3c1e98b396f9b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a35c035c7dbe4121979d464defe720e5f23138256a7708711837bffb9ddbe7f
+        checksum/config: 75d8cc474889291c54e7ac5b202160e56639b16c98a7fd410dc5d77989dd1b4b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd2ba601bcb409443744fd789e06cde7e5102452f49ac9d1923ee61fb7f50d0c
+        checksum/config: f0276a9329ce0dd483f44e983c6d9596a48088657ff27b58314caa7901c73f2e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2f26465d39eff25e6c04185e52086d89fef1f4630c211b611672702a881fd50f
+        checksum/config: dbc97415f383049daac7d158764f2a23fe68087d87ef8022edd52f2d3f4af0b1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d1f1e1c8d7d96b7bdc23904d9065fe0f0a68a25e8a4496fbd281b91f0b0162e2
+        checksum/config: 830ebfd5939b8e64c64ffbe54f82f921806a7ea39a7bd61758dc68d0b520cb26
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d1f1e1c8d7d96b7bdc23904d9065fe0f0a68a25e8a4496fbd281b91f0b0162e2
+        checksum/config: 830ebfd5939b8e64c64ffbe54f82f921806a7ea39a7bd61758dc68d0b520cb26
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a35c035c7dbe4121979d464defe720e5f23138256a7708711837bffb9ddbe7f
+        checksum/config: 75d8cc474889291c54e7ac5b202160e56639b16c98a7fd410dc5d77989dd1b4b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7d65a5e4e594f8099839ec7884b41e60d746d290e908353f2112ac4f47d45b81
+        checksum/config: a52049e216965a760b684506f7deb38a8a5cc60d0984d0f81d1f22950b530395
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.54.0
+    helm.sh/chart: opentelemetry-collector-0.54.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.75.0"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.22.0
+version: 0.22.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -5,7 +5,7 @@ in kubernetes cluster.
 
 ## Prerequisites
 
-- Kubernetes 1.23+
+- Kubernetes 1.24+
 - Helm 3.9+
 
 ## Installing the Chart

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -520,7 +520,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -604,7 +604,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -798,7 +798,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -878,7 +878,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -960,7 +960,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1062,7 +1062,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1146,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1230,7 +1230,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1334,7 +1334,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1438,7 +1438,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1616,7 +1616,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1700,7 +1700,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1782,7 +1782,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1868,7 +1868,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1956,7 +1956,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2034,7 +2034,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2086,7 +2086,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.0
+    helm.sh/chart: opentelemetry-demo-0.22.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.26.3
+version: 0.26.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -6,7 +6,7 @@ At this point, it has [OpenTelemetry Collector](https://github.com/open-telemetr
 
 ## Prerequisites
 
-- Kubernetes 1.19+ is required for OpenTelemetry Operator installation
+- Kubernetes 1.24+ is required for OpenTelemetry Operator installation
 - Helm 3.9+
 
 ### TLS Certificate Requirement

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -219,7 +219,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.26.3
+    helm.sh/chart: opentelemetry-operator-0.26.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.74.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Bumps the minimum required k8s version to 1.24, which is currently the minimum supported k8s version by the kubernetes team.  As part of the bump I also updated our CI to explicitly test on our minimum supported version.