### PR TITLE
[operator] Allow setting custom secret labels

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.29.0
+version: 0.29.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -219,7 +219,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.29.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -15,6 +15,9 @@ metadata:
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
+    {{- if .Values.admissionWebhooks.secretLabels }}
+    {{- toYaml .Values.admissionWebhooks.secretLabels | nindent 4 }}
+    {{- end }}
   name: {{ default (printf "%s-controller-manager-service-cert" (include "opentelemetry-operator.fullname" .)) .Values.admissionWebhooks.secretName }}
   namespace: {{ .Release.Namespace }}
 data:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -199,6 +199,8 @@ admissionWebhooks:
 
   ## Secret annotations
   secretAnnotations: {}
+  ## Secret labels
+  secretLabels: {}
 
 ## Create the provided Roles and RoleBindings
 ##


### PR DESCRIPTION
Following the change done in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/760, we also need to be able to add custom labels to the [secret](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml#L6) that is created. This PR adds that possibility.