### PR TITLE
Add support for HPA behavior

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.57.0
+version: 0.57.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f94751306b7535ecee53c26466a9fa34d5ab46cedb6fa2d0355f7ff0854e068
+        checksum/config: a2969110b0b41e75158f1eac70872c03e8d501951f24c7e624f5d7a1d3c0fa5e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7a039415da6bae70ab2609f561ebf61547e2bfcbbed6e73e5d8594643ea0aff3
+        checksum/config: 3ddeedfa7811a5e582a3db1a231f22bc2f55140a7e4a3c9170ac348acb478e6e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 881d8cd5b74f3decac1b27a449cabf0caddf9aaf8bfd281032705f7e6f373d40
+        checksum/config: 0157b21fbc83d03a8f8a775d86677bac6cb0d39776361d857970678f2224d6c4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5b832509031a80422dd52ff420f1243f95a3492342833a7fa5fafda904122bdb
+        checksum/config: b1ef54445f0bc1ae2a20a9740cfca5cde60281f6a2ca6dd0e6a3dbed92eb4212
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7257af883d3050fb7badb31bcd808395403b2f2355c860de26199b049ad40749
+        checksum/config: 22762358c4808c5df719947f0ee81a212de8facf3e0f9f7f7e2f024be113803b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7257af883d3050fb7badb31bcd808395403b2f2355c860de26199b049ad40749
+        checksum/config: 22762358c4808c5df719947f0ee81a212de8facf3e0f9f7f7e2f024be113803b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7a039415da6bae70ab2609f561ebf61547e2bfcbbed6e73e5d8594643ea0aff3
+        checksum/config: 3ddeedfa7811a5e582a3db1a231f22bc2f55140a7e4a3c9170ac348acb478e6e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 55799c060d34e8011f3195effd32ce640188346033effa1365f4a53a9941dc57
+        checksum/config: bad7d7e5f3b9595817871dbeeb56231ce268d4157f8302a431fcaf3b7bfc7f44
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.0
+    helm.sh/chart: opentelemetry-collector-0.57.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.77.0"

--- a/charts/opentelemetry-collector/templates/hpa.yaml
+++ b/charts/opentelemetry-collector/templates/hpa.yaml
@@ -12,6 +12,10 @@ spec:
     name: {{ include "opentelemetry-collector.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -720,6 +720,9 @@
         "maxReplicas": {
           "type": "integer"
         },
+        "behavior": {
+          "type": "object"
+        },
         "targetCPUUtilizationPercentage": {
           "type": "integer"
         }

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -409,6 +409,7 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 10
+  behavior: {}
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
We ran into a use case where it would have been helpful to fine tune a little bit HPA behaviour.

This PR will allow to optionally define a behaviour on the `HorizontalPodAutoscaler` resource. See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/ and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#horizontalpodautoscalerspec-v2-autoscaling for reference.