### PR TITLE
(demo): update prometheus to use otlp write

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.25.1
+version: 0.25.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -21,11 +21,10 @@ data:
         endpoint: 'example-jaeger-collector:4317'
         tls:
           insecure: true
-      prometheus:
-        enable_open_metrics: true
-        endpoint: ${env.MY_POD_IP}:9464
-        resource_to_telemetry_conversion:
-          enabled: true
+      otlphttp/prometheus:
+        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        tls:
+          insecure: true
     extensions:
       health_check: {}
       memory_ballast:
@@ -123,7 +122,7 @@ data:
           - otlp
         metrics:
           exporters:
-          - prometheus
+          - otlphttp/prometheus
           - logging
           processors:
           - k8sattributes

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 518c3ef7264131872ee1b376e06b047314401d2f476eff96eedaccab0f720a57
+        checksum/config: d7424fe1fb3eafd1ad5ac4ef5c15d435680dba7922e20fe4b5caee1493b05edf
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -49,6 +49,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
+            - --enable-feature=otlp-write-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -638,7 +638,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -720,7 +720,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -780,7 +780,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -842,7 +842,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -924,7 +924,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -988,7 +988,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1052,7 +1052,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1222,7 +1222,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1288,7 +1288,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1360,7 +1360,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1424,7 +1424,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1486,7 +1486,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1552,7 +1552,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1620,7 +1620,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -21,11 +21,10 @@ data:
         endpoint: 'example-jaeger-collector:4317'
         tls:
           insecure: true
-      prometheus:
-        enable_open_metrics: true
-        endpoint: ${env.MY_POD_IP}:9464
-        resource_to_telemetry_conversion:
-          enabled: true
+      otlphttp/prometheus:
+        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        tls:
+          insecure: true
     extensions:
       health_check: {}
       memory_ballast:
@@ -130,7 +129,7 @@ data:
           - otlp
         metrics:
           exporters:
-          - prometheus
+          - otlphttp/prometheus
           - logging
           processors:
           - k8sattributes

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56a80372282ff051cb09972ca3e14235be5a2cb738818f70812bf9effc74e812
+        checksum/config: 9c4da9dcd4fa11aaa117c255936647d4bfc1689658bb0d462a5ce8df60ad18ba
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -49,6 +49,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
+            - --enable-feature=otlp-write-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -21,11 +21,10 @@ data:
         endpoint: 'example-jaeger-collector:4317'
         tls:
           insecure: true
-      prometheus:
-        enable_open_metrics: true
-        endpoint: ${env.MY_POD_IP}:9464
-        resource_to_telemetry_conversion:
-          enabled: true
+      otlphttp/prometheus:
+        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        tls:
+          insecure: true
     extensions:
       health_check: {}
       memory_ballast:
@@ -121,7 +120,7 @@ data:
           - otlp
         metrics:
           exporters:
-          - prometheus
+          - otlphttp/prometheus
           - logging
           processors:
           - k8sattributes

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b80dddd04ba49616adbcd4b6beae151559b457a93866959f649eeab21a7d2728
+        checksum/config: 49703765f0bfe99d5a06ae6582f5aaaf825e75af1173b143b75da074377f0643
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -49,6 +49,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
+            - --enable-feature=otlp-write-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1710,7 +1710,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -21,11 +21,10 @@ data:
         endpoint: 'example-jaeger-collector:4317'
         tls:
           insecure: true
-      prometheus:
-        enable_open_metrics: true
-        endpoint: ${env.MY_POD_IP}:9464
-        resource_to_telemetry_conversion:
-          enabled: true
+      otlphttp/prometheus:
+        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        tls:
+          insecure: true
     extensions:
       health_check: {}
       memory_ballast:
@@ -121,7 +120,7 @@ data:
           - otlp
         metrics:
           exporters:
-          - prometheus
+          - otlphttp/prometheus
           - logging
           processors:
           - k8sattributes

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b80dddd04ba49616adbcd4b6beae151559b457a93866959f649eeab21a7d2728
+        checksum/config: 49703765f0bfe99d5a06ae6582f5aaaf825e75af1173b143b75da074377f0643
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -49,6 +49,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
+            - --enable-feature=otlp-write-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.1
+    helm.sh/chart: opentelemetry-demo-0.25.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -619,11 +619,10 @@ opentelemetry-collector:
         tls:
           insecure: true
       # Create an exporter to Prometheus (metrics)
-      prometheus:
-        endpoint: "${env.MY_POD_IP}:9464"
-        resource_to_telemetry_conversion:
-          enabled: true
-        enable_open_metrics: true
+      otlphttp/prometheus:
+        endpoint: '{{ include "otel-demo.name" . }}-prometheus-server:9090/api/v1/otlp'
+        tls:
+          insecure: true
 
     processors:
       resource:
@@ -662,7 +661,7 @@ opentelemetry-collector:
         metrics:
           receivers: [otlp, spanmetrics]
           processors: [memory_limiter, filter/ottl, transform, resource, batch]
-          exporters: [prometheus, logging]
+          exporters: [otlphttp/prometheus, logging]
 
 jaeger:
   enabled: true
@@ -709,6 +708,7 @@ prometheus:
   server:
     extraFlags:
       - "enable-feature=exemplar-storage"
+      - "enable-feature=otlp-write-receiver"
     global:
       scrape_interval: 5s
       scrape_timeout: 3s


### PR DESCRIPTION
Updates Prometheus to use OTLP write. Collector exporter updated accordingly.

References this [demo repo PR](https://github.com/open-telemetry/opentelemetry-demo/pull/1149)