### PR TITLE
[operator] Make ServiceMonitor annotation optional

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.29.2
+version: 0.29.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -201,7 +201,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -219,7 +219,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.29.2
+    helm.sh/chart: opentelemetry-operator-0.29.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-operator/templates/servicemonitor.yaml
@@ -10,10 +10,12 @@ metadata:
     {{- range $key, $value := .Values.manager.serviceMonitor.extraLabels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
+  {{- if .Values.manager.serviceMonitor.annotations }}
   annotations:
     {{- range $key, $value := .Values.manager.serviceMonitor.annotations }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Currently if you do not specify a ServiceMonitor annotation it outputs null.

This is an issue if you use Argo CD with self-healing enabled. This is because Kubernetes strips this property when it is applied, leading to Argo CD to notice a difference in this property, causing it to re-apply which obviously does nothing (meaning it gets stuck in a loop).