### PR TITLE
Add ability to configure replicas for services

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.66.2
+version: 0.66.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.66.3
+version: 0.66.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.66.1
+version: 0.66.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.66.4
+version: 0.67.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.83.0
+appVersion: 0.84.0

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -87,8 +87,7 @@ The collector can be used to collect logs sent to standard output by Kubernetes 
 This feature is disabled by default. It has the following requirements:
 
 - It needs agent collector to be deployed.
-- It requires the [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version
-of the collector image.
+- It requires the [Filelog receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#filelog-receiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.logsCollection.enabled` property to `true`.
 Here is an example `values.yaml`:
@@ -148,7 +147,7 @@ The collector can be configured to add Kubernetes metadata, such as pod name and
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) processor to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+- It requires the [Kubernetes Attributes processor](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-attributes-processor) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.kubernetesAttributes.enabled` property to `true`.
 Here is an example `values.yaml`:
@@ -164,13 +163,31 @@ presets:
     extractAllPodAnnotations: true
 ```
 
+### Configuration for Retrieving Kubelet Metrics
+
+The collector can be configured to collect node, pod, and container metrics from the API server on a kubelet.
+
+This feature is disabled by default. It has the following requirements:
+
+- It requires the [Kubeletstats receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubeletstats-receiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+
+To enable this feature, set the  `presets.kubeletMetrics.enabled` property to `true`.
+Here is an example `values.yaml`:
+
+```yaml
+mode: daemonset
+presets:
+  kubeletMetrics:
+    enabled: true
+```
+
 ### Configuration for Kubernetes Cluster Metrics
 
 The collector can be configured to collects cluster-level metrics from the Kubernetes API server. A single instance of this receiver can be used to monitor a cluster.
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+- It requires the [Kubernetes Cluster receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 - It requires statefulset or deployment mode with a single replica.
 
 To enable this feature, set the  `presets.clusterMetrics.enabled` property to `true`.
@@ -185,31 +202,13 @@ presets:
     enabled: true
 ```
 
-### Configuration for Retrieving Kubelet Metrics
-
-The collector can be configured to collect Kubelet metrics.
-
-This feature is disabled by default. It has the following requirements:
-
-- It requires [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
-
-To enable this feature, set the  `presets.kubeletMetrics.enabled` property to `true`.
-Here is an example `values.yaml`:
-
-```yaml
-mode: daemonset
-presets:
-  kubeletMetrics:
-    enabled: true
-```
-
 ### Configuration for Retrieving Kubernetes Events
 
 The collector can be configured to collect Kubernetes events.
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [k8sobjects](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+- It requires [Kubernetes Objects receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-objects-receiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.kubernetesEvents.enabled` property to `true`.
 Here is an example `values.yaml`:
@@ -228,7 +227,7 @@ The collector can be configured to collect host metrics for Kubernetes nodes.
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [hostmetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetrics) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+- It requires [Host Metrics receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#host-metrics-receiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.hostMetrics.enabled` property to `true`.
 Here is an example `values.yaml`:

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -24,6 +24,8 @@ helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector -
 
 Where the `mode` value needs to be set to one of `daemonset`, `deployment` or `statefulset`.
 
+For an in-depth walk through getting started in Kubernetes using this helm chart, see [OpenTelemetry Kubernetes Getting Started](https://opentelemetry.io/docs/kubernetes/getting-started/).
+
 ## Upgrading
 
 See [UPGRADING.md](UPGRADING.md).
@@ -56,11 +58,9 @@ By default collector has the following receivers enabled:
 - **traces**: OTLP, zipkin and jaeger (thrift and grpc).
 - **logs**: OTLP (to enable container logs, see [Configuration for Kubernetes container logs](#configuration-for-kubernetes-container-logs)).
 
-There are two ways to configure collector pipelines, which can be used together as well.
+### Basic Top Level Configuration
 
-### Basic top level configuration
-
-Default components can be removed with `null`.  When changing a pipeline, you must explicitly list all the components that are in the pipeline, including any default components.
+The Collector's configuration is set via the `config` section. Default components can be removed with `null`. Remember that lists in helm are not merged, so if you want to modify any default list you must specify all items, including any default items you want to keep.
 
 *Example*: Disable metrics and logging pipelines and non-otlp receivers:
 
@@ -79,23 +79,15 @@ config:
       logs: null
 ```
 
-*Example*: Add host metrics receiver:
+The chart also provides several presets, detailed below, to help configure important Kubernetes components. For more details on each component, see [Kubernetes Collector Components](https://opentelemetry.io/docs/kubernetes/collector/components/).
 
-```yaml
-mode: daemonset
-
-presets:
-  hostMetrics:
-    enabled: true
-```
-
-### Configuration for Kubernetes container logs
+### Configuration for Kubernetes Container Logs
 
 The collector can be used to collect logs sent to standard output by Kubernetes containers.
 This feature is disabled by default. It has the following requirements:
 
 - It needs agent collector to be deployed.
-- It requires the [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) version
+- It requires the [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version
 of the collector image.
 
 To enable this feature, set the  `presets.logsCollection.enabled` property to `true`.
@@ -150,13 +142,13 @@ config:
           - otlphttp
 ```
 
-### Configuration for Kubernetes attributes processor
+### Configuration for Kubernetes Attributes Processor
 
-The collector can be configured to add Kubernetes metadata to logs, metrics and traces.
+The collector can be configured to add Kubernetes metadata, such as pod name and namespace name, as resource attributes to incoming logs, metrics and traces. 
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) processor to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) version of the collector image.
+- It requires [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) processor to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.kubernetesAttributes.enabled` property to `true`.
 Here is an example `values.yaml`:
@@ -166,6 +158,10 @@ mode: daemonset
 presets:
   kubernetesAttributes:
     enabled: true
+    # You can also configure the preset to add all of the associated pod's labels and annotations to you telemetry.
+    # The label/annotation name will become the resource attribute's key.
+    extractAllPodLabels: true
+    extractAllPodAnnotations: true
 ```
 
 ### Configuration for Kubernetes Cluster Metrics
@@ -174,7 +170,7 @@ The collector can be configured to collects cluster-level metrics from the Kuber
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) version of the collector image.
+- It requires [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver) to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 - It requires statefulset or deployment mode with a single replica.
 
 To enable this feature, set the  `presets.clusterMetrics.enabled` property to `true`.
@@ -189,13 +185,13 @@ presets:
     enabled: true
 ```
 
-### Configuration for retrieving Kubelet metrics
+### Configuration for Retrieving Kubelet Metrics
 
 The collector can be configured to collect Kubelet metrics.
 
 This feature is disabled by default. It has the following requirements:
 
-- It requires [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) version of the collector image.
+- It requires [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
 
 To enable this feature, set the  `presets.kubeletMetrics.enabled` property to `true`.
 Here is an example `values.yaml`:
@@ -207,7 +203,44 @@ presets:
     enabled: true
 ```
 
-### CRDs
+### Configuration for Retrieving Kubernetes Events
+
+The collector can be configured to collect Kubernetes events.
+
+This feature is disabled by default. It has the following requirements:
+
+- It requires [k8sobjects](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+
+To enable this feature, set the  `presets.kubernetesEvents.enabled` property to `true`.
+Here is an example `values.yaml`:
+
+```yaml
+mode: deployment
+replicaCount: 1
+presets:
+  kubernetesEvents:
+    enabled: true
+```
+
+### Configuration for Host Metrics
+
+The collector can be configured to collect host metrics for Kubernetes nodes.
+
+This feature is disabled by default. It has the following requirements:
+
+- It requires [hostmetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetrics) receiver to be included in the collector, such as [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) version of the collector image.
+
+To enable this feature, set the  `presets.hostMetrics.enabled` property to `true`.
+Here is an example `values.yaml`:
+
+```yaml
+mode: daemonset
+presets:
+  hostMetrics:
+    enabled: true
+```
+
+## CRDs
 
 At this time, Prometheus CRDs are supported but other CRDs are not.
 

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1d3c1bda5cb0d96d6b141ee4e5b8ff914fee6c62c6388ca5413e6113b4ec1fbb
+        checksum/config: d591d7a96ebe8e907b4e2babc5528bf26de5913825caba5bbc4f11dc83bad0ee
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7b64dbf926d340af8ec9128cc1583068a1d05b2158b7e7e977d4b7eafa56d71e
+        checksum/config: 1d3c1bda5cb0d96d6b141ee4e5b8ff914fee6c62c6388ca5413e6113b4ec1fbb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d591d7a96ebe8e907b4e2babc5528bf26de5913825caba5bbc4f11dc83bad0ee
+        checksum/config: 306ccb4b5b4f7ebc75d88340487a42c673b10905ac5abaa549b1fc75a24bde56
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 306ccb4b5b4f7ebc75d88340487a42c673b10905ac5abaa549b1fc75a24bde56
+        checksum/config: 0785b889feadd21d25bdb2f6a4f571af5584b3603818387b4d1fe9cf1504e82d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -41,7 +41,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 45115c8c454d58aeb2ac93b2109b3790aa86236e5e97c65f79133477f275372c
+        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dffaf024a9279aa1e00b119107a2175df969a592a20465c9ec33ac71869ba4fb
+        checksum/config: 45115c8c454d58aeb2ac93b2109b3790aa86236e5e97c65f79133477f275372c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
+        checksum/config: 8c9cb2130d865643053378e7dab1d05d800b61326f6e404a1ddceef91c75a0af
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
+        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4330d689ccdc658d07457fda6cf3c869e5680b391d9af7fc8cb6e5786bdd2e37
+        checksum/config: e5e5bf15320b50267f4a1989db5454de48ae14f1487bff0e3f346400af3433fc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e5e5bf15320b50267f4a1989db5454de48ae14f1487bff0e3f346400af3433fc
+        checksum/config: 5dd6cf134433dd8852bd66845c6a713f9039710b0680d530342e002cd6493929
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5dd6cf134433dd8852bd66845c6a713f9039710b0680d530342e002cd6493929
+        checksum/config: d309884d9adac2c949e05d6fc213392e7a84003cbe6a0d068a19fce59b3aa959
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -41,7 +41,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ee598808417675e3315b0cb4ad5a70ff47c181b5eafde83ab7235d307b8af150
+        checksum/config: 4330d689ccdc658d07457fda6cf3c869e5680b391d9af7fc8cb6e5786bdd2e37
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3302aeae562111e74014876cbaa6b0aa4f592e73d011b6fcb8513828d410827b
+        checksum/config: 48c0d2ff85f9f7d11213ac4286a8cb3cba222fac40a52f03c1845c68ad847fcc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0cc9092e47a747f51748bbf05dc5598605420ceaa7bead02c77a9819c53c4f94
+        checksum/config: f37559c08449233c89d3d834cf51a5446853b4e57933f055b4380e424f6671c9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -41,7 +41,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 48c0d2ff85f9f7d11213ac4286a8cb3cba222fac40a52f03c1845c68ad847fcc
+        checksum/config: 0cc9092e47a747f51748bbf05dc5598605420ceaa7bead02c77a9819c53c4f94
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 992f0c19a9609e475dfeaf377f031f659384e98d8e31455826eecaf06a8380f0
+        checksum/config: 3302aeae562111e74014876cbaa6b0aa4f592e73d011b6fcb8513828d410827b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 83853683de291251b2300379c3c80e6af3079c8846faf1aa3f80f832e2e2205d
+        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
+        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e27c8cf2fc5b45f0161308346afb23e8a240c7a69f11ad7c9ea7f62101a965dc
+        checksum/config: 83853683de291251b2300379c3c80e6af3079c8846faf1aa3f80f832e2e2205d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
+        checksum/config: e148cc5b7c97b587cdd80d6c9b8e26a1a9a83d858e020665b1ff7096036f0f08
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -41,7 +41,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 83853683de291251b2300379c3c80e6af3079c8846faf1aa3f80f832e2e2205d
+        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
+        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e27c8cf2fc5b45f0161308346afb23e8a240c7a69f11ad7c9ea7f62101a965dc
+        checksum/config: 83853683de291251b2300379c3c80e6af3079c8846faf1aa3f80f832e2e2205d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
+        checksum/config: e148cc5b7c97b587cdd80d6c9b8e26a1a9a83d858e020665b1ff7096036f0f08
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -41,7 +41,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 45115c8c454d58aeb2ac93b2109b3790aa86236e5e97c65f79133477f275372c
+        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 3
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
+        checksum/config: 8c9cb2130d865643053378e7dab1d05d800b61326f6e404a1ddceef91c75a0af
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dffaf024a9279aa1e00b119107a2175df969a592a20465c9ec33ac71869ba4fb
+        checksum/config: 45115c8c454d58aeb2ac93b2109b3790aa86236e5e97c65f79133477f275372c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
+        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4f7e3ee2c34567f31d0aada436446deee2566a1f85ce3fc5d85aab4221ee2e42
+        checksum/config: 0a2474e865afacdac61302206a18b923dbd5448991ee5a2ff5b453ff1f75f708
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f03c0b4eea87d9e1057e23a564bab931da3c83459d8f5113da6d40ce99d602ce
+        checksum/config: 4f7e3ee2c34567f31d0aada436446deee2566a1f85ce3fc5d85aab4221ee2e42
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7305c787c10974cc54284bfa150c9add010ee3080df0d74905ae066689a7bd12
+        checksum/config: f03c0b4eea87d9e1057e23a564bab931da3c83459d8f5113da6d40ce99d602ce
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b2147160133c332e6657c90cc1e111cdd1122521959562a284f7808d65de59a8
+        checksum/config: 7305c787c10974cc54284bfa150c9add010ee3080df0d74905ae066689a7bd12
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/config.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 41cb3ee81579bec841358e320cef56e379196bec0b0f946e2f14b476c537d69e
+        checksum/config: 9c0e33a2291af9f2eab07b384394feec92f8d90d0ac55529c4a838d2dc22ffe4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 412fb3807e3708b7f6026c796980b953e9409647c62e0d243dd7b93dd3b7647e
+        checksum/config: 41cb3ee81579bec841358e320cef56e379196bec0b0f946e2f14b476c537d69e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78158d5ea7af886471eba1ee403a69986e7d47e75946a18fb4529fc8b3b30b98
+        checksum/config: f2fd547af13f7be2bfc18390ca0483c589dbc0e41d30df706d78e6107aad172c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f2fd547af13f7be2bfc18390ca0483c589dbc0e41d30df706d78e6107aad172c
+        checksum/config: 412fb3807e3708b7f6026c796980b953e9409647c62e0d243dd7b93dd3b7647e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
     component: statefulset-collector
 spec:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.2
+    helm.sh/chart: opentelemetry-collector-0.66.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b905aaf182f8793194d1c4d47ef0d755718156630c1dfc4dcc7ab499c295e989
+        checksum/config: af45f1a3f19d21465934589edd45ac5f68b85eed9ac77c530e5d63f1f0e5e396
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.1
+    helm.sh/chart: opentelemetry-collector-0.66.2
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9961bbb5713861100a5bf39ed3cde563176f4abb38804b9b2318ec549f956e0f
+        checksum/config: b905aaf182f8793194d1c4d47ef0d755718156630c1dfc4dcc7ab499c295e989
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -24,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: af45f1a3f19d21465934589edd45ac5f68b85eed9ac77c530e5d63f1f0e5e396
+        checksum/config: f39b79a54dfb785b773640ebd55d45eb0213bc83f131fb42a3dfb3ae3d4b7cc5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.4
+    helm.sh/chart: opentelemetry-collector-0.67.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.83.0"
+    app.kubernetes.io/version: "0.84.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: example-opentelemetry-collector
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f39b79a54dfb785b773640ebd55d45eb0213bc83f131fb42a3dfb3ae3d4b7cc5
+        checksum/config: 2dcd08a52f3c6a913161c3889d6d1b9457c29ce0d731adfb6ede6b13c5b61771
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.83.0"
+          image: "otel/opentelemetry-collector-contrib:0.84.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -158,4 +158,13 @@ Compute InternalTrafficPolicy on Service creation
   {{- end }}
 {{- end -}}
 
-
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "opentelemetry-collector.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/opentelemetry-collector/templates/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-agent.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-statefulset
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/configmap.yaml
+++ b/charts/opentelemetry-collector/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/daemonset.yaml
+++ b/charts/opentelemetry-collector/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
@@ -42,7 +43,7 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
@@ -42,7 +43,7 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $podValues := deepCopy .Values }}

--- a/charts/opentelemetry-collector/templates/hpa.yaml
+++ b/charts/opentelemetry-collector/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/ingress.yaml
+++ b/charts/opentelemetry-collector/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- else }}
   name: {{ include "opentelemetry-collector.fullname" $ }}
   {{- end }}
+  namespace: {{ template "opentelemetry-collector.namespace" $ }}
   labels:
     {{- include "opentelemetry-collector.labels" $ | nindent 4 }}
     {{- include "opentelemetry-collector.component" $ | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/networkpolicy.yaml
+++ b/charts/opentelemetry-collector/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.networkPolicy.annotations }}

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/podmonitor.yaml
+++ b/charts/opentelemetry-collector/templates/podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.podMonitor.extraLabels }}

