### PR TITLE
[operator] Bump operator to 0.77.0

### DIFF
--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install opentelemetry-operator chart
         run: |
-          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator --set "manager.featureGates=+operator.autoinstrumentation.go"
+          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator --set "manager.featureGates=operator.autoinstrumentation.go"
           kubectl wait --timeout=5m --for=condition=available deployment my-opentelemetry-operator -n opentelemetry-operator-system
 
       - name: Run e2e tests

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install opentelemetry-operator chart
         run: |
-          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator
+          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator --set "manager.featureGates=+operator.autoinstrumentation.go"
           kubectl wait --timeout=5m --for=condition=available deployment my-opentelemetry-operator -n opentelemetry-operator-system
 
       - name: Run e2e tests

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.29.2
+version: 0.30.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.76.1
+appVersion: 0.77.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
@@ -297,6 +297,54 @@ spec:
                   image:
                     description: Image is a container image with Apache SDK and auto-instrumentation.
                     type: string
+                  resourceRequirements:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
                   version:
                     description: Apache HTTPD server version. One of 2.4 or 2.2. Default
                       is 2.4
@@ -426,6 +474,54 @@ spec:
                   image:
                     description: Image is a container image with DotNet SDK and auto-instrumentation.
                     type: string
+                  resourceRequirements:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
                 type: object
               env:
                 description: 'Env defines common env vars. There are four layers for
@@ -545,6 +641,136 @@ spec:
                 properties:
                   endpoint:
                     description: Endpoint is address of the collector with OTLP endpoint.
