### PR TITLE
[operator] limit prometheus rules to opentelemetrycollector application

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.36.0
+version: 0.37.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -232,7 +232,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.36.0
+    helm.sh/chart: opentelemetry-operator-0.37.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.83.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-operator/templates/prometheusrule.yaml
@@ -23,7 +23,7 @@ spec:
   - name: managerRules
     rules:
     - alert: ReconcileErrors
-      expr: rate(controller_runtime_reconcile_total{result="error"}[5m]) > 0
+      expr: rate(controller_runtime_reconcile_total{controller="opentelemetrycollector",result="error"}[5m]) > 0
       for: 5m
       labels:
         severity: warning
@@ -31,7 +31,7 @@ spec:
         description: '{{`Reconciliation errors for {{ $labels.controller }} is increasing and has now reached {{ humanize $value }} `}}'
         runbook_url: 'Check manager logs for reasons why this might happen'
     - alert: WorkqueueDepth
-      expr: workqueue_depth > 0
+      expr: workqueue_depth{name="opentelemetrycollector"} > 0
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
The chart deploys alerting rules `ReconcileErrors` and `WorkqueueDepth` to monitor the operator. However, since these rules do not filter on any labels they apply to any operator deployed in the Kubernetes cluster.
To contain this chart only to the Opentelemetry Operator this PRs adds the relevant labels to the PrometheusRules.

No user impact is expected with this change