--- a/charts/opentelemetry-collector/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-collector/templates/prometheusrule.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.prometheusRule.extraLabels }}

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- include "opentelemetry-collector.component" . | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opentelemetry-collector.serviceAccountName" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}

--- a/charts/opentelemetry-collector/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-collector/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.extraLabels }}

--- a/charts/opentelemetry-collector/templates/statefulset.yaml
+++ b/charts/opentelemetry-collector/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -35,6 +35,10 @@
       "type": "string",
       "enum": ["daemonset", "deployment", "statefulset", ""]
     },
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Name of the namespace to deploy the resources into."
+    },
     "presets": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -22,6 +22,7 @@ presets:
   # Adds the filelog receiver to the logs pipeline
   # and adds the necessary volumes and volume mounts.
   # Best used with mode = daemonset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#filelog-receiver for details on the receiver.
   logsCollection:
     enabled: false
     includeCollectorLogs: false
@@ -35,12 +36,14 @@ presets:
   # Adds the hostmetrics receiver to the metrics pipeline
   # and adds the necessary volumes and volume mounts.
   # Best used with mode = daemonset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#host-metrics-receiver for details on the receiver.
   hostMetrics:
     enabled: false
   # Configures the Kubernetes Processor to add Kubernetes metadata.
   # Adds the k8sattributes processor to all the pipelines
   # and adds the necessary rules to ClusteRole.
   # Best used with mode = daemonset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-attributes-processor for details on the receiver.
   kubernetesAttributes:
     enabled: false
     # When enabled the processor will extra all labels for an associated pod and add them as resource attributes.
@@ -49,23 +52,26 @@ presets:
     # When enabled the processor will extra all annotations for an associated pod and add them as resource attributes.
     # The annotation's exact name will be the key.
     extractAllPodAnnotations: false
+  # Configures the collector to collect node, pod, and container metrics from the API server on a kubelet..
+  # Adds the kubeletstats receiver to the metrics pipeline
+  # and adds the necessary rules to ClusteRole.
+  # Best used with mode = daemonset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubeletstats-receiver for details on the receiver.
+  kubeletMetrics:
+    enabled: false
   # Configures the collector to collect kubernetes events.
   # Adds the k8sobject receiver to the logs pipeline
   # and collects kubernetes events by default.
   # Best used with mode = deployment or statefulset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-objects-receiver for details on the receiver.
   kubernetesEvents:
     enabled: false
   # Configures the Kubernetes Cluster Receiver to collect cluster-level metrics.
   # Adds the k8s_cluster receiver to the metrics pipeline
   # and adds the necessary rules to ClusteRole.
   # Best used with mode = deployment or statefulset.
+  # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver for details on the receiver.
   clusterMetrics:
-    enabled: false
-  # Configures the collector to collect Kubelet metrics.
-  # Adds the kubeletstats receiver to the metrics pipeline
-  # and adds the necessary rules to ClusteRole.
-  # Best used with mode = daemonset.
-  kubeletMetrics:
     enabled: false
 
 configMap:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -8,6 +8,9 @@ fullnameOverride: ""
 # Valid values are "daemonset", "deployment", and "statefulset".
 mode: ""
 
+# Specify which namespace should be used to deploy the resources into
+namespaceOverride: ""
+
 # Handles basic configuration of components that
 # also require k8s modifications to work correctly.
 # .Values.config can be used to modify/add to a preset

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.23.0
+version: 0.23.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -89,6 +89,7 @@ the demo
 | `serviceAccount.annotations`           | Annotations for the serviceAccount                                                        | `{}`                                                 |
 | `serviceAccount.create`                | Whether to create a serviceAccount or use an existing one                                 | `true`                                               |
 | `serviceAccount.name`                  | The name of the ServiceAccount to use for demo components                                 | `""`                                                 |
+| `replicas`                             | The number of replicas for each of the services (doesn't apply to databases)              | `1`                                                 |
 
 ### Component parameters
 
@@ -139,6 +140,7 @@ component.
 | `initContainers[].name`              | Name of the init container                                                                                 | `nil`                                                         |
 | `initContainers[].image`             | Image to use for the init container                                                                        | `nil`                                                         |
 | `initContainers[].command`           | Command to run for the init container                                                                      | `nil`                                                         |
+| `replicasOverride`                   | Used to override the number of replicas of this component                                              | `nil`                                                         |
 
 ### Sub-charts
 

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -518,7 +519,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -528,6 +529,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -600,7 +602,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -610,6 +612,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -690,7 +693,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -700,6 +703,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -790,7 +794,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,6 +804,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -868,7 +873,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -878,6 +883,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -948,7 +954,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -958,6 +964,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1058,6 +1065,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1132,7 +1140,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1142,6 +1150,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1214,7 +1223,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1224,6 +1233,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1316,7 +1326,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1326,6 +1336,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1420,7 +1431,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1430,6 +1441,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1506,7 +1518,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1516,6 +1528,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1596,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1606,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1678,7 +1692,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1688,6 +1702,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1758,7 +1773,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1768,6 +1783,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1842,7 +1858,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1852,6 +1868,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1928,7 +1945,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1938,6 +1955,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2006,7 +2024,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2016,6 +2034,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -518,7 +519,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -528,6 +529,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -600,7 +602,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -610,6 +612,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -690,7 +693,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -700,6 +703,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -790,7 +794,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,6 +804,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -868,7 +873,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -878,6 +883,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -948,7 +954,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -958,6 +964,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1058,6 +1065,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1132,7 +1140,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1142,6 +1150,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1214,7 +1223,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1224,6 +1233,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1316,7 +1326,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1326,6 +1336,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1420,7 +1431,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1430,6 +1441,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1506,7 +1518,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1516,6 +1528,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1596,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1606,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1678,7 +1692,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1688,6 +1702,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1758,7 +1773,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1768,6 +1783,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1842,7 +1858,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1852,6 +1868,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1928,7 +1945,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1938,6 +1955,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2006,7 +2024,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2016,6 +2034,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,11 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
-        kubectl.kubernetes.io/default-container: grafana
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -38,20 +37,12 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
-        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "docker.io/bats/bats:v1.4.1"
+      image: "bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,6 +96,4 @@ spec:
           resources:
             limits:
               memory: 300Mi
-          volumeMounts:
       serviceAccountName: example-jaeger
-      volumes:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e62fcdf5b3a33ec3cdb0ad02e110fcaa5f3ec9f29067a643b7413b0bd7623171
+        checksum/config: 19f2931042e627b07e3bf0e0b69778e9bcb40885393993fb6b7e8acebdc5c357
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "otel/opentelemetry-collector-contrib:0.77.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -4,43 +4,38 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: prometheus
-      app.kubernetes.io/instance: example
+      component: "server"
+      app: prometheus
+      release: example
   replicas: 1
-  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
-        app.kubernetes.io/name: prometheus
-        app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.46.0
-        helm.sh/chart: prometheus-23.3.0
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/part-of: prometheus
+        component: "server"
+        app: prometheus
+        release: example
+        chart: prometheus-20.2.0
+        heritage: Helm
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.46.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
@@ -20,8 +18,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
+    component: "server"
+    app: prometheus
+    release: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -520,7 +521,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -530,6 +531,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -604,7 +606,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -614,6 +616,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -696,7 +699,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -706,6 +709,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -798,7 +802,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -808,6 +812,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -878,7 +883,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -888,6 +893,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -960,7 +966,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -970,6 +976,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1062,7 +1069,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1072,6 +1079,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1146,7 +1154,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1156,6 +1164,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1230,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1240,6 +1249,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1334,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1344,6 +1354,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1438,7 +1449,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1448,6 +1459,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1524,7 +1536,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1534,6 +1546,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1616,7 +1629,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1626,6 +1639,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1700,7 +1714,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1710,6 +1724,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1782,7 +1797,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1792,6 +1807,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1868,7 +1884,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1878,6 +1894,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1956,7 +1973,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1966,6 +1983,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2034,7 +2052,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2044,6 +2062,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,11 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
-        kubectl.kubernetes.io/default-container: grafana
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -38,20 +37,12 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
-        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "docker.io/bats/bats:v1.4.1"
+      image: "bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,6 +96,4 @@ spec:
           resources:
             limits:
               memory: 300Mi
-          volumeMounts:
       serviceAccountName: example-jaeger
-      volumes:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 20851ed0c4bdafbefc52a90b489ba1a5a377b40e2add9425e2e4de2dcfce0f2d
+        checksum/config: f85af59ffecbb732ad2cb7dddd076c5820e389485040b4cdedf8ad9e9cbe49b2
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "otel/opentelemetry-collector-contrib:0.77.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,4 +52,3 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
-  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -4,43 +4,38 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: prometheus
-      app.kubernetes.io/instance: example
+      component: "server"
+      app: prometheus
+      release: example
   replicas: 1
-  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
-        app.kubernetes.io/name: prometheus
-        app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.46.0
-        helm.sh/chart: prometheus-23.3.0
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/part-of: prometheus
+        component: "server"
+        app: prometheus
+        release: example
+        chart: prometheus-20.2.0
+        heritage: Helm
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.46.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
@@ -20,8 +18,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
+    component: "server"
+    app: prometheus
+    release: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -518,7 +519,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -528,6 +529,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -600,7 +602,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -610,6 +612,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -690,7 +693,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -700,6 +703,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -790,7 +794,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,6 +804,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -868,7 +873,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -878,6 +883,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -948,7 +954,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -958,6 +964,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1058,6 +1065,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1132,7 +1140,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1142,6 +1150,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1214,7 +1223,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1224,6 +1233,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1316,7 +1326,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1326,6 +1336,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1420,7 +1431,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1430,6 +1441,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1506,7 +1518,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1516,6 +1528,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1596,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1606,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1678,7 +1692,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1688,6 +1702,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1758,7 +1773,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1768,6 +1783,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1842,7 +1858,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1852,6 +1868,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1928,7 +1945,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1938,6 +1955,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2006,7 +2024,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2016,6 +2034,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,11 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
-        kubectl.kubernetes.io/default-container: grafana
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -38,20 +37,12 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
-        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "docker.io/bats/bats:v1.4.1"
+      image: "bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,6 +96,4 @@ spec:
           resources:
             limits:
               memory: 300Mi
-          volumeMounts:
       serviceAccountName: example-jaeger
-      volumes:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 642250a36237ea6c5d9137695bbc2874323b1d1849096d6e61789e892007fbf3
+        checksum/config: 330262db4024d8ef55d028492989fd4d8f77bb62c61f0f461b58ce2ff369ac80
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "otel/opentelemetry-collector-contrib:0.77.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,4 +52,3 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
-  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -4,43 +4,38 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: prometheus
-      app.kubernetes.io/instance: example
+      component: "server"
+      app: prometheus
+      release: example
   replicas: 1
-  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
-        app.kubernetes.io/name: prometheus
-        app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.46.0
-        helm.sh/chart: prometheus-23.3.0
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/part-of: prometheus
+        component: "server"
+        app: prometheus
+        release: example
+        chart: prometheus-20.2.0
+        heritage: Helm
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.46.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
@@ -20,8 +18,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
+    component: "server"
+    app: prometheus
+    release: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -518,7 +519,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -528,6 +529,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -600,7 +602,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -610,6 +612,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -690,7 +693,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -700,6 +703,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -790,7 +794,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,6 +804,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -868,7 +873,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -878,6 +883,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -948,7 +954,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -958,6 +964,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1058,6 +1065,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1132,7 +1140,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1142,6 +1150,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1214,7 +1223,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1224,6 +1233,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1316,7 +1326,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1326,6 +1336,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1420,7 +1431,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1430,6 +1441,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1506,7 +1518,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1516,6 +1528,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1596,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1606,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1678,7 +1692,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1688,6 +1702,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1758,7 +1773,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1768,6 +1783,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1842,7 +1858,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1852,6 +1868,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1928,7 +1945,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1938,6 +1955,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2006,7 +2024,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2016,6 +2034,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -2086,7 +2105,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,11 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
-        kubectl.kubernetes.io/default-container: grafana
+        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
     spec:
       
       serviceAccountName: example-grafana
@@ -38,20 +37,12 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
-        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "grafana/grafana:9.4.7"
           imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.52.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "9.4.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "docker.io/bats/bats:v1.4.1"
+      image: "bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.42.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,6 +96,4 @@ spec:
           resources:
             limits:
               memory: 300Mi
-          volumeMounts:
       serviceAccountName: example-jaeger
-      volumes:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.11
+    helm.sh/chart: jaeger-0.69.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.45.0"
+    app.kubernetes.io/version: "1.42.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 642250a36237ea6c5d9137695bbc2874323b1d1849096d6e61789e892007fbf3
+        checksum/config: 330262db4024d8ef55d028492989fd4d8f77bb62c61f0f461b58ce2ff369ac80
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.82.0"
+          image: "otel/opentelemetry-collector-contrib:0.77.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,4 +52,3 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
-  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.65.1
+    helm.sh/chart: opentelemetry-collector-0.57.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.77.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -4,13 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -4,43 +4,38 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: prometheus
-      app.kubernetes.io/instance: example
+      component: "server"
+      app: prometheus
+      release: example
   replicas: 1
-  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
-        app.kubernetes.io/name: prometheus
-        app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.46.0
-        helm.sh/chart: prometheus-23.3.0
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/part-of: prometheus
+        component: "server"
+        app: prometheus
+        release: example
+        chart: prometheus-20.2.0
+        heritage: Helm
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.46.0"
+          image: "quay.io/prometheus/prometheus:v2.43.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
 spec:
@@ -20,8 +18,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
+    component: "server"
+    app: prometheus
+    release: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: prometheus
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.46.0
-    helm.sh/chart: prometheus-23.3.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: prometheus
+    component: "server"
+    app: prometheus
+    release: example
+    chart: prometheus-20.2.0
+    heritage: Helm
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.23.0
+    helm.sh/chart: opentelemetry-demo-0.23.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .replicasOverride | default .defaultValues.replicas }}
   selector:
     matchLabels:
       {{- include "otel-demo.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -197,6 +197,9 @@
               "type": "object"
             }
           }
