### PR TITLE
Added dns config param

### DIFF
--- a/charts/opentelemetry-collector/templates/daemonset.yaml
+++ b/charts/opentelemetry-collector/templates/daemonset.yaml
@@ -41,4 +41,8 @@ spec:
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -38,6 +38,13 @@ spec:
         {{- include "opentelemetry-collector.component" . | nindent 8 }}
         {{- include "opentelemetry-collector.podLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- $podValues := deepCopy .Values }}
       {{- $podData := dict "Values" $podValues "configmapSuffix" "" "isAgent" false }}
       {{- include "opentelemetry-collector.pod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -488,6 +488,9 @@
       "type": "string",
       "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", ""]
     },
+    "dnsConfig": {
+      "type": "object"
+    },
     "replicaCount": {
       "type": "integer"
     },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -279,6 +279,9 @@ hostNetwork: false
 # Pod DNS policy ClusterFirst, ClusterFirstWithHostNet, None, Default, None
 dnsPolicy: ""
 
+# Custom DNS config. Required when DNS policy is None.
+dnsConfig: {}
+
 # only used with deployment mode
 replicaCount: 1
 


### PR DESCRIPTION
Sample DNS Configuration.
```
dnsConfig:
    nameservers:
    - 169.254.20.10
    searches:
    - svc.cluster.local
    - cluster.local
    - {{ .Values.region }}.compute.internal
    options:
    - name: ndots
      value: '2'
```
DNS Config allows us to provide custom DNS routing rules to enable Pods with Host network to search Kubernetes services and endpoints.