+                    type: string
+                type: object
+              go:
+                description: Go defines configuration for Go auto-instrumentation.
+                  When using Go auto-instrumenetation you must provide a value for
+                  the OTEL_GO_AUTO_TARGET_EXE env var via the Instrumentation env
+                  vars or via the instrumentation.opentelemetry.io/otel-go-auto-target-exe
+                  pod annotation. Failure to set this value causes instrumentation
+                  injection to abort, leaving the original pod unchanged.
+                properties:
+                  env:
+                    description: 'Env defines Go specific env vars. There are four
+                      layers for env vars'' definitions and the precedence order is:
+                      `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image is a container image with Go SDK and auto-instrumentation.
                     type: string
                 type: object
               java:
@@ -672,6 +898,54 @@ spec:
                     description: Image is a container image with javaagent auto-instrumentation
                       JAR.
                     type: string
+                  resources:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
                 type: object
               nodejs:
                 description: NodeJS defines configuration for nodejs auto-instrumentation.
@@ -797,6 +1071,54 @@ spec:
                   image:
                     description: Image is a container image with NodeJS SDK and auto-instrumentation.
                     type: string
+                  resourceRequirements:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
                 type: object
               propagators:
                 description: Propagators defines inter-process context propagation
@@ -939,6 +1261,54 @@ spec:
                   image:
                     description: Image is a container image with Python SDK and auto-instrumentation.
                     type: string
+                  resourceRequirements:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
                 type: object
               resource:
                 description: Resource defines the configuration for the resource attributes,

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -85,9 +85,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -201,9 +201,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -219,9 +219,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -33,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.76.1
+            - --collector-image=otel/opentelemetry-collector-contrib:0.77.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.76.1"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.77.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -34,6 +34,7 @@ spec:
             - --health-probe-addr=:8081
             - --webhook-port=9443
             - --collector-image=otel/opentelemetry-collector-contrib:0.77.0
+            - --auto-instrumentation-go-image=ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.1-alpha
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.30.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -61,6 +61,12 @@ spec:
             {{- if and .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag }}
             - --auto-instrumentation-dotnet-image={{ .Values.manager.autoInstrumentationImage.dotnet.repository }}:{{ .Values.manager.autoInstrumentationImage.dotnet.tag }}
             {{- end }}
+            {{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag }}
+            - --auto-instrumentation-go-image={{ .Values.manager.autoInstrumentationImage.go.repository }}:{{ .Values.manager.autoInstrumentationImage.go.tag }}
+            {{- end }}
+            {{- if .Values.manager.featureGates }}
+            - --feature-gates={{ .Values.manager.featureGates }}
+            {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -139,13 +139,13 @@
                             "default": "",
                             "title": "The tag Schema",
                             "examples": [
-                                "v0.75.0"
+                                "v0.77.0"
                             ]
                         }
                     },
                     "examples": [{
                         "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                        "tag": "v0.75.0"
+                        "tag": "v0.77.0"
                     }]
                 },
                 "collectorImage": {
@@ -170,13 +170,13 @@
                             "default": "",
                             "title": "The tag Schema",
                             "examples": [
-                                "0.75.0"
+                                "0.77.0"
                             ]
                         }
                     },
                     "examples": [{
                         "repository": "otel/opentelemetry-collector-contrib",
-                        "tag": "0.75.0"
+                        "tag": "0.77.0"
                     }]
                 },
                 "targetAllocatorImage": {
@@ -840,11 +840,11 @@
             "examples": [{
                 "image": {
                     "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                    "tag": "v0.75.0"
+                    "tag": "v0.77.0"
                 },
                 "collectorImage": {
                     "repository": "otel/opentelemetry-collector-contrib",
-                    "tag": "0.75.0"
+                    "tag": "0.77.0"
                 },
                 "targetAllocatorImage": {
                     "repository": "",
@@ -1505,11 +1505,11 @@
         "manager": {
             "image": {
                 "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                "tag": "v0.75.0"
+                "tag": "v0.77.0"
             },
             "collectorImage": {
                 "repository": "otel/opentelemetry-collector-contrib",
-                "tag": "0.75.0"
+                "tag": "0.77.0"
             },
             "targetAllocatorImage": {
                 "repository": "",

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -398,7 +398,7 @@
                 },
                 "featureGates": {
                     "type": "string",
-                    "default": "+operator.autoinstrumentation.go",
+                    "default": "operator.autoinstrumentation.go",
                     "title": "The featureGates Schema",
                     "examples": [
                         "-operator.autoinstrumentation.go,-operator.autoinstrumentation.go"

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -344,6 +344,37 @@
                                 "repository": "",
                                 "tag": ""
                             }]
+                        },
+                        "go": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The Go Schema",
+                            "required": [
+                                "repository",
+                                "tag"
+                            ],
+                            "properties": {
+                                "repository": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The repository Schema",
+                                    "examples": [
+                                        ""
+                                    ]
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The tag Schema",
+                                    "examples": [
+                                        ""
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "repository": "",
+                                "tag": ""
+                            }]
                         }
                     },
                     "examples": [{
@@ -364,6 +395,14 @@
                             "tag": ""
                         }
                     }]
+                },
+                "featureGates": {
+                    "type": "string",
+                    "default": "+operator.autoinstrumentation.go",
+                    "title": "The featureGates Schema",
+                    "examples": [
+                        "-operator.autoinstrumentation.go,-operator.autoinstrumentation.go"
+                    ]
                 },
                 "ports": {
                     "type": "object",
@@ -864,6 +903,10 @@
                         "tag": ""
                     },
                     "dotnet": {
+                        "repository": "",
+                        "tag": ""
+                    },
+                    "go": {
                         "repository": "",
                         "tag": ""
                     }

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -50,10 +50,12 @@ manager:
       repository: ""
       tag: ""
     # The Go instrumentaiton support in the operator is disabled by default.
-    # To enable it, use the +operator.autoinstrumentation.go feature gate.
+    # To enable it, use the operator.autoinstrumentation.go feature gate.
     go:
-      repository: ""
-      tag: ""
+      # Must set the default value manually for now.
+      # See https://github.com/open-telemetry/opentelemetry-operator/issues/1756 for details.
+      repository: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+      tag: v0.2.1-alpha
   featureGates: ""
   ports:
     metricsPort: 8080

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -29,10 +29,10 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.76.1
+    tag: v0.77.0
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.76.1
+    tag: 0.77.0
   targetAllocatorImage:
     repository: ""
     tag: ""

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -56,6 +56,10 @@ manager:
       # See https://github.com/open-telemetry/opentelemetry-operator/issues/1756 for details.
       repository: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
       tag: v0.2.1-alpha
+  # Feature Gates are a a comma-delimited list of feature gate identifiers.
+  # Prefix a gate with '-' to disable support.
+  # Prefixing a gate with '+' or no prefix will enable support.
+  # A full list of valud identifiers can be found here: https://github.com/open-telemetry/opentelemetry-operator/blob/main/pkg/featuregate/featuregate.go
   featureGates: ""
   ports:
     metricsPort: 8080

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -49,6 +49,12 @@ manager:
     dotnet:
       repository: ""
       tag: ""
+    # The Go instrumentaiton support in the operator is disabled by default.
+    # To enable it, use the +operator.autoinstrumentation.go feature gate.
+    go:
+      repository: ""
+      tag: ""
+  featureGates: ""
   ports:
     metricsPort: 8080
     webhookPort: 9443


### PR DESCRIPTION
Operator 0.77.0 added support for Go auto-instrumentation.  As a result, this PR adds:
- the ability to set the go image repo and tag.
- the ability to set feature-gates flag.