### PR TITLE
chore(demo): update chart dependencies

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.57.2
+  version: 0.65.1
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.69.1
+  version: 0.71.11
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 20.2.0
+  version: 23.3.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.52.8
-digest: sha256:29bfb18c99b19d1f1476b543b7a87b4a72b605407e2e5db87ffa81932feccfa9
-generated: "2023-06-27T19:07:05.571632+02:00"
+  version: 6.58.8
+digest: sha256:07407bf09ca623b169850105796321e569cf9f0934b667ab44dd8a3e611c9534
+generated: "2023-08-10T22:36:06.487161-04:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.22.4
+version: 0.23.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -14,18 +14,18 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: "1.4.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.57.2
+    version: 0.65.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 0.69.1
+    version: 0.71.11
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 20.2.0
+    version: 23.3.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 6.52.8
+    version: 6.58.8
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled

--- a/charts/opentelemetry-demo/UPGRADING.md
+++ b/charts/opentelemetry-demo/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrade guidelines
 
+## To 0.23
+
+The Prometheus sub-chart dependency made updates to pod labels. You may need to
+use the `--force` option with your Helm upgrade command, or delete the release
+and re-install it.
+
 ## To 0.22
 
 This release moves to using the `connectors` functionality in the OpenTelemetry

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,11 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
+        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
+        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        kubectl.kubernetes.io/default-container: grafana
     spec:
       
       serviceAccountName: example-grafana
@@ -37,12 +38,20 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
+        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.4.7"
+          image: "docker.io/grafana/grafana:10.0.3"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.42.0
+          image: jaegertracing/all-in-one:1.45.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,4 +96,6 @@ spec:
           resources:
             limits:
               memory: 300Mi
+          volumeMounts:
       serviceAccountName: example-jaeger
+      volumes:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 627ef43facddeaa6c6e7f91d8b1e04c1c7f292cbacad373de913a5a337dfc669
+        checksum/config: e62fcdf5b3a33ec3cdb0ad02e110fcaa5f3ec9f29067a643b7413b0bd7623171
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.76.1"
+          image: "otel/opentelemetry-collector-contrib:0.82.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: example-otelcol-agent
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 19f2931042e627b07e3bf0e0b69778e9bcb40885393993fb6b7e8acebdc5c357
+        checksum/config: 627ef43facddeaa6c6e7f91d8b1e04c1c7f292cbacad373de913a5a337dfc669
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.77.0"
+          image: "otel/opentelemetry-collector-contrib:0.76.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -4,38 +4,43 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      component: "server"
-      app: prometheus
-      release: example
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: example
   replicas: 1
+  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        component: "server"
-        app: prometheus
-        release: example
-        chart: prometheus-20.2.0
-        heritage: Helm
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: v2.46.0
+        helm.sh/chart: prometheus-23.3.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.43.0"
+          image: "quay.io/prometheus/prometheus:v2.46.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
@@ -18,8 +20,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    component: "server"
-    app: prometheus
-    release: example
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -520,7 +520,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -604,7 +604,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -798,7 +798,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -878,7 +878,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -960,7 +960,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1062,7 +1062,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1146,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1230,7 +1230,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1334,7 +1334,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1438,7 +1438,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1524,7 +1524,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1616,7 +1616,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1700,7 +1700,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1782,7 +1782,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1868,7 +1868,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1956,7 +1956,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2034,7 +2034,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,11 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
+        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
+        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        kubectl.kubernetes.io/default-container: grafana
     spec:
       
       serviceAccountName: example-grafana
@@ -37,12 +38,20 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
+        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.4.7"
+          image: "docker.io/grafana/grafana:10.0.3"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.42.0
+          image: jaegertracing/all-in-one:1.45.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,4 +96,6 @@ spec:
           resources:
             limits:
               memory: 300Mi
+          volumeMounts:
       serviceAccountName: example-jaeger
+      volumes:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f85af59ffecbb732ad2cb7dddd076c5820e389485040b4cdedf8ad9e9cbe49b2
+        checksum/config: a3a9263b6d6111b94da158ff4c9d9fd67c6cb3aed729b134ea907554519dfa6e
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.77.0"
+          image: "otel/opentelemetry-collector-contrib:0.76.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a3a9263b6d6111b94da158ff4c9d9fd67c6cb3aed729b134ea907554519dfa6e
+        checksum/config: 20851ed0c4bdafbefc52a90b489ba1a5a377b40e2add9425e2e4de2dcfce0f2d
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.76.1"
+          image: "otel/opentelemetry-collector-contrib:0.82.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,3 +52,4 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -4,38 +4,43 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      component: "server"
-      app: prometheus
-      release: example
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: example
   replicas: 1
+  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        component: "server"
-        app: prometheus
-        release: example
-        chart: prometheus-20.2.0
-        heritage: Helm
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: v2.46.0
+        helm.sh/chart: prometheus-23.3.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.43.0"
+          image: "quay.io/prometheus/prometheus:v2.46.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
@@ -18,8 +20,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    component: "server"
-    app: prometheus
-    release: example
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,11 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
+        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
+        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        kubectl.kubernetes.io/default-container: grafana
     spec:
       
       serviceAccountName: example-grafana
