### PR TITLE
[opentelemtry-collector] Enforce kubeVersion >=1.24.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -12,3 +12,4 @@ maintainers:
   - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 0.75.0
+kubeVersion: ">=1.23.0"

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 0.75.0
-kubeVersion: ">=1.23.0"
+kubeVersion: ">=1.24.0"

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -108,18 +108,6 @@ Create the name of the clusterRoleBinding to use
 {{- end }}
 
 {{/*
-Return the appropriate apiVersion for podDisruptionBudget.
-*/}}
-{{- define "podDisruptionBudget.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
-    {{- print "policy/v1" -}}
-  {{- else -}}
-    {{- print "policy/v1beta1" -}}
-  {{- end -}}
-{{- end -}}
-
-
-{{/*
 Check if logs collection is enabled via deprecated "containerLogs" or "preset.logsCollection"
 */}}
 {{- define "opentelemetry-collector.logsCollectionEnabled" }}

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.podDisruptionBudget.enabled (eq .Values.mode "deployment") }}
-apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+apiVersion: "policy/v1"
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}


### PR DESCRIPTION
This is a small chore to update the chart to reflect that the Chart only supports K8s 1.24.0+. A similar change has been made for HPA https://github.com/open-telemetry/opentelemetry-helm-charts/pull/541