### PR TITLE
Add example for enabling rewrite target allocator feature

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.40.0
+version: 0.40.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -49,8 +49,14 @@ $ helm install --namespace opentelemetry-operator-system \
 If you wish for helm to create an automatically generated self-signed certificate, make sure to set the appropriate values when installing the chart:
 
 ```console
-$ helm install  --set admissionWebhooks.certManager.enabled=false --set admissionWebhooks.certManager.autoGenerateCert=true \
+$ helm install --set admissionWebhooks.certManager.enabled=false --set admissionWebhooks.certManager.autoGenerateCert=true \
   opentelemetry-operator open-telemetry/opentelemetry-operator
+```
+
+Additional featureGates can also be enabled through the Helm installation. For enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature, add a `--set` flag as follows.
+
+```console
+$ helm install --set manager.featureGates=operator.collector.rewritetargetallocator opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -53,12 +53,6 @@ $ helm install --set admissionWebhooks.certManager.enabled=false --set admission
   opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 
-Additional featureGates can also be enabled through the Helm installation. For enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature, add a `--set` flag as follows.
-
-```console
-$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator --set manager.featureGates=operator.collector.rewritetargetallocator
-```
-
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
 ## Uninstall Chart
@@ -99,6 +93,14 @@ The following command will show all the configurable options with detailed comme
 
 ```console
 $ helm show values open-telemetry/opentelemetry-operator
+```
+
+Extra configuration values can be passed into the the chart individually using the `--set` flag, or in a values file using the `--values` flag as per the `helm install` [instructions](https://helm.sh/docs/helm/helm_install/).  
+
+Additional featureGates need to be enabled during the Helm installation. Enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature gate can be done by adding a `--set` flag as follows:
+
+```console
+$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator --set manager.featureGates=operator.collector.rewritetargetallocator
 ```
 
 ## Install OpenTelemetry Collector

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -56,7 +56,7 @@ $ helm install --set admissionWebhooks.certManager.enabled=false --set admission
 Additional featureGates can also be enabled through the Helm installation. For enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature, add a `--set` flag as follows.
 
 ```console
-$ helm install --set manager.featureGates=operator.collector.rewritetargetallocator opentelemetry-operator open-telemetry/opentelemetry-operator
+$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator --set manager.featureGates=operator.collector.rewritetargetallocator
 ```
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -97,7 +97,7 @@ $ helm show values open-telemetry/opentelemetry-operator
 
 Extra configuration values can be passed into the the chart individually using the `--set` flag, or in a values file using the `--values` flag as per the `helm install` [instructions](https://helm.sh/docs/helm/helm_install/).  
 
-Additional featureGates need to be enabled during the Helm installation. Enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature gate can be done by adding a `--set` flag as follows:
+Additional Operator featureGates may need to be enabled during the Helm installation. For example, enabling the [rewrite target allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator-config-rewriting) feature gate can be done by adding a `--set` flag as follows:
 
 ```console
 $ helm install opentelemetry-operator open-telemetry/opentelemetry-operator --set manager.featureGates=operator.collector.rewritetargetallocator

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -85,7 +85,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -226,7 +226,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -244,7 +244,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.40.0
+    helm.sh/chart: opentelemetry-operator-0.40.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.86.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Enabling the rewrite target allocator feature is a common need when deploying this chart. A specific example in the documentation should make it easier for newcomers (like myself) to deploy the operator and scrape serviceMonitor endpoints.