### PR TITLE
(demo): fix prometheus endpoint

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.25.4
+version: 0.25.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -22,7 +22,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        endpoint: http://example-prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a10350907061c98d8b39ce3d7de72d6120306e5da65daddeb24c08937b322906
+        checksum/config: c2097009710e087829835f7c6dec0cdd0050c1c1e65db70b3accb22b1a4bc52b
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -638,7 +638,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -720,7 +720,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -780,7 +780,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -842,7 +842,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -924,7 +924,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -988,7 +988,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1052,7 +1052,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1222,7 +1222,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1288,7 +1288,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1360,7 +1360,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1424,7 +1424,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1486,7 +1486,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1552,7 +1552,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1620,7 +1620,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -22,7 +22,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        endpoint: http://example-prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 225b1ec1632bbe43020e7abd937486fc8ebe672f55adecc752866659feb6585a
+        checksum/config: fd1033df5c7cd1d7aa3150b96cc690db5d19c272619246f1ea45ce68bdb59b3b
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -22,7 +22,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        endpoint: http://example-prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b1fd43266f9af2be8e276be8dba108b9548c51989f71dfd9fddbf0d8fb04846c
+        checksum/config: cb75a0f098289ab60742f12b1079f1a633e0e94b1d6f3d7fb9453a35104fe38e
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1710,7 +1710,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -22,7 +22,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: 'example-prometheus-server:9090/api/v1/otlp'
+        endpoint: http://example-prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b1fd43266f9af2be8e276be8dba108b9548c51989f71dfd9fddbf0d8fb04846c
+        checksum/config: cb75a0f098289ab60742f12b1079f1a633e0e94b1d6f3d7fb9453a35104fe38e
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.4
+    helm.sh/chart: opentelemetry-demo-0.25.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -620,7 +620,7 @@ opentelemetry-collector:
           insecure: true
       # Create an exporter to Prometheus (metrics)
       otlphttp/prometheus:
-        endpoint: '{{ include "otel-demo.name" . }}-prometheus-server:9090/api/v1/otlp'
+        endpoint: 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090/api/v1/otlp'
         tls:
           insecure: true
 


### PR DESCRIPTION
Adds the `http://` scheme to the Prometheus endpoint. I'm not sure how this worked or was missed before. Grafana charts now work properly in the demo.