### PR TITLE
(demo) fix jaeger spm and prometheus config

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.69.1
+  version: 0.72.0
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.71.14
+  version: 0.71.17
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.0.0
+  version: 25.1.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.58.8
-digest: sha256:cb54fa9f2baedac6ac1bb90723d5e273e028a7feb73d7cccd2846a3114363268
-generated: "2023-09-29T10:12:06.686332-06:00"
+  version: 6.60.4
+digest: sha256:1fd6c4a7367448c253614c304ed964f6c5c7f341f6db10e5fff9b1e0ba69c162
+generated: "2023-10-13T00:47:30.213353-04:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.25.5
+version: 0.25.7
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -14,18 +14,18 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: "1.5.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.69.1
+    version: 0.72.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 0.71.14
+    version: 0.71.17
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 25.0.0
+    version: 25.1.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 6.58.8
+    version: 6.60.4
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.25.7
+version: 0.25.6
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 487537f82daa31d9db48a159aeac4e007dc207ccecb6ce03cc84d32a8b9e4797
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        checksum/secret: 2608a7e52fee257b921d27d90925d644cc663872fd8f57d224676f100117b0c3
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
@@ -43,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "docker.io/grafana/grafana:10.1.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"
@@ -31,7 +31,7 @@ spec:
       annotations:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
-    spec:
+    spec:    
       containers:
         - env:
             - name: METRICS_STORAGE_TYPE
@@ -44,16 +44,15 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.50
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces"
-            - "8000"
-            - "--query.base-path"
-            - "/jaeger/ui"
-            - "--prometheus.server-url"
-            - "http://example-prometheus-server:9090"
+            - "--memory.max-traces=8000"
+            - "--query.base-path=/jaeger/ui"
+            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.query.normalize-calls=true"
+            - "--prometheus.query.normalize-duration=true"
           ports:
             - containerPort: 5775
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |
@@ -17,6 +17,7 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
+      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c2097009710e087829835f7c6dec0cdd0050c1c1e65db70b3accb22b1a4bc52b
+        checksum/config: 4e4828fd03a4de4e0c3dc080872ec311ac8035d3e6ed5f794f33b0fa7375405f
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.86.0"
+          image: "otel/opentelemetry-collector-contrib:0.87.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -34,6 +34,14 @@ rules:
     resources:
       - ingresses/status
       - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -21,26 +21,15 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml
     - /etc/config/rules
     - /etc/config/alerts
-    scrape_configs:
-    - honor_labels: true
-      job_name: opentelemetry-community-demo
-      kubernetes_sd_configs:
-      - namespaces:
-          own_namespace: true
-        role: pod
-      relabel_configs:
-      - action: keep
-        regex: true
-        source_labels:
-        - __meta_kubernetes_pod_annotation_opentelemetry_community_demo
+    scrape_configs: []
   recording_rules.yml: |
     {}
   rules: |

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: prometheus-25.0.0
+        helm.sh/chart: prometheus-25.1.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -638,7 +638,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -720,7 +720,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -780,7 +780,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -842,7 +842,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -924,7 +924,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -988,7 +988,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1052,7 +1052,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1222,7 +1222,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1288,7 +1288,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1360,7 +1360,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1424,7 +1424,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1486,7 +1486,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1552,7 +1552,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1620,7 +1620,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -500,7 +500,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -564,7 +564,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -638,7 +638,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -720,7 +720,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -780,7 +780,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -842,7 +842,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -924,7 +924,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -988,7 +988,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1052,7 +1052,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1136,7 +1136,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1222,7 +1222,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1288,7 +1288,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1360,7 +1360,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1424,7 +1424,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1486,7 +1486,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1552,7 +1552,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1620,7 +1620,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1678,7 +1678,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 487537f82daa31d9db48a159aeac4e007dc207ccecb6ce03cc84d32a8b9e4797
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        checksum/secret: 2608a7e52fee257b921d27d90925d644cc663872fd8f57d224676f100117b0c3
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
@@ -43,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "docker.io/grafana/grafana:10.1.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"
@@ -31,7 +31,7 @@ spec:
       annotations:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
-    spec:
+    spec:    
       containers:
         - env:
             - name: METRICS_STORAGE_TYPE
