### PR TITLE
[Operator] Feature certificate manifest improvements

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.35.1
+version: 0.35.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -17,6 +17,7 @@ spec:
     - example-opentelemetry-operator-webhook.default.svc
     - example-opentelemetry-operator-webhook.default.svc.cluster.local
   issuerRef:
+    group: cert-manager.io
     kind: Issuer
     name: example-opentelemetry-operator-selfsigned-issuer
   secretName: example-opentelemetry-operator-controller-manager-service-cert

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -232,7 +232,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources:
+          resources: 
             limits:
               cpu: 100m
               memory: 128Mi
@@ -71,7 +71,7 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-
+        
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -83,7 +83,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources:
+          resources: 
             limits:
               cpu: 500m
               memory: 128Mi

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -60,7 +60,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources: 
+          resources:
             limits:
               cpu: 100m
               memory: 128Mi
@@ -71,7 +71,7 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-        
+
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -83,7 +83,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
+          resources:
             limits:
               cpu: 500m
               memory: 128Mi

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.35.1
+    helm.sh/chart: opentelemetry-operator-0.35.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.82.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -19,6 +19,7 @@ spec:
     {{- if .Values.admissionWebhooks.certManager.issuerRef }}
     {{- toYaml .Values.admissionWebhooks.certManager.issuerRef | nindent 4 }}
     {{- else }}
+    group: cert-manager.io
     kind: Issuer
     name: {{ template "opentelemetry-operator.fullname" . }}-selfsigned-issuer
     {{- end }}
@@ -26,6 +27,9 @@ spec:
   subject:
     organizationalUnits:
       - {{ template "opentelemetry-operator.fullname" . }}
+  {{- if .Values.admissionWebhooks.certManager.extraSpecs }}
+  {{- toYaml .Values.admissionWebhooks.certManager.extraSpecs | nindent 2 }}
+  {{- end }}
 {{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -206,14 +206,21 @@ admissionWebhooks:
   ## certManager must be enabled. If enabled, always takes precendence over options 2 and 3.
   certManager:
     enabled: true
-    ## Provide the issuer kind and name to do the cert auth job.
+    ## Provide the issuer kind, group and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}
       # kind:
       # name:
+      # group:
     ## Annotations for the cert and issuer if cert-manager is enabled.
     certificateAnnotations: {}
     issuerAnnotations: {}
+    ## Extra Specs for the cert which would be required if custom ca issuers are used
+    extraSpecs: {}
+      # renewBefore:
+      # privateKey:
+      # usages:
+
 
   ## TLS Certificate Option 2: Use Helm to automatically generate self-signed certificate.
   ## certManager must be disabled and autoGenerateCert must be enabled.


### PR DESCRIPTION
This PR addresses issues related to certificates of opentelemetry-operator
1. If group: cert-manager.io is not mentioned in issuerRef, there is a chance that the issuer might not be picked if the cluster has another external CA issuer.
2. In case of not opting for self-signed issuer, you need extraSpecs such as the commented ones in values.yaml which is not possible with the current structure