### PR TITLE
Add ability to set your own common labels for all resources

### DIFF
--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -59,6 +59,9 @@ helm.sh/chart: {{ include "opentelemetry-collector.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -4,7 +4,7 @@
 
 nameOverride: ""
 fullnameOverride: ""
-
+commonLabels: {}
 # Valid values are "daemonset", "deployment", and "statefulset".
 mode: ""
 


### PR DESCRIPTION
This change gives us a new optional variable that we can set which allows you to add your own custom labels to all of the resources being deployed. Currently we are able to do this with Pods but not anything else like deployments, config-maps etc.
This is already quite common among many other open source helm charts. It fixes a problem for us where we use these labels for identifying which teams own certain resources which in turn helps us direct prometheus alerts to the correct teams.