+        },
+        "replicasOverride": {
+          "type": "integer"
         }
       },
       "required": [
@@ -266,6 +269,9 @@
         },
         "securityContext": {
           "type": "object"
+        },
+        "replicas": {
+          "type": "integer"
         }
       },
       "required": [

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -48,6 +48,8 @@ default:
     affinity: {}
     tolerations: []
   securityContext: {}
+  replicas: 1
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -146,6 +148,8 @@ components:
   #     - name: <init-container-name>
   #       image: <init-container-image>
   #       command: [list of commands for the init container to run]
+  # # Number of replicas to run for this component. Default is set in the defaults.replicas
+  #   replicasOverride: 1
   accountingService:
     enabled: true
     useDefault:
@@ -427,6 +431,7 @@ components:
     resources:
       limits:
         memory: 120Mi
+    replicasOverride: 1
 
   paymentService:
     enabled: true
@@ -549,6 +554,7 @@ components:
       runAsUser: 999  # postgres
       runAsGroup: 999
       runAsNonRoot: true
+    replicasOverride: 1
 
   kafka:
     enabled: true
@@ -573,6 +579,7 @@ components:
       runAsUser: 1000  # appuser
       runAsGroup: 1000
       runAsNonRoot: true
+    replicasOverride: 1
 
   redis:
     enabled: true
@@ -591,6 +598,7 @@ components:
       runAsUser: 999  # redis
       runAsGroup: 1000
       runAsNonRoot: true
+    replicasOverride: 1
 
 opentelemetry-collector:
   enabled: true

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.36.0
+version: 0.37.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.35.2
+version: 0.36.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.82.0
+appVersion: 0.83.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -46,20 +46,1114 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+            description: APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              internal value, and may reject unrecognized values.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
+            description: Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              submits requests to. Cannot be updated. In CamelCase.
             type: string
           metadata:
             type: object
           spec:
             description: OpenTelemetryCollectorSpec defines the desired state of OpenTelemetryCollector.
             properties:
+              additionalContainers:
+                description: AdditionalContainers allows injecting additional containers
+                  into the Collector's pod definition.
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
+                  properties:
+                    args:
+                      description: Arguments to the entrypoint. The container image's
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container's environment.
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's
+                        environment.
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    image:
+                      description: 'Container image name. More info: https://kubernetes.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
+                      properties:
+                        postStart:
+                          description: PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name. This will
+                                      be canonicalized upon output, so case-variant
+                                      names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name. This will
+                                      be canonicalized upon output, so case-variant
+                                      names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    resizePolicy:
+                      description: Resources resize policy for the container.
+                      items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
+                        properties:
+                          resourceName:
+                            description: 'Name of the resource to which this resource
+                              resize policy applies. Supported values: cpu, memory.'
+                            type: string
+                          restartPolicy:
+                            description: Restart policy to apply when specified resource
+                              is resized. If not specified, it defaults to NotRequired.
+                            type: string
+                        required:
+                        - resourceName
+                        - restartPolicy
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry
+                                  in pod.spec.resourceClaims of the Pod where this
+                                  field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
+                          type: object
+                      type: object
+                    restartPolicy:
+                      description: RestartPolicy defines the restart behavior of individual
+                        containers in a pod. This field may only be set for init containers,
+                        and the only allowed value is "Always".
+                      type: string
+                    securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with. If set, the fields of SecurityContext
+                        override the equivalent fields of PodSecurityContext.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: AllowPrivilegeEscalation controls whether a
+                            process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process.
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime. Note that this field cannot be
+                            set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work.
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used."
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully.
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name. This will
+                                      be canonicalized upon output, so case-variant
+                                      names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions.
+                      type: boolean
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               affinity:
                 description: If specified, indicates the pod's scheduling constraints
                 properties:
@@ -71,14 +1165,7 @@ spec:
                         description: The scheduler will prefer to schedule pods to
                           nodes that satisfy the affinity expressions specified by
                           this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
+                          more of the expressions.
                         items:
                           description: An empty preferred scheduling term matches
                             all objects with implicit weight 0 (i.e. it's a no-op).
@@ -112,11 +1199,7 @@ spec:
                                           the operator is In or NotIn, the values
                                           array must be non-empty. If the operator
                                           is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                          must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -148,11 +1231,7 @@ spec:
                                           the operator is In or NotIn, the values
                                           array must be non-empty. If the operator
                                           is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                          must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -176,10 +1255,7 @@ spec:
                       requiredDuringSchedulingIgnoredDuringExecution:
                         description: If the affinity requirements specified by this
                           field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+                          scheduled onto the node.
                         properties:
                           nodeSelectorTerms:
                             description: Required. A list of node selector terms.
@@ -213,11 +1289,7 @@ spec:
                                           the operator is In or NotIn, the values
                                           array must be non-empty. If the operator
                                           is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                          must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -249,11 +1321,7 @@ spec:
                                           the operator is In or NotIn, the values
                                           array must be non-empty. If the operator
                                           is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                          must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -278,14 +1346,7 @@ spec:
                         description: The scheduler will prefer to schedule pods to
                           nodes that satisfy the affinity expressions specified by
                           this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                          more of the expressions.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
                             fields are added per-node to find the most preferred node(s)
@@ -323,9 +1384,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -338,11 +1397,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -351,9 +1406,6 @@ spec:
                                     that the term applies to. The term is applied
                                     to the union of the namespaces selected by this
                                     field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -380,9 +1432,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -395,11 +1445,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -408,19 +1454,16 @@ spec:
                                     of namespace names that the term applies to. The
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
+                                    namespaceSelector.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
+                                  description: 'This pod should be co-located (affinity)
                                     or not co-located (anti-affinity) with the pods
                                     matching the labelSelector in the specified namespaces,
                                     where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                    whose '
                                   type: string
                               required:
                               - topologyKey
@@ -438,21 +1481,12 @@ spec:
                       requiredDuringSchedulingIgnoredDuringExecution:
                         description: If the affinity requirements specified by this
                           field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
+                          scheduled onto the node.
                         items:
                           description: Defines a set of pods (namely those matching
                             the labelSelector relative to the given namespace(s))
                             that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                            (anti-affinity) with, where co-locate
                           properties:
                             labelSelector:
                               description: A label query over a set of resources,
@@ -480,8 +1514,7 @@ spec:
                                           values. If the operator is In or NotIn,
                                           the values array must be non-empty. If the
                                           operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                          values array must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -494,11 +1527,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -506,9 +1535,7 @@ spec:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
                                 union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
+                                the ones listed in the namespaces field.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -532,8 +1559,7 @@ spec:
                                           values. If the operator is In or NotIn,
                                           the values array must be non-empty. If the
                                           operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                          values array must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -546,11 +1572,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -558,20 +1580,15 @@ spec:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
                                 to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
+                                and the ones selected by namespaceSelector.
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
+                              description: 'This pod should be co-located (affinity)
                                 or not co-located (anti-affinity) with the pods matching
                                 the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                                co-located is defined as running on a node whose '
                               type: string
                           required:
                           - topologyKey
@@ -587,14 +1604,7 @@ spec:
                         description: The scheduler will prefer to schedule pods to
                           nodes that satisfy the anti-affinity expressions specified
                           by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                          or more of the expressions.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
                             fields are added per-node to find the most preferred node(s)
@@ -632,9 +1642,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -647,11 +1655,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -660,9 +1664,6 @@ spec:
                                     that the term applies to. The term is applied
                                     to the union of the namespaces selected by this
                                     field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -689,9 +1690,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -704,11 +1703,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -717,19 +1712,16 @@ spec:
                                     of namespace names that the term applies to. The
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
+                                    namespaceSelector.
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
+                                  description: 'This pod should be co-located (affinity)
                                     or not co-located (anti-affinity) with the pods
                                     matching the labelSelector in the specified namespaces,
                                     where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                    whose '
                                   type: string
                               required:
                               - topologyKey
@@ -747,21 +1739,12 @@ spec:
                       requiredDuringSchedulingIgnoredDuringExecution:
                         description: If the anti-affinity requirements specified by
                           this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
+                          not be scheduled onto the node.
                         items:
                           description: Defines a set of pods (namely those matching
                             the labelSelector relative to the given namespace(s))
                             that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                            (anti-affinity) with, where co-locate
                           properties:
                             labelSelector:
                               description: A label query over a set of resources,
@@ -789,8 +1772,7 @@ spec:
                                           values. If the operator is In or NotIn,
                                           the values array must be non-empty. If the
                                           operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                          values array must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -803,11 +1785,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -815,9 +1793,7 @@ spec:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
                                 union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
+                                the ones listed in the namespaces field.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
@@ -841,8 +1817,7 @@ spec:
                                           values. If the operator is In or NotIn,
                                           the values array must be non-empty. If the
                                           operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                          values array must be empty.
                                         items:
                                           type: string
                                         type: array
@@ -855,11 +1830,7 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -867,20 +1838,15 @@ spec:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
                                 to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
+                                and the ones selected by namespaceSelector.
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
+                              description: 'This pod should be co-located (affinity)
                                 or not co-located (anti-affinity) with the pods matching
                                 the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                                co-located is defined as running on a node whose '
                               type: string
                           required:
                           - topologyKey
@@ -907,8 +1873,7 @@ spec:
                         description: scaleDown is scaling policy for scaling Down.
                           If not set, the default value is to allow to scale down
                           to minReplicas pods, with a 300 second stabilization window
-                          (i.e., the highest recommendation for the last 300sec is
-                          used).
+                          (i.e.
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
@@ -949,22 +1914,14 @@ spec:
                               used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: 'stabilizationWindowSeconds is the number
+                            description: stabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              considered while scaling up or scaling down.
                             format: int32
                             type: integer
                         type: object
                       scaleUp:
-                        description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of: * increase
-                          no more than 4 pods per 60 seconds * double the number of
-                          pods per 60 seconds No stabilization is used.'
+                        description: scaleUp is scaling policy for scaling Up.
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
@@ -1005,14 +1962,9 @@ spec:
                               used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: 'stabilizationWindowSeconds is the number
+                            description: stabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              considered while scaling up or scaling down.
                             format: int32
                             type: integer
                         type: object
@@ -1025,8 +1977,7 @@ spec:
                   metrics:
                     description: Metrics is meant to provide a customizable way to
                       configure HPA metrics. currently the only supported custom metrics
-                      is type=Pod. Use TargetCPUUtilization or TargetMemoryUtilization
-                      instead if scaling on these common resource metrics.
+                      is type=Pod.
                     items:
                       description: MetricSpec defines a subset of metrics to be defined
                         for the HPA's metric array more metric type can be supported
@@ -1036,9 +1987,7 @@ spec:
                         pods:
                           description: PodsMetricSource indicates how to scale on
                             a metric describing each pod in the current scale target
-                            (for example, transactions-processed-per-second). The
-                            values will be averaged together before being compared
-                            to the target value.
+                            (for example, transactions-processed-per-second).
                           properties:
                             metric:
                               description: metric identifies the target metric by
@@ -1052,8 +2001,7 @@ spec:
                                     of a standard kubernetes label selector for the
                                     given metric When set, it is passed as an additional
                                     parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                    metrics scopi
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -1080,9 +2028,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -1095,11 +2041,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1115,8 +2057,6 @@ spec:
                                     of the average of the resource metric across all
                                     relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
                                   format: int32
                                   type: integer
                                 averageValue:
@@ -1189,15 +2129,9 @@ spec:
                       description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
+                      description: Variable references $(VAR_NAME) are expanded using
                         the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
+                        and any service environment variables.
                       type: string
                     valueFrom:
                       description: Source for the environment variable's value. Cannot
@@ -1225,7 +2159,7 @@ spec:
                           description: 'Selects a field of the pod: supports metadata.name,
                             metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
                             spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                            status.'
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -1243,7 +2177,7 @@ spec:
                           description: 'Selects a resource of the container: only
                             resources limits and requests (limits.cpu, limits.memory,
                             limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                            and requests.'
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -1370,6 +2304,14 @@ spec:
                         - reencrypt
                         type: string
                     type: object
+                  ruleType:
+                    description: RuleType defines how Ingress exposes collector receivers.
+                      IngressRuleTypePath ("path") exposes each receiver port on a
+                      unique path on single domain defined in Hostname.
+                    enum:
+                    - path
+                    - subdomain
+                    type: string
                   tls:
                     description: TLS configuration.
                     items:
@@ -1379,9 +2321,7 @@ spec:
                         hosts:
                           description: hosts is a list of hosts included in the TLS
                             certificate. The values in this list must match the name/s
-                            used in the tlsSecret. Defaults to the wildcard host setting
-                            for the loadbalancer controller fulfilling this Ingress,
-                            if left unspecified.
+                            used in the tlsSecret.
                           items:
                             type: string
                           type: array
@@ -1389,56 +2329,37 @@ spec:
                         secretName:
                           description: secretName is the name of the secret used to
                             terminate TLS traffic on port 443. Field is left optional
-                            to allow TLS routing based on SNI hostname alone. If the
-                            SNI host in a listener conflicts with the "Host" header
-                            field used by an IngressRule, the SNI host is used for
-                            termination and value of the "Host" header is used for
-                            routing.
+                            to allow TLS routing based on SNI hostname alone.
                           type: string
                       type: object
                     type: array
                   type:
-                    description: 'Type default value is: "" Supported types are: ingress'
+                    description: 'Type default value is: "" Supported types are: ingress,
+                      route'
                     enum:
                     - ingress
                     - route
                     type: string
                 type: object
               initContainers:
-                description: 'InitContainers allows injecting initContainers to the
-                  Collector''s pod definition. These init containers can be used to
-                  fetch secrets for injection into the configuration from external
-                  sources, run added checks, etc. Any errors during the execution
-                  of an initContainer will lead to a restart of the Pod. More info:
-                  https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                description: InitContainers allows injecting initContainers to the
+                  Collector's pod definition.
                 items:
                   description: A single application container that you want to run
                     within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The container image''s
+                      description: Arguments to the entrypoint. The container image's
                         CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        are expanded using the container's environment.
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's
+                        environment.
                       items:
                         type: string
                       type: array
@@ -1454,16 +2375,9 @@ spec:
                               a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                            description: Variable references $(VAR_NAME) are expanded
                               using the previously defined environment variables in
                               the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
                             type: string
                           valueFrom:
                             description: Source for the environment variable's value.
@@ -1493,8 +2407,7 @@ spec:
                                 description: 'Selects a field of the pod: supports
                                   metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
                                   `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
+                                  spec.serviceAccountName, status.hostIP, status.'
                                 properties:
                                   apiVersion:
                                     description: Version of the schema the FieldPath
@@ -1512,8 +2425,7 @@ spec:
                                 description: 'Selects a resource of the container:
                                   only resources limits and requests (limits.cpu,
                                   limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
+                                  requests.memory and requests.'
                                 properties:
                                   containerName:
                                     description: 'Container name: required for volumes,
@@ -1564,11 +2476,7 @@ spec:
                     envFrom:
                       description: List of sources to populate environment variables
                         in the container. The keys defined within a source must be
-                        a C_IDENTIFIER. All invalid keys will be reported as an event
-                        when the container is starting. When a key exists in multiple
-                        sources, the value associated with the last source will take
-                        precedence. Values defined by an Env with a duplicate key
-                        will take precedence. Cannot be updated.
+                        a C_IDENTIFIER.
                       items:
                         description: EnvFromSource represents the source of a set
                           of ConfigMaps
@@ -1607,26 +2515,21 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
+                      description: 'Container image name. More info: https://kubernetes.'
                       type: string
                     imagePullPolicy:
                       description: 'Image pull policy. One of Always, Never, IfNotPresent.
                         Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        otherwise. Cannot be updated. More info: https://kubernetes.'
                       type: string
                     lifecycle:
                       description: Actions that the management system should take
                         in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container
+                          description: PostStart is called immediately after a container
                             is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            and restarted according to its restart policy.
                           properties:
                             exec:
                               description: Exec specifies the action to take.
@@ -1635,12 +2538,7 @@ spec:
                                   description: Command is the command line to execute
                                     inside the container, the working directory for
                                     the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
+                                    filesystem.
                                   items:
                                     type: string
                                   type: array
@@ -1694,8 +2592,6 @@ spec:
                             tcpSocket:
                               description: Deprecated. TCPSocket is NOT supported
                                 as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -1714,17 +2610,10 @@ spec:
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container
+                          description: PreStop is called immediately before a container
                             is terminated due to an API request or management event
                             such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            contention, etc.
                           properties:
                             exec:
                               description: Exec specifies the action to take.
@@ -1733,12 +2622,7 @@ spec:
                                   description: Command is the command line to execute
                                     inside the container, the working directory for
                                     the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
+                                    filesystem.
                                   items:
                                     type: string
                                   type: array
@@ -1792,8 +2676,6 @@ spec:
                             tcpSocket:
                               description: Deprecated. TCPSocket is NOT supported
                                 as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -1824,11 +2706,6 @@ spec:
                               description: Command is the command line to execute
                                 inside the container, the working directory for the
                                 command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -1848,10 +2725,8 @@ spec:
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                               type: string
                           required:
                           - port
@@ -1941,19 +2816,7 @@ spec:
                           type: object
                         terminationGracePeriodSeconds:
                           description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
@@ -1971,11 +2834,7 @@ spec:
                     ports:
                       description: List of ports to expose from the container. Not
                         specifying a port here DOES NOT prevent that port from being
-                        exposed. Any port which is listening on the default "0.0.0.0"
-                        address inside a container will be accessible from the network.
-                        Modifying this array with strategic merge patch may corrupt
-                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                        Cannot be updated.
+                        exposed. Any port which is listening on the default "0.0.0.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -2017,7 +2876,7 @@ spec:
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
                         Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        fails. Cannot be updated. More info: https://kubernetes.'
                       properties:
                         exec:
                           description: Exec specifies the action to take.
@@ -2026,11 +2885,6 @@ spec:
                               description: Command is the command line to execute
                                 inside the container, the working directory for the
                                 command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -2050,10 +2904,8 @@ spec:
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                               type: string
                           required:
                           - port
@@ -2143,19 +2995,7 @@ spec:
                           type: object
                         terminationGracePeriodSeconds:
                           description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
@@ -2193,8 +3033,7 @@ spec:
                           description: "Claims lists the names of resources, defined
                             in spec.resourceClaims, that are used by this container.
                             \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
+                            feature gate."
                           items:
                             description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
@@ -2228,27 +3067,25 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
+                    restartPolicy:
+                      description: RestartPolicy defines the restart behavior of individual
+                        containers in a pod. This field may only be set for init containers,
+                        and the only allowed value is "Always".
+                      type: string
                     securityContext:
-                      description: 'SecurityContext defines the security options the
+                      description: SecurityContext defines the security options the
                         container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        override the equivalent fields of PodSecurityContext.
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
+                          description: AllowPrivilegeEscalation controls whether a
+                            process can gain more privileges than its parent process.
                             This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
+                            be set on the container process.
                           type: boolean
                         capabilities:
                           description: The capabilities to add/drop when running containers.
@@ -2281,9 +3118,7 @@ spec:
                           description: procMount denotes the type of proc mount to
                             use for the containers. The default is DefaultProcMount
                             which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled. Note that this field cannot
-                            be set when spec.os.name is windows.
+                            paths and masked paths.
                           type: string
                         readOnlyRootFilesystem:
                           description: Whether this container has a read-only root
@@ -2293,39 +3128,24 @@ spec:
                         runAsGroup:
                           description: The GID to run the entrypoint of the container
                             process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
+                            in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
                           description: Indicates that the container must run as a
-                            non-root user. If true, the Kubelet will validate the
-                            image at runtime to ensure that it does not run as UID
-                            0 (root) and fail to start the container if it does. If
-                            unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
+                            non-root user.
                           type: boolean
                         runAsUser:
                           description: The UID to run the entrypoint of the container
                             process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence. Note
-                            that this field cannot be set when spec.os.name is windows.
+                            if unspecified. May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         seLinuxOptions:
                           description: The SELinux context to be applied to the container.
                             If unspecified, the container runtime will allocate a
                             random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
+                            set in PodSecurityContext.
                           properties:
                             level:
                               description: Level is SELinux level label that applies
@@ -2348,24 +3168,17 @@ spec:
                           description: The seccomp options to use by this container.
                             If seccomp options are provided at both the pod & container
                             level, the container options override the pod options.
-                            Note that this field cannot be set when spec.os.name is
-                            windows.
                           properties:
                             localhostProfile:
                               description: localhostProfile indicates a profile defined
                                 in a file on the node should be used. The profile
-                                must be preconfigured on the node to work. Must be
-                                a descending path, relative to the kubelet's configured
-                                seccomp profile location. Must only be set if type
-                                is "Localhost".
+                                must be preconfigured on the node to work.
                               type: string
                             type:
                               description: "type indicates which kind of seccomp profile
                                 will be applied. Valid options are: \n Localhost -
                                 a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
+                                used."
                               type: string
                           required:
                           - type
@@ -2373,10 +3186,7 @@ spec:
                         windowsOptions:
                           description: The Windows specific settings applied to all
                             containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is
-                            linux.
+                            will be used.
                           properties:
                             gmsaCredentialSpec:
                               description: GMSACredentialSpec is where the GMSA admission
@@ -2390,36 +3200,20 @@ spec:
                               type: string
                             hostProcess:
                               description: HostProcess determines if a container should
-                                be run as a 'Host Process' container. This field is
-                                alpha-level and will only be honored by components
-                                that enable the WindowsHostProcessContainers feature
-                                flag. Setting this field without the feature flag
-                                will result in errors when validating the Pod. All
-                                of a Pod's containers must have the same effective
-                                HostProcess value (it is not allowed to have a mix
-                                of HostProcess containers and non-HostProcess containers).  In
-                                addition, if HostProcess is true then HostNetwork
-                                must also be set to true.
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
                               description: The UserName in Windows to run the entrypoint
                                 of the container process. Defaults to the user specified
                                 in image metadata if unspecified. May also be set
-                                in PodSecurityContext. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                in PodSecurityContext.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully
+                      description: StartupProbe indicates that the Pod has successfully
                         initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        this completes successfully.
                       properties:
                         exec:
                           description: Exec specifies the action to take.
@@ -2428,11 +3222,6 @@ spec:
                               description: Command is the command line to execute
                                 inside the container, the working directory for the
                                 command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -2452,10 +3241,8 @@ spec:
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                              description: Service is the name of the service to place
+                                in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                               type: string
                           required:
                           - port
@@ -2545,19 +3332,7 @@ spec:
                           type: object
                         terminationGracePeriodSeconds:
                           description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
@@ -2577,32 +3352,18 @@ spec:
                       description: Whether the container runtime should close the
                         stdin channel after it has been opened by a single attach.
                         When stdin is true the stdin stream will remain open across
-                        multiple attach sessions. If stdinOnce is set to true, stdin
-                        is opened on container start, is empty until the first client
-                        attaches to stdin, and then remains open and accepts data
-                        until the client disconnects, at which time stdin is closed
-                        and remains closed until the container is restarted. If this
-                        flag is false, a container processes that reads from stdin
-                        will never receive an EOF. Default is false
+                        multiple attach sessions.
                       type: boolean
                     terminationMessagePath:
                       description: 'Optional: Path at which the file to which the
                         container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        into the container''s filesystem.'
                       type: string
                     terminationMessagePolicy:
                       description: Indicate how the termination message should be
                         populated. File will use the contents of terminationMessagePath
                         to populate the container status message on both success and
-                        failure. FallbackToLogsOnError will use the last chunk of
-                        container log output if the termination message file is empty
-                        and the container exited with an error. The log output is
-                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                        to File. Cannot be updated.
+                        failure.
                       type: string
                     tty:
                       description: Whether this container should allocate a TTY for
@@ -2658,11 +3419,7 @@ spec:
                             type: string
                           subPathExpr:
                             description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -2683,11 +3440,9 @@ spec:
                   to container lifecycle events. Cannot be updated.
                 properties:
                   postStart:
-                    description: 'PostStart is called immediately after a container
+                    description: PostStart is called immediately after a container
                       is created. If the handler fails, the container is terminated
-                      and restarted according to its restart policy. Other management
-                      of the container blocks until the hook completes. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      and restarted according to its restart policy.
                     properties:
                       exec:
                         description: Exec specifies the action to take.
@@ -2695,12 +3450,7 @@ spec:
                           command:
                             description: Command is the command line to execute inside
                               the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
+                              root ('/') in the container's filesystem.
                             items:
                               type: string
                             type: array
@@ -2753,9 +3503,7 @@ spec:
                         type: object
                       tcpSocket:
                         description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                          and kept for the backward compatibility. There are no validation
-                          of this field and lifecycle hooks will fail in runtime when
-                          tcp handler is specified.
+                          and kept for the backward compatibility.
                         properties:
                           host:
                             description: 'Optional: Host name to connect to, defaults
@@ -2774,17 +3522,10 @@ spec:
                         type: object
                     type: object
                   preStop:
-                    description: 'PreStop is called immediately before a container
+                    description: PreStop is called immediately before a container
                       is terminated due to an API request or management event such
                       as liveness/startup probe failure, preemption, resource contention,
-                      etc. The handler is not called if the container crashes or exits.
-                      The Pod''s termination grace period countdown begins before
-                      the PreStop hook is executed. Regardless of the outcome of the
-                      handler, the container will eventually terminate within the
-                      Pod''s termination grace period (unless delayed by finalizers).
-                      Other management of the container blocks until the hook completes
-                      or until the termination grace period is reached. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      etc.
                     properties:
                       exec:
                         description: Exec specifies the action to take.
@@ -2792,12 +3533,7 @@ spec:
                           command:
                             description: Command is the command line to execute inside
                               the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
+                              root ('/') in the container's filesystem.
                             items:
                               type: string
                             type: array
@@ -2850,9 +3586,7 @@ spec:
                         type: object
                       tcpSocket:
                         description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                          and kept for the backward compatibility. There are no validation
-                          of this field and lifecycle hooks will fail in runtime when
-                          tcp handler is specified.
+                          and kept for the backward compatibility.
                         properties:
                           host:
                             description: 'Optional: Host name to connect to, defaults
@@ -2874,8 +3608,7 @@ spec:
               livenessProbe:
                 description: Liveness config for the OpenTelemetry Collector except
                   the probe handler which is auto generated from the health extension
-                  of the collector. It is only effective when healthcheckextension
-                  is configured in the OpenTelemetry Collector pipeline.
+                  of the collector.
                 properties:
                   failureThreshold:
                     description: Minimum consecutive failures for the probe to be
@@ -2886,7 +3619,7 @@ spec:
                   initialDelaySeconds:
                     description: 'Number of seconds after the container has started
                       before liveness probes are initiated. Defaults to 0 seconds.
-                      Minimum value is 0. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      Minimum value is 0. More info: https://kubernetes.'
                     format: int32
                     type: integer
                   periodSeconds:
@@ -2902,18 +3635,7 @@ spec:
                     type: integer
                   terminationGracePeriodSeconds:
                     description: Optional duration in seconds the pod needs to terminate
-                      gracefully upon probe failure. The grace period is the duration
-                      in seconds after the processes running in the pod are sent a
-                      termination signal and the time when the processes are forcibly
-                      halted with a kill signal. Set this value longer than the expected
-                      cleanup time for your process. If this value is nil, the pod's
-                      terminationGracePeriodSeconds will be used. Otherwise, this
-                      value overrides the value provided by the pod spec. Value must
-                      be non-negative integer. The value zero indicates stop immediately
-                      via the kill signal (no opportunity to shut down). This is a
-                      beta field and requires enabling ProbeTerminationGracePeriod
-                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                      is used if unset.
+                      gracefully upon probe failure.
                     format: int64
                     type: integer
                   timeoutSeconds:
@@ -2980,64 +3702,39 @@ spec:
               podSecurityContext:
                 description: PodSecurityContext holds pod-level security attributes
                   and common container settings. Some fields are also present in container.securityContext.  Field
-                  values of container.securityContext take precedence over field values
-                  of PodSecurityContext.
+                  values of container.
                 properties:
                   fsGroup:
                     description: "A special supplemental group that applies to all
                       containers in a pod. Some volume types allow the Kubelet to
                       change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
+                      \n 1."
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
+                    description: fsGroupChangePolicy defines behavior of changing
                       ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                      inside Pod.
                     type: string
                   runAsGroup:
                     description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      Uses runtime default if unset. May also be set in SecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
                     description: Indicates that the container must run as a non-root
-                      user. If true, the Kubelet will validate the image at runtime
-                      to ensure that it does not run as UID 0 (root) and fail to start
-                      the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
+                      user.
                     type: boolean
                   runAsUser:
                     description: The UID to run the entrypoint of the container process.
                       Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
-                      and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
+                      May also be set in SecurityContext.
                     format: int64
                     type: integer
                   seLinuxOptions:
                     description: The SELinux context to be applied to all containers.
                       If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
+                      SELinux context for each container.  May also be set in SecurityContext.
                     properties:
                       level:
                         description: Level is SELinux level label that applies to
@@ -3064,16 +3761,12 @@ spec:
                       localhostProfile:
                         description: localhostProfile indicates a profile defined
                           in a file on the node should be used. The profile must be
-                          preconfigured on the node to work. Must be a descending
-                          path, relative to the kubelet's configured seccomp profile
-                          location. Must only be set if type is "Localhost".
+                          preconfigured on the node to work.
                         type: string
                       type:
                         description: "type indicates which kind of seccomp profile
                           will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          defined in a file on the node should be used."
                         type: string
                     required:
                     - type
@@ -3082,12 +3775,7 @@ spec:
                     description: A list of groups applied to the first process run
                       in each container, in addition to the container's primary GID,
                       the fsGroup (if specified), and group memberships defined in
-                      the container image for the uid of the container process. If
-                      unspecified, no additional groups are added to any container.
-                      Note that group memberships defined in the container image for
-                      the uid of the container process are still effective, even if
-                      they are not included in this list. Note that this field cannot
-                      be set when spec.os.name is windows.
+                      the container image for th
                     items:
                       format: int64
                       type: integer
@@ -3096,7 +3784,7 @@ spec:
                     description: Sysctls hold a list of namespaced sysctls used for
                       the pod. Pods with unsupported sysctls (by the container runtime)
                       might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
+                      spec.os.
                     items:
                       description: Sysctl defines a kernel parameter to be set
                       properties:
@@ -3114,9 +3802,7 @@ spec:
                   windowsOptions:
                     description: The Windows specific settings applied to all containers.
                       If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
-                      the value specified in SecurityContext takes precedence. Note
-                      that this field cannot be set when spec.os.name is linux.
+                      will be used.
                     properties:
                       gmsaCredentialSpec:
                         description: GMSACredentialSpec is where the GMSA admission
@@ -3130,57 +3816,37 @@ spec:
                         type: string
                       hostProcess:
                         description: HostProcess determines if a container should
-                          be run as a 'Host Process' container. This field is alpha-level
-                          and will only be honored by components that enable the WindowsHostProcessContainers
-                          feature flag. Setting this field without the feature flag
-                          will result in errors when validating the Pod. All of a
-                          Pod's containers must have the same effective HostProcess
-                          value (it is not allowed to have a mix of HostProcess containers
-                          and non-HostProcess containers).  In addition, if HostProcess
-                          is true then HostNetwork must also be set to true.
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
                         description: The UserName in Windows to run the entrypoint
                           of the container process. Defaults to the user specified
                           in image metadata if unspecified. May also be set in PodSecurityContext.
-                          If set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               ports:
                 description: Ports allows a set of ports to be exposed by the underlying
                   v1.Service. By default, the operator will attempt to infer the required
-                  ports by parsing the .Spec.Config property but this property can
-                  be used to open additional ports that can't be inferred by the operator,
-                  like for custom receivers.
+                  ports by parsing the .Spec.
                 items:
                   description: ServicePort contains information on service's port.
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field
-                        follows standard Kubernetes label syntax. Un-prefixed names
-                        are reserved for IANA standard service names (as per RFC-6335
-                        and https://www.iana.org/assignments/service-names). Non-standard
-                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      description: The application protocol for this port. This is
+                        used as a hint for implementations to offer richer behavior
+                        for protocols that they understand. This field follows standard
+                        Kubernetes label syntax.
                       type: string
                     name:
                       description: The name of this port within the service. This
                         must be a DNS_LABEL. All ports within a ServiceSpec must have
-                        unique names. When considering the endpoints for a Service,
-                        this must match the 'name' field in the EndpointPort. Optional
-                        if only one ServicePort is defined on this service.
+                        unique names.
                       type: string
                     nodePort:
-                      description: 'The port on each node on which this service is
+                      description: The port on each node on which this service is
                         exposed when type is NodePort or LoadBalancer.  Usually assigned
-                        by the system. If a value is specified, in-range, and not
-                        in use it will be used, otherwise the operation will fail.  If
-                        not specified, a port will be allocated if this Service requires
-                        one.  If this field is specified when creating a Service which
-                        does not need it, creation will fail. This field will be wiped
-                        when updating a Service to no longer need it (e.g. changing
-                        type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                        by the system.
                       format: int32
                       type: integer
                     port:
@@ -3196,14 +3862,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: 'Number or name of the port to access on the pods
+                      description: Number or name of the port to access on the pods
                         targeted by the service. Number must be in the range 1 to
-                        65535. Name must be an IANA_SVC_NAME. If this is a string,
-                        it will be looked up as a named port in the target Pod''s
-                        container ports. If this is not specified, the value of the
-                        ''port'' field is used (an identity map). This field is ignored
-                        for services with clusterIP=None, and should be omitted or
-                        set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                        65535. Name must be an IANA_SVC_NAME.
                       x-kubernetes-int-or-string: true
                   required:
                   - port
@@ -3226,8 +3887,7 @@ spec:
                     description: "Claims lists the names of resources, defined in
                       spec.resourceClaims, that are used by this container. \n This
                       is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      feature gate."
                     items:
                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
@@ -3260,11 +3920,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    description: Requests describes the minimum amount of compute
+                      resources required.
                     type: object
                 type: object
               securityContext:
@@ -3272,12 +3929,10 @@ spec:
                   context.
                 properties:
                   allowPrivilegeEscalation:
-                    description: 'AllowPrivilegeEscalation controls whether a process
+                    description: AllowPrivilegeEscalation controls whether a process
                       can gain more privileges than its parent process. This bool
                       directly controls if the no_new_privs flag will be set on the
-                      container process. AllowPrivilegeEscalation is true always when
-                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-                      Note that this field cannot be set when spec.os.name is windows.'
+                      container process.
                     type: boolean
                   capabilities:
                     description: The capabilities to add/drop when running containers.
@@ -3308,8 +3963,6 @@ spec:
                     description: procMount denotes the type of proc mount to use for
                       the containers. The default is DefaultProcMount which uses the
                       container runtime defaults for readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
-                      Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
                     description: Whether this container has a read-only root filesystem.
@@ -3318,37 +3971,23 @@ spec:
                     type: boolean
                   runAsGroup:
                     description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence. Note that this
-                      field cannot be set when spec.os.name is windows.
+                      Uses runtime default if unset. May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
                     description: Indicates that the container must run as a non-root
-                      user. If true, the Kubelet will validate the image at runtime
-                      to ensure that it does not run as UID 0 (root) and fail to start
-                      the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in PodSecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence.
+                      user.
                     type: boolean
                   runAsUser:
                     description: The UID to run the entrypoint of the container process.
                       Defaults to user specified in image metadata if unspecified.
-                      May also be set in PodSecurityContext.  If set in both SecurityContext
-                      and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence. Note that this field cannot be set when spec.os.name
-                      is windows.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   seLinuxOptions:
                     description: The SELinux context to be applied to the container.
                       If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in PodSecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence. Note that this
-                      field cannot be set when spec.os.name is windows.
+                      SELinux context for each container.  May also be set in PodSecurityContext.
                     properties:
                       level:
                         description: Level is SELinux level label that applies to
@@ -3370,22 +4009,17 @@ spec:
                   seccompProfile:
                     description: The seccomp options to use by this container. If
                       seccomp options are provided at both the pod & container level,
-                      the container options override the pod options. Note that this
-                      field cannot be set when spec.os.name is windows.
+                      the container options override the pod options.
                     properties:
                       localhostProfile:
                         description: localhostProfile indicates a profile defined
                           in a file on the node should be used. The profile must be
-                          preconfigured on the node to work. Must be a descending
-                          path, relative to the kubelet's configured seccomp profile
-                          location. Must only be set if type is "Localhost".
+                          preconfigured on the node to work.
                         type: string
                       type:
                         description: "type indicates which kind of seccomp profile
                           will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          defined in a file on the node should be used."
                         type: string
                     required:
                     - type
@@ -3393,9 +4027,7 @@ spec:
                   windowsOptions:
                     description: The Windows specific settings applied to all containers.
                       If unspecified, the options from the PodSecurityContext will
-                      be used. If set in both SecurityContext and PodSecurityContext,
-                      the value specified in SecurityContext takes precedence. Note
-                      that this field cannot be set when spec.os.name is linux.
+                      be used.
                     properties:
                       gmsaCredentialSpec:
                         description: GMSACredentialSpec is where the GMSA admission
@@ -3409,21 +4041,12 @@ spec:
                         type: string
                       hostProcess:
                         description: HostProcess determines if a container should
-                          be run as a 'Host Process' container. This field is alpha-level
-                          and will only be honored by components that enable the WindowsHostProcessContainers
-                          feature flag. Setting this field without the feature flag
-                          will result in errors when validating the Pod. All of a
-                          Pod's containers must have the same effective HostProcess
-                          value (it is not allowed to have a mix of HostProcess containers
-                          and non-HostProcess containers).  In addition, if HostProcess
-                          is true then HostNetwork must also be set to true.
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
                         description: The UserName in Windows to run the entrypoint
                           of the container process. Defaults to the user specified
                           in image metadata if unspecified. May also be set in PodSecurityContext.
-                          If set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
@@ -3462,15 +4085,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -3499,8 +4116,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -3518,7 +4134,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -3569,7 +4185,6 @@ spec:
                     description: FilterStrategy determines how to filter targets before
                       allocating them among the collectors. The only current option
                       is relabel-config (drops targets based on prom relabel_config).
-                      Filtering is disabled by default.
                     type: string
                   image:
                     description: Image indicates the container image to use for the
@@ -3584,9 +4199,7 @@ spec:
                   prometheusCR:
                     description: PrometheusCR defines the configuration for the retrieval
                       of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.com/v1
-                      and podmonitor.monitoring.coreos.com/v1 )  retrieval. All CR
-                      instances which the ServiceAccount has access to will be retrieved.
-                      This includes other namespaces.
+                      and podmonitor.monitoring.coreos.com/v1 )  retrieval.
                     properties:
                       enabled:
                         description: Enabled indicates whether to use a PrometheusOperator
@@ -3598,7 +4211,7 @@ spec:
                         description: PodMonitors to be selected for target discovery.
                           This is a map of {key,value} pairs. Each {key,value} in
                           the map is going to exactly match a label in a PodMonitor's
-                          meta labels. The requirements are ANDed.
+                          meta labels.
                         type: object
                       scrapeInterval:
                         default: 30s
@@ -3612,15 +4225,13 @@ spec:
                         description: ServiceMonitors to be selected for target discovery.
                           This is a map of {key,value} pairs. Each {key,value} in
                           the map is going to exactly match a label in a ServiceMonitor's
-                          meta labels. The requirements are ANDed.
+                          meta labels.
                         type: object
                     type: object
                   replicas:
                     description: Replicas is the number of pod instances for the underlying
                       TargetAllocator. This should only be set to a value other than
                       1 if a strategy that allows for high availability is chosen.
-                      Currently, the only allocation strategy that can be run in a
-                      high availability mode is consistent-hashing.
                     format: int32
                     type: integer
                   resources:
@@ -3631,8 +4242,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -3666,11 +4276,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   serviceAccount:
@@ -3682,7 +4289,7 @@ spec:
                     description: TopologySpreadConstraints embedded kubernetes pod
                       configuration option, controls how pods are spread across your
                       cluster among failure-domains such as regions, zones, nodes,
-                      and other user-defined topology domains https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+                      and other user-defined top
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         matching pods among the given topology.
@@ -3714,8 +4321,6 @@ spec:
                                       If the operator is In or NotIn, the values array
                                       must be non-empty. If the operator is Exists
                                       or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -3728,131 +4333,44 @@ spec:
                               additionalProperties:
                                 type: string
                               description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: "MatchLabelKeys is a set of pod label keys
-                            to select the pods over which spreading will be calculated.
-                            The keys are used to lookup values from the incoming pod
-                            labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading
-                            will be calculated for the incoming pod. The same key
-                            is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                            MatchLabelKeys cannot be set when LabelSelector isn't
-                            set. Keys that don't exist in the incoming pod labels
-                            will be ignored. A null or empty list means only match
-                            against labelSelector. \n This is a beta field and requires
-                            the MatchLabelKeysInPodTopologySpread feature gate to
-                            be enabled (enabled by default)."
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: 'MaxSkew describes the degree to which pods
-                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                            it is the maximum permitted difference between the number
-                            of matching pods in the target topology and the global
-                            minimum. The global minimum is the minimum number of matching
-                            pods in an eligible domain or zero if the number of eligible
-                            domains is less than MinDomains. For example, in a 3-zone
-                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                            spread as 2/2/1: In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
-                            if MaxSkew is 1, incoming pod can only be scheduled to
-                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(3-1) on zone1(zone2) violate
-                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
-                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                            it is used to give higher precedence to topologies that
-                            satisfy it. It''s a required field. Default value is 1
-                            and 0 is not allowed.'
+                          description: MaxSkew describes the degree to which pods
+                            may be unevenly distributed.
                           format: int32
                           type: integer
                         minDomains:
-                          description: "MinDomains indicates a minimum number of eligible
-                            domains. When the number of eligible domains with matching
-                            topology keys is less than minDomains, Pod Topology Spread
-                            treats \"global minimum\" as 0, and then the calculation
-                            of Skew is performed. And when the number of eligible
-                            domains with matching topology keys equals or greater
-                            than minDomains, this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less
-                            than minDomains, scheduler won't schedule more than maxSkew
-                            Pods to those domains. If value is nil, the constraint
-                            behaves as if MinDomains is equal to 1. Valid values are
-                            integers greater than 0. When value is not nil, WhenUnsatisfiable
-                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
-                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
-                            the same labelSelector spread as 2/2/2: | zone1 | zone2
-                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
-                            is less than 5(MinDomains), so \"global minimum\" is treated
-                            as 0. In this situation, new pod with the same labelSelector
-                            cannot be scheduled, because computed skew will be 3(3
-                            - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is a beta field and requires
-                            the MinDomainsInPodTopologySpread feature gate to be enabled
-                            (enabled by default)."
+                          description: MinDomains indicates a minimum number of eligible
+                            domains.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: "NodeAffinityPolicy indicates how we will treat
+                          description: NodeAffinityPolicy indicates how we will treat
                             Pod's nodeAffinity/nodeSelector when calculating pod topology
-                            spread skew. Options are: - Honor: only nodes matching
-                            nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
-                            are included in the calculations. \n If this value is
-                            nil, the behavior is equivalent to the Honor policy. This
-                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
-                            feature flag."
+                            spread skew.
                           type: string
                         nodeTaintsPolicy:
-                          description: "NodeTaintsPolicy indicates how we will treat
+                          description: NodeTaintsPolicy indicates how we will treat
                             node taints when calculating pod topology spread skew.
-                            Options are: - Honor: nodes without taints, along with
-                            tainted nodes for which the incoming pod has a toleration,
-                            are included. - Ignore: node taints are ignored. All nodes
-                            are included. \n If this value is nil, the behavior is
-                            equivalent to the Ignore policy. This is a beta-level
-                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
-                            feature flag."
                           type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
-                            considered to be in the same topology. We consider each
-                            <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. We define a domain as a particular
-                            instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
-                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                            each Node is a domain of that topology. And, if TopologyKey
-                            is "topology.kubernetes.io/zone", each zone is a domain
-                            of that topology. It's a required field.
+                            considered to be in the same topology.
                           type: string
                         whenUnsatisfiable:
-                          description: 'WhenUnsatisfiable indicates how to deal with
-                            a pod if it doesn''t satisfy the spread constraint. -
-                            DoNotSchedule (default) tells the scheduler not to schedule
-                            it. - ScheduleAnyway tells the scheduler to schedule the
-                            pod in any location, but giving higher precedence to topologies
-                            that would help reduce the skew. A constraint is considered
-                            "Unsatisfiable" for an incoming pod if and only if every
-                            possible node assignment for that pod would violate "MaxSkew"
-                            on some topology. For example, in a 3-zone cluster, MaxSkew
-                            is set to 1, and pods with the same labelSelector spread
-                            as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                            If WhenUnsatisfiable is set to DoNotSchedule, incoming
-                            pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                            as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1).
-                            In other words, the cluster can still be imbalanced, but
-                            scheduler won''t make it *more* imbalanced. It''s a required
-                            field.'
+                          description: WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn't satisfy the spread constraint. - DoNotSchedule
+                            (default) tells the scheduler not to schedule it.
                           type: string
                       required:
                       - maxSkew
@@ -3889,16 +4407,11 @@ spec:
                     operator:
                       description: Operator represents a key's relationship to the
                         value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
                       description: TolerationSeconds represents the period of time
                         the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                        this field is ignored) tolerates the taint.
                       format: int64
                       type: integer
                     value:
@@ -3911,9 +4424,7 @@ spec:
               topologySpreadConstraints:
                 description: TopologySpreadConstraints embedded kubernetes pod configuration
                   option, controls how pods are spread across your cluster among failure-domains
-                  such as regions, zones, nodes, and other user-defined topology domains
-                  https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
-                  This is only relevant to statefulset, and deployment mode
+                  such as regions, zones, nodes, and other user-defined top
                 items:
                   description: TopologySpreadConstraint specifies how to spread matching
                     pods among the given topology.
@@ -3944,8 +4455,7 @@ spec:
                                 description: values is an array of string values.
                                   If the operator is In or NotIn, the values array
                                   must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                  DoesNotExist, the values array must be empty.
                                 items:
                                   type: string
                                 type: array
@@ -3958,125 +4468,44 @@ spec:
                           additionalProperties:
                             type: string
                           description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: "MatchLabelKeys is a set of pod label keys to select
-                        the pods over which spreading will be calculated. The keys
-                        are used to lookup values from the incoming pod labels, those
-                        key-value labels are ANDed with labelSelector to select the
-                        group of existing pods over which spreading will be calculated
-                        for the incoming pod. The same key is forbidden to exist in
-                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
-                        be set when LabelSelector isn't set. Keys that don't exist
-                        in the incoming pod labels will be ignored. A null or empty
-                        list means only match against labelSelector. \n This is a
-                        beta field and requires the MatchLabelKeysInPodTopologySpread
-                        feature gate to be enabled (enabled by default)."
+                      description: MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: 'MaxSkew describes the degree to which pods may
-                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                        it is the maximum permitted difference between the number
-                        of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods
-                        in an eligible domain or zero if the number of eligible domains
-                        is less than MinDomains. For example, in a 3-zone cluster,
-                        MaxSkew is set to 1, and pods with the same labelSelector
-                        spread as 2/2/1: In this case, the global minimum is 1. |
-                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                        is 1, incoming pod can only be scheduled to zone3 to become
-                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                        it is used to give higher precedence to topologies that satisfy
-                        it. It''s a required field. Default value is 1 and 0 is not
-                        allowed.'
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
                       format: int32
                       type: integer
                     minDomains:
-                      description: "MinDomains indicates a minimum number of eligible
-                        domains. When the number of eligible domains with matching
-                        topology keys is less than minDomains, Pod Topology Spread
-                        treats \"global minimum\" as 0, and then the calculation of
-                        Skew is performed. And when the number of eligible domains
-                        with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling. As a result, when
-                        the number of eligible domains is less than minDomains, scheduler
-                        won't schedule more than maxSkew Pods to those domains. If
-                        value is nil, the constraint behaves as if MinDomains is equal
-                        to 1. Valid values are integers greater than 0. When value
-                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                        is set to 5 and pods with the same labelSelector spread as
-                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so \"global
-                        minimum\" is treated as 0. In this situation, new pod with
-                        the same labelSelector cannot be scheduled, because computed
-                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is a beta field
-                        and requires the MinDomainsInPodTopologySpread feature gate
-                        to be enabled (enabled by default)."
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: "NodeAffinityPolicy indicates how we will treat
+                      description: NodeAffinityPolicy indicates how we will treat
                         Pod's nodeAffinity/nodeSelector when calculating pod topology
-                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                        are ignored. All nodes are included in the calculations. \n
-                        If this value is nil, the behavior is equivalent to the Honor
-                        policy. This is a beta-level feature default enabled by the
-                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                        spread skew.
                       type: string
                     nodeTaintsPolicy:
-                      description: "NodeTaintsPolicy indicates how we will treat node
-                        taints when calculating pod topology spread skew. Options
-                        are: - Honor: nodes without taints, along with tainted nodes
-                        for which the incoming pod has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-                        \n If this value is nil, the behavior is equivalent to the
-                        Ignore policy. This is a beta-level feature default enabled
-                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                      description: NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew.
                       type: string
                     topologyKey:
                       description: TopologyKey is the key of node labels. Nodes that
                         have a label with this key and identical values are considered
-                        to be in the same topology. We consider each <key, value>
-                        as a "bucket", and try to put balanced number of pods into
-                        each bucket. We define a domain as a particular instance of
-                        a topology. Also, we define an eligible domain as a domain
-                        whose nodes meet the requirements of nodeAffinityPolicy and
-                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                        each Node is a domain of that topology. And, if TopologyKey
-                        is "topology.kubernetes.io/zone", each zone is a domain of
-                        that topology. It's a required field.
+                        to be in the same topology.
                       type: string
                     whenUnsatisfiable:
-                      description: 'WhenUnsatisfiable indicates how to deal with a
-                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
-                        giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
-                        for that pod would violate "MaxSkew" on some topology. For
-                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                        set to DoNotSchedule, incoming pod can only be scheduled to
-                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                        can still be imbalanced, but scheduler won''t make it *more*
-                        imbalanced. It''s a required field.'
+                      description: WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn't satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it.
                       type: string
                   required:
                   - maxSkew
@@ -4099,16 +4528,15 @@ spec:
                     to a persistent volume
                   properties:
                     apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
+                      description: APIVersion defines the versioned schema of this
                         representation of an object. Servers should convert recognized
                         schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        values.
                       type: string
                     kind:
-                      description: 'Kind is a string value representing the REST resource
+                      description: Kind is a string value representing the REST resource
                         this object represents. Servers may infer this from the endpoint
                         the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
                     metadata:
                       description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
@@ -4142,16 +4570,7 @@ spec:
                           type: array
                         dataSource:
                           description: 'dataSource field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                            * An existing PVC (PersistentVolumeClaim) If the provisioner
-                            or an external controller can support the specified data
-                            source, it will create a new volume based on the contents
-                            of the specified data source. When the AnyVolumeDataSource
-                            feature gate is enabled, dataSource contents will be copied
-                            to dataSourceRef, and dataSourceRef contents will be copied
-                            to dataSource when dataSourceRef.namespace is not specified.
-                            If the namespace is specified, then dataSourceRef will
-                            not be copied to dataSource.'
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -4171,33 +4590,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         dataSourceRef:
-                          description: 'dataSourceRef specifies the object from which
+                          description: dataSourceRef specifies the object from which
                             to populate the volume with data, if a non-empty volume
-                            is desired. This may be any object from a non-empty API
-                            group (non core object) or a PersistentVolumeClaim object.
-                            When this field is specified, volume binding will only
-                            succeed if the type of the specified object matches some
-                            installed volume populator or dynamic provisioner. This
-                            field will replace the functionality of the dataSource
-                            field and as such if both fields are non-empty, they must
-                            have the same value. For backwards compatibility, when
-                            namespace isn''t specified in dataSourceRef, both fields
-                            (dataSource and dataSourceRef) will be set to the same
-                            value automatically if one of them is empty and the other
-                            is non-empty. When namespace is specified in dataSourceRef,
-                            dataSource isn''t set to the same value and must be empty.
-                            There are three important differences between dataSource
-                            and dataSourceRef: * While dataSource only allows two
-                            specific types of objects, dataSourceRef allows any non-core
-                            object, as well as PersistentVolumeClaim objects. * While
-                            dataSource ignores disallowed values (dropping them),
-                            dataSourceRef preserves all values, and generates an error
-                            if a disallowed value is specified. * While dataSource
-                            only allows local objects, dataSourceRef allows objects
-                            in any namespaces. (Beta) Using this field requires the
-                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
-                            Using the namespace field of dataSourceRef requires the
-                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                            is desired.
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -4214,31 +4609,21 @@ spec:
                             namespace:
                               description: Namespace is the namespace of resource
                                 being referenced Note that when a namespace is specified,
-                                a gateway.networking.k8s.io/ReferenceGrant object
-                                is required in the referent namespace to allow that
-                                namespace's owner to accept the reference. See the
-                                ReferenceGrant documentation for details. (Alpha)
-                                This field requires the CrossNamespaceVolumeDataSource
-                                feature gate to be enabled.
+                                a gateway.networking.k8s.
                               type: string
                           required:
                           - kind
                           - name
                           type: object
                         resources:
-                          description: 'resources represents the minimum resources
-                            the volume should have. If RecoverVolumeExpansionFailure
-                            feature is enabled users are allowed to specify resource
-                            requirements that are lower than previous value but must
-                            still be higher than capacity recorded in the status field
-                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          description: resources represents the minimum resources
+                            the volume should have.
                           properties:
                             claims:
                               description: "Claims lists the names of resources, defined
                                 in spec.resourceClaims, that are used by this container.
                                 \n This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate. \n This field
-                                is immutable. It can only be set for containers."
+                                DynamicResourceAllocation feature gate."
                               items:
                                 description: ResourceClaim references one entry in
                                   PodSpec.ResourceClaims.
@@ -4273,11 +4658,8 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: Requests describes the minimum amount of
+                                compute resources required.
                               type: object
                           type: object
                         selector:
@@ -4306,8 +4688,6 @@ spec:
                                       If the operator is In or NotIn, the values array
                                       must be non-empty. If the operator is Exists
                                       or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -4320,10 +4700,6 @@ spec:
                               additionalProperties:
                                 type: string
                               description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -4351,6 +4727,18 @@ spec:
                           items:
                             type: string
                           type: array
+                        allocatedResourceStatuses:
+                          additionalProperties:
+                            description: When a controller receives persistentvolume
+                              claim update with ClaimResourceStatus for a resource
+                              that it does not recognizes, then it should ignore that
+                              update and let other controllers handle it.
+                            type: string
+                          description: allocatedResourceStatuses stores status of
+                            resource being resized for the given PVC. Key names follow
+                            standard Kubernetes label syntax.
+                          type: object
+                          x-kubernetes-map-type: granular
                         allocatedResources:
                           additionalProperties:
                             anyOf:
@@ -4358,18 +4746,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: allocatedResources is the storage resource
-                            within AllocatedResources tracks the capacity allocated
-                            to a PVC. It may be larger than the actual capacity when
-                            a volume expansion operation is requested. For storage
-                            quota, the larger value from allocatedResources and PVC.spec.resources
-                            is used. If allocatedResources is not set, PVC.spec.resources
-                            alone is used for quota calculation. If a volume expansion
-                            capacity request is lowered, allocatedResources is only
-                            lowered if there are no expansion operations in progress
-                            and if the actual volume capacity is equal or lower than
-                            the requested capacity. This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature.
+                          description: allocatedResources tracks the resources allocated
+                            to a PVC including its capacity. Key names follow standard
+                            Kubernetes label syntax.
                           type: object
                         capacity:
                           additionalProperties:
@@ -4406,9 +4785,7 @@ spec:
                               reason:
                                 description: reason is a unique, this should be a
                                   short, machine understandable string that gives
-                                  the reason for condition's last transition. If it
-                                  reports "ResizeStarted" that means the underlying
-                                  persistent volume is being resized.
+                                  the reason for condition's last transition.
                                 type: string
                               status:
                                 type: string
@@ -4423,13 +4800,6 @@ spec:
                           type: array
                         phase:
                           description: phase represents the current phase of PersistentVolumeClaim.
-                          type: string
-                        resizeStatus:
-                          description: resizeStatus stores status of resize operation.
-                            ResizeStatus is not set by default but when expansion
-                            is complete resizeStatus is set to empty string by resize
-                            controller or kubelet. This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature.
                           type: string
                       type: object
                   type: object
@@ -4465,10 +4835,7 @@ spec:
                       type: string
                     subPathExpr:
                       description: Expanded path within the volume from which the
-                        container's volume should be mounted. Behaves similarly to
-                        SubPath but environment variable references $(VAR_NAME) are
-                        expanded using the container's environment. Defaults to ""
-                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                        container's volume should be mounted.
                       type: string
                   required:
                   - mountPath
@@ -4486,23 +4853,19 @@ spec:
                     awsElasticBlockStore:
                       description: 'awsElasticBlockStore represents an AWS Disk resource
                         that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        to the pod. More info: https://kubernetes.'
                       properties:
                         fsType:
                           description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            "ext4", "xfs", "ntfs".'
                           type: string
                         partition:
                           description: 'partition is the partition in the volume that
                             you want to mount. If omitted, the default is to mount
                             by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).'
+                            the partition as "1".'
                           format: int32
                           type: integer
                         readOnly:
@@ -4542,7 +4905,7 @@ spec:
                           description: 'kind expected values are Shared: multiple
                             blob disks per storage account  Dedicated: single blob
                             disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
+                            disk (only in managed availability set).'
                           type: string
                         readOnly:
                           description: readOnly Defaults to false (read/write). ReadOnly
@@ -4621,7 +4984,7 @@ spec:
                           description: 'fsType is the filesystem type to mount. Must
                             be a filesystem type supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
-                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            be "ext4" if unspecified.'
                           type: string
                         readOnly:
                           description: 'readOnly defaults to false (read/write). ReadOnly
@@ -4653,24 +5016,14 @@ spec:
                           description: 'defaultMode is optional: mode bits used to
                             set permissions on created files by default. Must be an
                             octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            0 and 511.'
                           format: int32
                           type: integer
                         items:
                           description: items if unspecified, each key-value pair in
                             the Data field of the referenced ConfigMap will be projected
                             into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
+                            is the value.
                           items:
                             description: Maps a string key to a path within a volume.
                             properties:
@@ -4681,12 +5034,7 @@ spec:
                                 description: 'mode is Optional: mode bits used to
                                   set permissions on this file. Must be an octal value
                                   between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  0 and 511.'
                                 format: int32
                                 type: integer
                               path:
@@ -4730,10 +5078,7 @@ spec:
                           description: nodePublishSecretRef is a reference to the
                             secret object containing sensitive information to pass
                             to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
+                            and NodeUnpublishVolume calls.
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -4762,14 +5107,7 @@ spec:
                         defaultMode:
                           description: 'Optional: mode bits to use on created files
                             by default. Must be a Optional: mode bits used to set
-                            permissions on created files by default. Must be an octal
-                            value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
@@ -4798,13 +5136,7 @@ spec:
                               mode:
                                 description: 'Optional: mode bits used to set permissions
                                   on this file, must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                  and 0777 or a decimal value between 0 and 511.'
                                 format: int32
                                 type: integer
                               path:
@@ -4849,64 +5181,29 @@ spec:
                         shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
-                          description: 'medium represents what type of storage medium
+                          description: medium represents what type of storage medium
                             should back this directory. The default is "" which means
-                            to use the node''s default medium. Must be an empty string
-                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            to use the node's default medium. Must be an empty string
+                            (default) or Memory.
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'sizeLimit is the total amount of local storage
+                          description: sizeLimit is the total amount of local storage
                             required for this EmptyDir volume. The size limit is also
-                            applicable for memory medium. The maximum usage on memory
-                            medium EmptyDir would be the minimum value between the
-                            SizeLimit specified here and the sum of memory limits
-                            of all containers in a pod. The default is nil which means
-                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            applicable for memory medium.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: "ephemeral represents a volume that is handled
-                        by a cluster storage driver. The volume's lifecycle is tied
-                        to the pod that defines it - it will be created before the
-                        pod starts, and deleted when the pod is removed. \n Use this
-                        if: a) the volume is only needed while the pod runs, b) features
-                        of normal volumes like restoring from snapshot or capacity
-                        tracking are needed, c) the storage driver is specified through
-                        a storage class, and d) the storage driver supports dynamic
-                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
-                        for more information on the connection between this volume
-                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                        or one of the vendor-specific APIs for volumes that persist
-                        for longer than the lifecycle of an individual pod. \n Use
-                        CSI for light-weight local ephemeral volumes if the CSI driver
-                        is meant to be used that way - see the documentation of the
-                        driver for more information. \n A pod can use both types of
-                        ephemeral volumes and persistent volumes at the same time."
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
                       properties:
                         volumeClaimTemplate:
-                          description: "Will be used to create a stand-alone PVC to
+                          description: Will be used to create a stand-alone PVC to
                             provision the volume. The pod in which this EphemeralVolumeSource
-                            is embedded will be the owner of the PVC, i.e. the PVC
-                            will be deleted together with the pod.  The name of the
-                            PVC will be `<pod name>-<volume name>` where `<volume
-                            name>` is the name from the `PodSpec.Volumes` array entry.
-                            Pod validation will reject the pod if the concatenated
-                            name is not valid for a PVC (for example, too long). \n
-                            An existing PVC with that name that is not owned by the
-                            pod will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC
-                            is meant to be used by the pod, the PVC has to updated
-                            with an owner reference to the pod once the pod exists.
-                            Normally this should not be necessary, but it may be useful
-                            when manually reconstructing a broken cluster. \n This
-                            field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created. \n Required, must
-                            not be nil."
+                            is embedded will be the owner of the PVC, i.e.
                           properties:
                             metadata:
                               description: May contain labels and annotations that
@@ -4933,8 +5230,7 @@ spec:
                             spec:
                               description: The specification for the PersistentVolumeClaim.
                                 The entire content is copied unchanged into the PVC
-                                that gets created from this template. The same fields
-                                as in a PersistentVolumeClaim are also valid here.
+                                that gets created from this template.
                               properties:
                                 accessModes:
                                   description: 'accessModes contains the desired access
@@ -4944,17 +5240,7 @@ spec:
                                   type: array
                                 dataSource:
                                   description: 'dataSource field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) If the
-                                    provisioner or an external controller can support
-                                    the specified data source, it will create a new
-                                    volume based on the contents of the specified
-                                    data source. When the AnyVolumeDataSource feature
-                                    gate is enabled, dataSource contents will be copied
-                                    to dataSourceRef, and dataSourceRef contents will
-                                    be copied to dataSource when dataSourceRef.namespace
-                                    is not specified. If the namespace is specified,
-                                    then dataSourceRef will not be copied to dataSource.'
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.'
                                   properties:
                                     apiGroup:
                                       description: APIGroup is the group for the resource
@@ -4977,38 +5263,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: 'dataSourceRef specifies the object
+                                  description: dataSourceRef specifies the object
                                     from which to populate the volume with data, if
-                                    a non-empty volume is desired. This may be any
-                                    object from a non-empty API group (non core object)
-                                    or a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
-                                    This field will replace the functionality of the
-                                    dataSource field and as such if both fields are
-                                    non-empty, they must have the same value. For
-                                    backwards compatibility, when namespace isn''t
-                                    specified in dataSourceRef, both fields (dataSource
-                                    and dataSourceRef) will be set to the same value
-                                    automatically if one of them is empty and the
-                                    other is non-empty. When namespace is specified
-                                    in dataSourceRef, dataSource isn''t set to the
-                                    same value and must be empty. There are three
-                                    important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types
-                                    of objects, dataSourceRef allows any non-core
-                                    object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping
-                                    them), dataSourceRef preserves all values, and
-                                    generates an error if a disallowed value is specified.
-                                    * While dataSource only allows local objects,
-                                    dataSourceRef allows objects in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource
-                                    feature gate to be enabled. (Alpha) Using the
-                                    namespace field of dataSourceRef requires the
-                                    CrossNamespaceVolumeDataSource feature gate to
-                                    be enabled.'
+                                    a non-empty volume is desired.
                                   properties:
                                     apiGroup:
                                       description: APIGroup is the group for the resource
@@ -5028,33 +5285,22 @@ spec:
                                     namespace:
                                       description: Namespace is the namespace of resource
                                         being referenced Note that when a namespace
-                                        is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                        object is required in the referent namespace
-                                        to allow that namespace's owner to accept
-                                        the reference. See the ReferenceGrant documentation
-                                        for details. (Alpha) This field requires the
-                                        CrossNamespaceVolumeDataSource feature gate
-                                        to be enabled.
+                                        is specified, a gateway.networking.k8s.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: 'resources represents the minimum resources
-                                    the volume should have. If RecoverVolumeExpansionFailure
-                                    feature is enabled users are allowed to specify
-                                    resource requirements that are lower than previous
-                                    value but must still be higher than capacity recorded
-                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  description: resources represents the minimum resources
+                                    the volume should have.
                                   properties:
                                     claims:
                                       description: "Claims lists the names of resources,
                                         defined in spec.resourceClaims, that are used
                                         by this container. \n This is an alpha field
                                         and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
+                                        feature gate."
                                       items:
                                         description: ResourceClaim references one
                                           entry in PodSpec.ResourceClaims.
@@ -5090,12 +5336,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 selector:
@@ -5127,9 +5369,7 @@ spec:
                                               values. If the operator is In or NotIn,
                                               the values array must be non-empty.
                                               If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                              the values array must be empty.
                                             items:
                                               type: string
                                             type: array
@@ -5142,11 +5382,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                       description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -5175,11 +5411,10 @@ spec:
                         pod.
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type to mount. Must
+                          description: fsType is the filesystem type to mount. Must
                             be a filesystem type supported by the host operating system.
                             Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. TODO: how do we prevent errors in the
-                            filesystem from compromising the machine'
+                            if unspecified.
                           type: string
                         lun:
                           description: 'lun is Optional: FC target lun number'
@@ -5231,9 +5466,7 @@ spec:
                           description: 'secretRef is Optional: secretRef is reference
                             to the secret object containing sensitive information
                             to pass to the plugin scripts. This may be empty if no
-                            secret object is specified. If the secret object contains
-                            more than one secret, all secrets are passed to the plugin
-                            scripts.'
+                            secret object is specified.'
                           properties:
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -5262,24 +5495,19 @@ spec:
                     gcePersistentDisk:
                       description: 'gcePersistentDisk represents a GCE Disk resource
                         that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        to the pod. More info: https://kubernetes.'
                       properties:
                         fsType:
                           description: 'fsType is filesystem type of the volume that
                             you want to mount. Tip: Ensure that the filesystem type
                             is supported by the host operating system. Examples: "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            "xfs", "ntfs".'
                           type: string
                         partition:
                           description: 'partition is the partition in the volume that
                             you want to mount. If omitted, the default is to mount
                             by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            the partition as "1".'
                           format: int32
                           type: integer
                         pdName:
@@ -5295,17 +5523,12 @@ spec:
                       type: object
                     gitRepo:
                       description: 'gitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
+                        revision. DEPRECATED: GitRepo is deprecated.'
                       properties:
                         directory:
                           description: directory is the target directory name. Must
                             not contain or start with '..'.  If '.' is supplied, the
-                            volume directory will be the git repository.  Otherwise,
-                            if specified, the volume will contain the git repository
-                            in the subdirectory with the given name.
+                            volume directory will be the git repository.
                           type: string
                         repository:
                           description: repository is the URL
@@ -5339,13 +5562,8 @@ spec:
                       - path
                       type: object
                     hostPath:
-                      description: 'hostPath represents a pre-existing file or directory
+                      description: hostPath represents a pre-existing file or directory
                         on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
                           description: 'path of the directory on the host. If the
@@ -5376,16 +5594,11 @@ spec:
                           description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            "ext4", "xfs", "ntfs".'
                           type: string
                         initiatorName:
                           description: initiatorName is the custom iSCSI Initiator
-                            Name. If initiatorName is specified with iscsiInterface
-                            simultaneously, new iSCSI interface <target portal>:<volume
-                            name> will be created for the connection.
+                            Name.
                           type: string
                         iqn:
                           description: iqn is the target iSCSI Qualified Name.
@@ -5457,7 +5670,7 @@ spec:
                     persistentVolumeClaim:
                       description: 'persistentVolumeClaimVolumeSource represents a
                         reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        More info: https://kubernetes.'
                       properties:
                         claimName:
                           description: 'claimName is the name of a PersistentVolumeClaim
@@ -5515,12 +5728,7 @@ spec:
                         defaultMode:
                           description: defaultMode are the mode bits used to set permissions
                             on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Directories within the path are
-                            not affected by this setting. This might be in conflict
-                            with other options that affect the file mode, like fsGroup,
-                            and the result can be other mode bits set.
+                            0000 and 0777 or a decimal value between 0 and 511.
                           format: int32
                           type: integer
                         sources:
@@ -5538,13 +5746,6 @@ spec:
                                       pair in the Data field of the referenced ConfigMap
                                       will be projected into the volume as a file
                                       whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -5557,13 +5758,7 @@ spec:
                                             used to set permissions on this file.
                                             Must be an octal value between 0000 and
                                             0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            511.'
                                           format: int32
                                           type: integer
                                         path:
@@ -5624,14 +5819,7 @@ spec:
                                           description: 'Optional: mode bits used to
                                             set permissions on this file, must be
                                             an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                            a decimal value between 0 and 511.'
                                           format: int32
                                           type: integer
                                         path:
@@ -5683,13 +5871,6 @@ spec:
                                       pair in the Data field of the referenced Secret
                                       will be projected into the volume as a file
                                       whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -5702,13 +5883,7 @@ spec:
                                             used to set permissions on this file.
                                             Must be an octal value between 0000 and
                                             0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            511.'
                                           format: int32
                                           type: integer
                                         path:
@@ -5744,19 +5919,14 @@ spec:
                                       of the token. A recipient of a token must identify
                                       itself with an identifier specified in the audience
                                       of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
+                                      token.
                                     type: string
                                   expirationSeconds:
                                     description: expirationSeconds is the requested
                                       duration of validity of the service account
                                       token. As the token approaches expiration, the
                                       kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
+                                      the service account token.
                                     format: int64
                                     type: integer
                                   path:
@@ -5814,10 +5984,7 @@ spec:
                           description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            "ext4", "xfs", "ntfs".'
                           type: string
                         image:
                           description: 'image is the rados image name. More info:
@@ -5927,24 +6094,14 @@ spec:
                           description: 'defaultMode is Optional: mode bits used to
                             set permissions on created files by default. Must be an
                             octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            0 and 511.'
                           format: int32
                           type: integer
                         items:
                           description: items If unspecified, each key-value pair in
                             the Data field of the referenced Secret will be projected
                             into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
+                            is the value.
                           items:
                             description: Maps a string key to a path within a volume.
                             properties:
@@ -5955,12 +6112,7 @@ spec:
                                 description: 'mode is Optional: mode bits used to
                                   set permissions on this file. Must be an octal value
                                   between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  0 and 511.'
                                 format: int32
                                 type: integer
                               path:
@@ -6016,12 +6168,7 @@ spec:
                         volumeNamespace:
                           description: volumeNamespace specifies the scope of the
                             volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
+                            then the Pod's namespace will be used.
                           type: string
                       type: object
                     vsphereVolume:
@@ -6093,7 +6240,7 @@ spec:
                     description: StatusReplicas is the number of pods targeted by
                       this OpenTelemetryCollector's with a Ready Condition / Total
                       number of non-terminated pods targeted by this OpenTelemetryCollector's
-                      (their labels match the selector). Deployment, Daemonset, StatefulSet.
+                      (their labels matc
                     type: string
                 type: object
               version:

--- a/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
@@ -36,14 +36,14 @@ spec:
         description: Instrumentation is the spec for OpenTelemetry instrumentation.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+            description: APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              internal value, and may reject unrecognized values.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
+            description: Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              submits requests to. Cannot be updated. In CamelCase.
             type: string
           metadata:
             type: object
@@ -57,7 +57,7 @@ spec:
                   attrs:
                     description: 'Attrs defines Apache HTTPD agent specific attributes.
                       The precedence is: `agent default attributes` > `instrument
-                      spec attributes` . Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module'
+                      spec attributes` . Attributes are documented at https://github.'
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -67,15 +67,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -104,8 +98,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -123,7 +116,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -175,12 +168,7 @@ spec:
                       only if different from default "/usr/local/apache2/conf"
                     type: string
                   env:
-                    description: 'Env defines Apache HTTPD specific env vars. There
-                      are four layers for env vars'' definitions and the precedence
-                      order is: `original container env vars` > `language specific
-                      env vars` > `common env vars` > `instrument spec configs'' vars`.
-                      If the former var had been defined, then the other vars would
-                      be ignored.'
+                    description: Env defines Apache HTTPD specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -190,15 +178,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -227,8 +209,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -246,7 +227,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -303,8 +284,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -338,11 +318,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   version:
@@ -354,11 +331,7 @@ spec:
                 description: DotNet defines configuration for DotNet auto-instrumentation.
                 properties:
                   env:
-                    description: 'Env defines DotNet specific env vars. There are
-                      four layers for env vars'' definitions and the precedence order
-                      is: `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines DotNet specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -368,15 +341,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -405,8 +372,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -424,7 +390,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -481,8 +447,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -516,20 +481,13 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
               env:
-                description: 'Env defines common env vars. There are four layers for
-                  env vars'' definitions and the precedence order is: `original container
-                  env vars` > `language specific env vars` > `common env vars` > `instrument
-                  spec configs'' vars`. If the former var had been defined, then the
-                  other vars would be ignored.'
+                description: Env defines common env vars.
                 items:
                   description: EnvVar represents an environment variable present in
                     a Container.
@@ -538,15 +496,9 @@ spec:
                       description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
+                      description: Variable references $(VAR_NAME) are expanded using
                         the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
+                        and any service environment variables.
                       type: string
                     valueFrom:
                       description: Source for the environment variable's value. Cannot
@@ -574,7 +526,7 @@ spec:
                           description: 'Selects a field of the pod: supports metadata.name,
                             metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
                             spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                            status.'
                           properties:
                             apiVersion:
                               description: Version of the schema the FieldPath is
@@ -592,7 +544,7 @@ spec:
                           description: 'Selects a resource of the container: only
                             resources limits and requests (limits.cpu, limits.memory,
                             limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                            and requests.'
                           properties:
                             containerName:
                               description: 'Container name: required for volumes,
@@ -646,18 +598,9 @@ spec:
                 type: object
               go:
                 description: Go defines configuration for Go auto-instrumentation.
-                  When using Go auto-instrumenetation you must provide a value for
-                  the OTEL_GO_AUTO_TARGET_EXE env var via the Instrumentation env
-                  vars or via the instrumentation.opentelemetry.io/otel-go-auto-target-exe
-                  pod annotation. Failure to set this value causes instrumentation
-                  injection to abort, leaving the original pod unchanged.
                 properties:
                   env:
-                    description: 'Env defines Go specific env vars. There are four
-                      layers for env vars'' definitions and the precedence order is:
-                      `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines Go specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -667,15 +610,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -704,8 +641,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -723,7 +659,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -780,8 +716,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -815,11 +750,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
@@ -827,11 +759,7 @@ spec:
                 description: Java defines configuration for java auto-instrumentation.
                 properties:
                   env:
-                    description: 'Env defines java specific env vars. There are four
-                      layers for env vars'' definitions and the precedence order is:
-                      `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines java specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -841,15 +769,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -878,8 +800,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -897,7 +818,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -955,8 +876,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -990,11 +910,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
@@ -1004,7 +921,7 @@ spec:
                   attrs:
                     description: 'Attrs defines Nginx agent specific attributes. The
                       precedence order is: `agent default attributes` > `instrument
-                      spec attributes` . Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module'
+                      spec attributes` . Attributes are documented at https://github.'
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1014,15 +931,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -1051,8 +962,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -1070,7 +980,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -1122,11 +1032,7 @@ spec:
                       if different from default "/etx/nginx/nginx.conf"
                     type: string
                   env:
-                    description: 'Env defines Nginx specific env vars. There are four
-                      layers for env vars'' definitions and the precedence order is:
-                      `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines Nginx specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1136,15 +1042,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -1173,8 +1073,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -1192,7 +1091,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -1249,8 +1148,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -1284,11 +1182,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
@@ -1296,11 +1191,7 @@ spec:
                 description: NodeJS defines configuration for nodejs auto-instrumentation.
                 properties:
                   env:
-                    description: 'Env defines nodejs specific env vars. There are
-                      four layers for env vars'' definitions and the precedence order
-                      is: `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines nodejs specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1310,15 +1201,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -1347,8 +1232,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -1366,7 +1250,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -1423,8 +1307,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -1458,11 +1341,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
@@ -1487,11 +1367,7 @@ spec:
                 description: Python defines configuration for python auto-instrumentation.
                 properties:
                   env:
-                    description: 'Env defines python specific env vars. There are
-                      four layers for env vars'' definitions and the precedence order
-                      is: `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
+                    description: Env defines python specific env vars.
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -1501,15 +1377,9 @@ spec:
                             C_IDENTIFIER.
                           type: string
                         value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                          description: Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
+                            the container and any service environment variables.
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -1538,8 +1408,7 @@ spec:
                               description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                spec.serviceAccountName, status.hostIP, status.'
                               properties:
                                 apiVersion:
                                   description: Version of the schema the FieldPath
@@ -1557,7 +1426,7 @@ spec:
                               description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                and requests.'
                               properties:
                                 containerName:
                                   description: 'Container name: required for volumes,
@@ -1614,8 +1483,7 @@ spec:
                         description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable. It can only be
-                          set for containers."
+                          feature gate."
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
@@ -1649,11 +1517,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. Requests cannot exceed
-                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                 type: object
@@ -1678,8 +1543,7 @@ spec:
                   argument:
                     description: Argument defines sampler argument. The value depends
                       on the sampler type. For instance for parentbased_traceidratio
-                      sampler type it is a number in range [0..1] e.g. 0.25. The value
-                      will be set in the OTEL_TRACES_SAMPLER_ARG env var.
+                      sampler type it is a number in range [0..1] e.g. 0.25.
                     type: string
                   type:
                     description: Type defines sampler type. The value will be set

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -85,9 +85,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -232,7 +232,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -214,9 +214,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -232,9 +232,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -33,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.82.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.83.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.82.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.83.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.2
+    helm.sh/chart: opentelemetry-operator-0.36.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.82.0"
+    app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-operator/templates/prometheusrule.yaml
@@ -23,7 +23,7 @@ spec:
   - name: managerRules
     rules:
     - alert: ReconcileErrors
-      expr: rate(controller_runtime_reconcile_total{result="error"}[5m]) > 0
+      expr: rate(controller_runtime_reconcile_total{controller="opentelemetrycollector",result="error"}[5m]) > 0
       for: 5m
       labels:
         severity: warning
@@ -31,7 +31,7 @@ spec:
         description: '{{`Reconciliation errors for {{ $labels.controller }} is increasing and has now reached {{ humanize $value }} `}}'
         runbook_url: 'Check manager logs for reasons why this might happen'
     - alert: WorkqueueDepth
-      expr: workqueue_depth > 0
+      expr: workqueue_depth{name="opentelemetrycollector"} > 0
       for: 5m
       labels:
         severity: warning

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -139,13 +139,13 @@
                             "default": "",
                             "title": "The tag Schema",
                             "examples": [
-                                "v0.81.0"
+                                "v0.83.0"
                             ]
                         }
                     },
                     "examples": [{
                         "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                        "tag": "v0.81.0"
+                        "tag": "v0.83.0"
                     }]
                 },
                 "collectorImage": {
@@ -879,7 +879,7 @@
             "examples": [{
                 "image": {
                     "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                    "tag": "v0.81.0"
+                    "tag": "v0.83.0"
                 },
                 "collectorImage": {
                     "repository": "otel/opentelemetry-collector-contrib",
@@ -1568,7 +1568,7 @@
         "manager": {
             "image": {
                 "repository": "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator",
-                "tag": "v0.81.0"
+                "tag": "v0.83.0"
             },
             "collectorImage": {
                 "repository": "otel/opentelemetry-collector-contrib",

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -29,10 +29,10 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.82.0
+    tag: v0.83.0
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.82.0
+    tag: 0.83.0
   targetAllocatorImage:
     repository: ""
     tag: ""


### PR DESCRIPTION
This PR adds 2 new settings to the `values.yaml`

- `default.replicas`
  This will configure how many replicas of each of the services should be create
- `components.<service>.replicaOverride`
  This will override the specific service's replicas from the default.

In the supplied `values.yaml` the `default.replicas` value is set to 1 so that it doesn't change for existing users. In addition there are specific services that I didn't think should be automatically scaled based on this setting, for these I've added a `replicasOverride` to their section to keep it at 1, users can obviously override these as they see fit. These are:

- Redis
- Postgres
- Kafka
- Load generator

I'm sure I need to update some change logs, but I'm not sure where, so any guidance would be appreciated.