### PR TITLE
[collector] Make it possible to specify namespace when running Helm template

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.66.3
+version: 0.66.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d591d7a96ebe8e907b4e2babc5528bf26de5913825caba5bbc4f11dc83bad0ee
+        checksum/config: 306ccb4b5b4f7ebc75d88340487a42c673b10905ac5abaa549b1fc75a24bde56
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
+        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e5e5bf15320b50267f4a1989db5454de48ae14f1487bff0e3f346400af3433fc
+        checksum/config: 5dd6cf134433dd8852bd66845c6a713f9039710b0680d530342e002cd6493929
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 48c0d2ff85f9f7d11213ac4286a8cb3cba222fac40a52f03c1845c68ad847fcc
+        checksum/config: 0cc9092e47a747f51748bbf05dc5598605420ceaa7bead02c77a9819c53c4f94
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
+        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-opentelemetry-collector-agent
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1319970d1125766adf87a74b44e1773f829a36bae81b64ce150ea312a3291eff
+        checksum/config: b421816fb164c2a0e674f8788791d2b97bbaa5b86db805b65c9d6d5130807792
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc9bc1e3d54174a3c0e6188f549b933604e54748632720336ad513b96bb7ee0f
+        checksum/config: 8df436fe1a34eb82cbd00cc160148eab89b943abb40fc415137b0c7282e6ddc3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f03c0b4eea87d9e1057e23a564bab931da3c83459d8f5113da6d40ce99d602ce
+        checksum/config: 4f7e3ee2c34567f31d0aada436446deee2566a1f85ce3fc5d85aab4221ee2e42
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 412fb3807e3708b7f6026c796980b953e9409647c62e0d243dd7b93dd3b7647e
+        checksum/config: 41cb3ee81579bec841358e320cef56e379196bec0b0f946e2f14b476c537d69e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-opentelemetry-collector-statefulset
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -4,8 +4,9 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: example-opentelemetry-collector
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.66.3
+    helm.sh/chart: opentelemetry-collector-0.66.4
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.83.0"
@@ -24,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: af45f1a3f19d21465934589edd45ac5f68b85eed9ac77c530e5d63f1f0e5e396
+        checksum/config: f39b79a54dfb785b773640ebd55d45eb0213bc83f131fb42a3dfb3ae3d4b7cc5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -159,12 +159,12 @@ Compute InternalTrafficPolicy on Service creation
 {{- end -}}
 
 {{/*
-Specify namespace
+Allow the release namespace to be overridden
 */}}
 {{- define "opentelemetry-collector.namespace" -}}
-{{- if .Values.namespace -}}
-{{- .Values.namespace -}}
-{{- else -}}
-{{- .Release.Namespace -}}
-{{- end -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -158,4 +158,13 @@ Compute InternalTrafficPolicy on Service creation
   {{- end }}
 {{- end -}}
 
-
+{{/*
+Specify namespace
+*/}}
+{{- define "opentelemetry-collector.namespace" -}}
+{{- if .Values.namespace -}}
+{{- .Values.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/opentelemetry-collector/templates/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-agent.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-statefulset
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/configmap.yaml
+++ b/charts/opentelemetry-collector/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/daemonset.yaml
+++ b/charts/opentelemetry-collector/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
@@ -42,7 +43,7 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
@@ -42,7 +43,7 @@ spec:
       dnsPolicy: {{ . }}
       {{- end }}
       {{- with .Values.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $podValues := deepCopy .Values }}

--- a/charts/opentelemetry-collector/templates/hpa.yaml
+++ b/charts/opentelemetry-collector/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/ingress.yaml
+++ b/charts/opentelemetry-collector/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- else }}
   name: {{ include "opentelemetry-collector.fullname" $ }}
   {{- end }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" $ | nindent 4 }}
     {{- include "opentelemetry-collector.component" $ | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/ingress.yaml
+++ b/charts/opentelemetry-collector/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- else }}
   name: {{ include "opentelemetry-collector.fullname" $ }}
   {{- end }}
-  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" $ }}
   labels:
     {{- include "opentelemetry-collector.labels" $ | nindent 4 }}
     {{- include "opentelemetry-collector.component" $ | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/networkpolicy.yaml
+++ b/charts/opentelemetry-collector/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.networkPolicy.annotations }}

--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/podmonitor.yaml
+++ b/charts/opentelemetry-collector/templates/podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}-agent
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.podMonitor.extraLabels }}

--- a/charts/opentelemetry-collector/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-collector/templates/prometheusrule.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.prometheusRule.extraLabels }}

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- include "opentelemetry-collector.component" . | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opentelemetry-collector.serviceAccountName" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}

--- a/charts/opentelemetry-collector/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-collector/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.extraLabels }}

--- a/charts/opentelemetry-collector/templates/statefulset.yaml
+++ b/charts/opentelemetry-collector/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- if .Values.annotations }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -35,7 +35,7 @@
       "type": "string",
       "enum": ["daemonset", "deployment", "statefulset", ""]
     },
-    "namespace": {
+    "namespaceOverride": {
       "type": "string",
       "description": "Name of the namespace to deploy the resources into."
     },

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -35,6 +35,10 @@
       "type": "string",
       "enum": ["daemonset", "deployment", "statefulset", ""]
     },
+    "namespace": {
+      "type": "string",
+      "description": "Name of the namespace to deploy the resources into."
+    },
     "presets": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 mode: ""
 
 # Specify which namespace should be used to deploy the resources into
-namespace: ""
+namespaceOverride: ""
 
 # Handles basic configuration of components that
 # also require k8s modifications to work correctly.

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -8,6 +8,9 @@ fullnameOverride: ""
 # Valid values are "daemonset", "deployment", and "statefulset".
 mode: ""
 
+# Specify which namespace should be used to deploy the resources into
+namespace: ""
+
 # Handles basic configuration of components that
 # also require k8s modifications to work correctly.
 # .Values.config can be used to modify/add to a preset


### PR DESCRIPTION
Currently it can be problematic to conveniently support GitOps tools like flux as `helm template` does not add `.Release.Namespace` to manifests as per https://github.com/helm/helm/issues/3553.

This PR fixes this by making it possible to render the the config into a specified namespace. Similar behaviour is present in other OSS charts as well.

E.g. `helm template otel opentelemetry-collector/ --namespace my-ns --set mode=daemonset`, will add `namespace: my-ns` to the rendered resources.