@@ -44,16 +44,15 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.50
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces"
-            - "8000"
-            - "--query.base-path"
-            - "/jaeger/ui"
-            - "--prometheus.server-url"
-            - "http://example-prometheus-server:9090"
+            - "--memory.max-traces=8000"
+            - "--query.base-path=/jaeger/ui"
+            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.query.normalize-calls=true"
+            - "--prometheus.query.normalize-duration=true"
           ports:
             - containerPort: 5775
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |
@@ -17,6 +17,7 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
+      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fd1033df5c7cd1d7aa3150b96cc690db5d19c272619246f1ea45ce68bdb59b3b
+        checksum/config: ac1ca0b2242e7d58cf9df2cf06e643c8667fb0b870e9b41fd510007979768a6a
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.86.0"
+          image: "otel/opentelemetry-collector-contrib:0.87.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -34,6 +34,14 @@ rules:
     resources:
       - ingresses/status
       - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -21,26 +21,15 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml
     - /etc/config/rules
     - /etc/config/alerts
-    scrape_configs:
-    - honor_labels: true
-      job_name: opentelemetry-community-demo
-      kubernetes_sd_configs:
-      - namespaces:
-          own_namespace: true
-        role: pod
-      relabel_configs:
-      - action: keep
-        regex: true
-        source_labels:
-        - __meta_kubernetes_pod_annotation_opentelemetry_community_demo
+    scrape_configs: []
   recording_rules.yml: |
     {}
   rules: |

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: prometheus-25.0.0
+        helm.sh/chart: prometheus-25.1.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 487537f82daa31d9db48a159aeac4e007dc207ccecb6ce03cc84d32a8b9e4797
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        checksum/secret: 2608a7e52fee257b921d27d90925d644cc663872fd8f57d224676f100117b0c3
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
@@ -43,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "docker.io/grafana/grafana:10.1.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"
@@ -31,7 +31,7 @@ spec:
       annotations:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
-    spec:
+    spec:    
       containers:
         - env:
             - name: METRICS_STORAGE_TYPE
@@ -44,16 +44,15 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.50
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces"
-            - "8000"
-            - "--query.base-path"
-            - "/jaeger/ui"
-            - "--prometheus.server-url"
-            - "http://example-prometheus-server:9090"
+            - "--memory.max-traces=8000"
+            - "--query.base-path=/jaeger/ui"
+            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.query.normalize-calls=true"
+            - "--prometheus.query.normalize-duration=true"
           ports:
             - containerPort: 5775
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |
@@ -17,6 +17,7 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
+      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cb75a0f098289ab60742f12b1079f1a633e0e94b1d6f3d7fb9453a35104fe38e
+        checksum/config: ca02171affb283a4f2102bf73aeea14380d80df87c1389f10178e88995dcd266
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.86.0"
+          image: "otel/opentelemetry-collector-contrib:0.87.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -34,6 +34,14 @@ rules:
     resources:
       - ingresses/status
       - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -21,26 +21,15 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml
     - /etc/config/rules
     - /etc/config/alerts
-    scrape_configs:
-    - honor_labels: true
-      job_name: opentelemetry-community-demo
-      kubernetes_sd_configs:
-      - namespaces:
-          own_namespace: true
-        role: pod
-      relabel_configs:
-      - action: keep
-        regex: true
-        source_labels:
-        - __meta_kubernetes_pod_annotation_opentelemetry_community_demo
+    scrape_configs: []
   recording_rules.yml: |
     {}
   rules: |

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: prometheus-25.0.0
+        helm.sh/chart: prometheus-25.1.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1710,7 +1710,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -498,7 +498,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -560,7 +560,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -632,7 +632,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -712,7 +712,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -830,7 +830,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -974,7 +974,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1036,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1118,7 +1118,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1204,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1270,7 +1270,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1340,7 +1340,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1402,7 +1402,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1462,7 +1462,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1526,7 +1526,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1592,7 +1592,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1650,7 +1650,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1710,7 +1710,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,10 +26,10 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: faa523acbb15ce366dd2353d5417b71479ace592c9694e315997add86f6592bc
+        checksum/config: 487537f82daa31d9db48a159aeac4e007dc207ccecb6ce03cc84d32a8b9e4797
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: a5b2dd94ad3d3c38ad2f31d52e0b0588f2df6263a230726d9f6673b8b23105da
+        checksum/secret: 2608a7e52fee257b921d27d90925d644cc663872fd8f57d224676f100117b0c3
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
@@ -43,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.0.3"
+          image: "docker.io/grafana/grafana:10.1.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.58.8
+    helm.sh/chart: grafana-6.60.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.0.3"
+    app.kubernetes.io/version: "10.1.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"
@@ -31,7 +31,7 @@ spec:
       annotations:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
