### PR TITLE
add support for include and exclude namespaces in logCollection preset

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.60.0
+version: 0.60.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fc64cc9e1870522fd4aafc5eced3fd8b9000c26553ae8916633d0ce044d28b6e
+        checksum/config: 975f4307150c720239b7085523777815df2bc1929fc899685ce9eae19d1e0397
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e551dd5d441d84d4e1edc7aabab79f91a691750705fea0c04c18ea47188ca2c3
+        checksum/config: fefab47f913829ac2cf25b441aa60ac29e42354dcfa3b1e453ebb8aca2226eb6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a482bad7e65a3b7808205a4b1c41d0724c09251bc90db7f739d3b7af6f236527
+        checksum/config: 42a2d0d6761181ea6da4bc7659d59a153bf3214717a06e4795abbd936913be62
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc752731e7eb7a33b2571dad3838fb73334697e2a567fd891be6a2ed2b5901fe
+        checksum/config: 79bcebfc12651c64fcd54312c33c5a8553d175293d70a42effab6d00bc91789a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 24e9f97a4161a8617a57f5d5f958b39954e58e1c118929e9988d0936a6008494
+        checksum/config: 7b6a1af247535db8ac8e69ffc860ecc85f1c8461b42d507837f54a6c9396611e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 24e9f97a4161a8617a57f5d5f958b39954e58e1c118929e9988d0936a6008494
+        checksum/config: 7b6a1af247535db8ac8e69ffc860ecc85f1c8461b42d507837f54a6c9396611e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e551dd5d441d84d4e1edc7aabab79f91a691750705fea0c04c18ea47188ca2c3
+        checksum/config: fefab47f913829ac2cf25b441aa60ac29e42354dcfa3b1e453ebb8aca2226eb6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0789fe4fd6bcdfdd4061a2fbbd205367b890a4a37924f59299129222e452a84f
+        checksum/config: 672f9e781319fa54791021e9d8325c686100bf417169a2bf97acaaa697bc2cd2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.60.0
+    helm.sh/chart: opentelemetry-collector-0.60.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.79.0"

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -54,7 +54,15 @@
             "storeCheckpoints": {
               "description": "Specifies whether logs checkpoints should be stored in /var/lib/otelcol/ host directory.",
               "type": "boolean"
-            }
+            },
+          "includeNamespaces": {
+            "description": "Specifies from which namespaces collector should collect logs.",
+            "type": "array"
+          },
+          "excludeNamespaces": {
+            "description": "Specifies from which namespaces collector should not collect logs.",
+            "type": "array"
+          }            
           }
         },
         "hostMetrics": {

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -28,6 +28,11 @@ presets:
     # Enabling this writes checkpoints in /var/lib/otelcol/ host directory.
     # Note this changes collector's user to root, so that it can write to host directory.
     storeCheckpoints: false
+    # Allows you to include logs specifically from the namespaces you have specified.
+    # If no specific values are set, it will include all namespaces.
+    includeNamespaces: []
+    # Allows you to exclude specified namespaces from logs.
+    excludeNamespaces: []
   # Configures the collector to collect host metrics.
   # Adds the hostmetrics receiver to the metrics pipeline
   # and adds the necessary volumes and volume mounts.


### PR DESCRIPTION
We needed to limit the collector to specific namespaces for collection logs.