### PR TITLE
mode: daemonset example indicates hostNetwork: true is required

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.35.1
+version: 0.35.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -158,6 +158,7 @@ metadata:
   name: my-collector
 spec:
   mode: daemonset
+  hostNetwork: true
   config: |
     receivers:
       jaeger:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -232,7 +232,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
The example in the README for a collector configured as a daemonset omitted the `hostNetwork: true` which is required for an application-side Open Telemetry SDK to communicate with the collector on the node.