### PR TITLE
feat: add container specific securityContext

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.29.0
+version: 0.30.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -219,7 +219,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.0
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
               name: cert
               readOnly: true
           {{- end }}
+          {{- with .Values.manager.securityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
         {{ if .Values.kubeRBACProxy.enabled }}
         - args:
             - --secure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.ports.proxyPort }}
@@ -120,6 +123,9 @@ spec:
               protocol: TCP
           {{- with .Values.kubeRBACProxy.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kubeRBACProxy.securityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -132,11 +132,11 @@ manager:
 
   ## Container specific securityContext
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-      - ALL
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #   - ALL
 
 ## Provide OpenTelemetry Operator kube-rbac-proxy container image.
 ##
@@ -161,11 +161,11 @@ kubeRBACProxy:
 
   ## Container specific securityContext
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-      - ALL
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #   - ALL
 
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 ## They also enable the sidecar injection for OpenTelemetryCollector and Instrumentation CR's

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -130,6 +130,14 @@ manager:
   # Enable manager pod automatically rolling
   rolling: false
 
+  ## Container specific securityContext
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+
 ## Provide OpenTelemetry Operator kube-rbac-proxy container image.
 ##
 kubeRBACProxy:
@@ -150,6 +158,14 @@ kubeRBACProxy:
   ## List of additional cli arguments to configure the kube-rbac-proxy
   ## for example: --tls-cipher-suites, --tls-min-version, etc.
   extraArgs: []
+
+  ## Container specific securityContext
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
 
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 ## They also enable the sidecar injection for OpenTelemetryCollector and Instrumentation CR's


### PR DESCRIPTION
This PR adds the missing container level securityContext to the deployment. 
This option is required to run the operator inside a restricted namespace