### PR TITLE
[otel-demo] Include namespace in NOTES.txt

### DIFF
--- a/charts/opentelemetry-demo/templates/NOTES.txt
+++ b/charts/opentelemetry-demo/templates/NOTES.txt
@@ -11,7 +11,7 @@
 
 - All services are available via the Frontend proxy: http://localhost:8080
   by running these commands:
-     kubectl port-forward svc/{{ include "otel-demo.name" . }}-frontendproxy 8080:8080
+     kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "otel-demo.name" . }}-frontendproxy 8080:8080
 
   The following services are available at these paths once the proxy is exposed:
   Webstore             http://localhost:8080/


### PR DESCRIPTION
For full copy & paste, the port-forwarding instructions need to  include the namespace.