@@ -37,12 +38,20 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
+        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.4.7"
+          image: "docker.io/grafana/grafana:10.0.3"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.42.0
+          image: jaegertracing/all-in-one:1.45.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,4 +96,6 @@ spec:
           resources:
             limits:
               memory: 300Mi
+          volumeMounts:
       serviceAccountName: example-jaeger
+      volumes:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 330262db4024d8ef55d028492989fd4d8f77bb62c61f0f461b58ce2ff369ac80
+        checksum/config: 70766a04d09e3d8f05813f244cafb07d295308fbae0aa3750f667c41619a50c1
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.77.0"
+          image: "otel/opentelemetry-collector-contrib:0.76.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 70766a04d09e3d8f05813f244cafb07d295308fbae0aa3750f667c41619a50c1
+        checksum/config: 642250a36237ea6c5d9137695bbc2874323b1d1849096d6e61789e892007fbf3
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.76.1"
+          image: "otel/opentelemetry-collector-contrib:0.82.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,3 +52,4 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -4,38 +4,43 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      component: "server"
-      app: prometheus
-      release: example
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: example
   replicas: 1
+  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        component: "server"
-        app: prometheus
-        release: example
-        chart: prometheus-20.2.0
-        heritage: Helm
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: v2.46.0
+        helm.sh/chart: prometheus-23.3.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.43.0"
+          image: "quay.io/prometheus/prometheus:v2.46.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
@@ -18,8 +20,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    component: "server"
-    app: prometheus
-    release: example
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -518,7 +518,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -600,7 +600,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -690,7 +690,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -948,7 +948,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -1048,7 +1048,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1132,7 +1132,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1316,7 +1316,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1420,7 +1420,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1506,7 +1506,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1596,7 +1596,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1758,7 +1758,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1842,7 +1842,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1928,7 +1928,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -2006,7 +2006,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -2086,7 +2086,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,11 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 0bd174d19e5d455ad71aea624e65ae51fd412a6b3c54fba8db25d85a897c0f1b
+        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 159754aaf8e3f63d0512321d2f4ec32957e240bc75210d5e24303e6d266666b4
+        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        kubectl.kubernetes.io/default-container: grafana
     spec:
       
       serviceAccountName: example-grafana
@@ -37,12 +38,20 @@ spec:
       securityContext:
         fsGroup: 472
         runAsGroup: 472
+        runAsNonRoot: true
         runAsUser: 472
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.4.7"
+          image: "docker.io/grafana/grafana:10.0.3"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.52.8
+    helm.sh/chart: grafana-6.58.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.4.7"
+    app.kubernetes.io/version: "10.0.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: example-grafana-test
   containers:
     - name: example-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.42.0
+          image: jaegertracing/all-in-one:1.45.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
@@ -96,4 +96,6 @@ spec:
           resources:
             limits:
               memory: 300Mi
+          volumeMounts:
       serviceAccountName: example-jaeger
+      volumes:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.69.1
+    helm.sh/chart: jaeger-0.71.11
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.42.0"
+    app.kubernetes.io/version: "1.45.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 330262db4024d8ef55d028492989fd4d8f77bb62c61f0f461b58ce2ff369ac80
+        checksum/config: 70766a04d09e3d8f05813f244cafb07d295308fbae0aa3750f667c41619a50c1
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.77.0"
+          image: "otel/opentelemetry-collector-contrib:0.76.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 70766a04d09e3d8f05813f244cafb07d295308fbae0aa3750f667c41619a50c1
+        checksum/config: 642250a36237ea6c5d9137695bbc2874323b1d1849096d6e61789e892007fbf3
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.76.1"
+          image: "otel/opentelemetry-collector-contrib:0.82.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:
@@ -52,3 +52,4 @@ spec:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
     component: standalone-collector
+  internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.55.1
+    helm.sh/chart: opentelemetry-collector-0.65.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.76.1"
+    app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.57.2
+    helm.sh/chart: opentelemetry-collector-0.55.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.77.0"
+    app.kubernetes.io/version: "0.76.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:
   - apiGroups:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -4,11 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -4,38 +4,43 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
   selector:
     matchLabels:
-      component: "server"
-      app: prometheus
-      release: example
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: example
   replicas: 1
+  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        component: "server"
-        app: prometheus
-        release: example
-        chart: prometheus-20.2.0
-        heritage: Helm
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: v2.46.0
+        helm.sh/chart: prometheus-23.3.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
       serviceAccountName: example-prometheus-server
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.43.0"
+          image: "quay.io/prometheus/prometheus:v2.46.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
 spec:
@@ -18,8 +20,8 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    component: "server"
-    app: prometheus
-    release: example
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
   sessionAffinity: None
   type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: example
-    chart: prometheus-20.2.0
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.46.0
+    helm.sh/chart: prometheus-23.3.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
   annotations:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.22.4
+    helm.sh/chart: opentelemetry-demo-0.23.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example


### PR DESCRIPTION
Updates all chart dependencies to the latest.  Because of an update with pod labels to the Prometheus dependency, upgrading may require a `--force` option.  This has been documented in UPGRADING.md