### PR TITLE
fix chart failing if internalTrafficPolicy isn't set

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.59.0
+version: 0.59.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -41,7 +41,7 @@
 [WARNING] The 'k8sobjects' is a ALPHA receiver and may be changed anytime.
 {{ end }}
 
-{{- if and (eq .Values.mode "daemonset") (eq .Values.service.internalTrafficPolicy "Cluster") }}
+{{- if and (eq .Values.mode "daemonset") (eq (default .Values.service.internalTrafficPolicy "") "Cluster") }}
 [WARNING] Setting internalTrafficPolicy to 'Cluster' on Daemonset is not recommended. Consider using 'Local' instead.
 {{ end }}
 


### PR DESCRIPTION
With 0.59.0 I started getting the following:
```
Error: Failed to render chart: exit status 1: Error: template: opentelemetry-collector/templates/NOTES.txt:44:42: executing "opentelemetry-collector/templates/NOTES.txt" at <eq .Values.service.internalTrafficPolicy "Cluster">: error calling eq: incompatible types for comparison
```

I think this should fix it, by setting a default value for `internalTrafficPolicy`