-    spec:
+    spec:    
       containers:
         - env:
             - name: METRICS_STORAGE_TYPE
@@ -44,16 +44,15 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.45.0
+          image: jaegertracing/all-in-one:1.50
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces"
-            - "8000"
-            - "--query.base-path"
-            - "/jaeger/ui"
-            - "--prometheus.server-url"
-            - "http://example-prometheus-server:9090"
+            - "--memory.max-traces=8000"
+            - "--query.base-path=/jaeger/ui"
+            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.query.normalize-calls=true"
+            - "--prometheus.query.normalize-duration=true"
           ports:
             - containerPort: 5775
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.71.14
+    helm.sh/chart: jaeger-0.71.17
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.45.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: [""]

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |
@@ -17,6 +17,7 @@ data:
       spanmetrics: null
     exporters:
       debug: {}
+      logging: {}
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cb75a0f098289ab60742f12b1079f1a633e0e94b1d6f3d7fb9453a35104fe38e
+        checksum/config: ca02171affb283a4f2102bf73aeea14380d80df87c1389f10178e88995dcd266
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.86.0"
+          image: "otel/opentelemetry-collector-contrib:0.87.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.69.1
+    helm.sh/chart: opentelemetry-collector-0.72.0
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.86.0"
+    app.kubernetes.io/version: "0.87.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -34,6 +34,14 @@ rules:
     resources:
       - ingresses/status
       - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -21,26 +21,15 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml
     - /etc/config/rules
     - /etc/config/alerts
-    scrape_configs:
-    - honor_labels: true
-      job_name: opentelemetry-community-demo
-      kubernetes_sd_configs:
-      - namespaces:
-          own_namespace: true
-        role: pod
-      relabel_configs:
-      - action: keep
-        regex: true
-        source_labels:
-        - __meta_kubernetes_pod_annotation_opentelemetry_community_demo
+    scrape_configs: []
   recording_rules.yml: |
     {}
   rules: |

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: prometheus-25.0.0
+        helm.sh/chart: prometheus-25.1.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: prometheus-25.0.0
+    helm.sh/chart: prometheus-25.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.5
+    helm.sh/chart: opentelemetry-demo-0.25.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.7
+    helm.sh/chart: opentelemetry-demo-0.25.6
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -669,13 +669,14 @@ jaeger:
     cassandra: false
   allInOne:
     enabled: true
+    # FIXME: Remove this tag after the Jaeger Helm chart supports appVersion >= "1.50"
+    tag: "1.50"
     args:
-      - "--memory.max-traces"
-      - "8000"
-      - "--query.base-path"
-      - "/jaeger/ui"
-      - "--prometheus.server-url"
-      - 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090'
+      - "--memory.max-traces=8000"
+      - "--query.base-path=/jaeger/ui"
+      - "--prometheus.server-url=http://{{ include \"otel-demo.name\" . }}-prometheus-server:9090"
+      - "--prometheus.query.normalize-calls=true"
+      - "--prometheus.query.normalize-duration=true"
     extraEnv:
       - name: METRICS_STORAGE_TYPE
         value: prometheus
@@ -709,10 +710,6 @@ prometheus:
     extraFlags:
       - "enable-feature=exemplar-storage"
       - "enable-feature=otlp-write-receiver"
-    global:
-      scrape_interval: 5s
-      scrape_timeout: 3s
-      evaluation_interval: 30s
     persistentVolume:
       enabled: false
     service:
@@ -723,17 +720,7 @@ prometheus:
 
   serverFiles:
     prometheus.yml:
-      scrape_configs:
-        - job_name: 'opentelemetry-community-demo'
-          honor_labels: true
-          kubernetes_sd_configs:
-            - role: pod
-              namespaces:
-                own_namespace: true
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_annotation_opentelemetry_community_demo]
-              action: keep
-              regex: true
+      scrape_configs: []
 
 grafana:
   enabled: true


### PR DESCRIPTION
References: [this PR](https://github.com/open-telemetry/opentelemetry-demo/pull/1174) from the demo repo

Configures Jaeger to properly support all the changes that have happened to the spanmetrics connector (formerly processor). It also removes unneeded Prometheus scrape configs since all data is now sent using the otlp write receiver.

Support for all the spanmetrics changes in Jaeger is done in the latest released version (1.50), but that version is not set with their Helm chart. An override on the Jaeger image tag is set. This override should be removed when the Jaeger Helm chart is updated with this version.