### PR TITLE
[demo] add replicas support

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.25.8
+version: 0.25.9
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -82,6 +82,7 @@ the demo
 | `default.image.tag`                    | Demo components image tag (leave blank to use app version)                                | `nil`                                                |
 | `default.image.pullPolicy`             | Demo components image pull policy                                                         | `IfNotPresent`                                       |
 | `default.image.pullSecrets`            | Demo components image pull secrets                                                        | `[]`                                                 |
+| `default.replicas`                     | Number of replicas for each component                                                     | `1`                                                  |
 | `default.schedulingRules.nodeSelector` | Node labels for pod assignment                                                            | `{}`                                                 |
 | `default.schedulingRules.affinity`     | Man of node/pod affinities                                                                | `{}`                                                 |
 | `default.schedulingRules.tolerations`  | Tolerations for pod assignment                                                            | `[]`                                                 |
@@ -117,6 +118,7 @@ component.
 | `ports`                              | Array of ports to open for deployment and service of this component                                        | `[]`                                                          |
 | `env`                                | Array of environment variables added to this component                                                     | Each component will have its own set of environment variables |
 | `envOverrides`                       | Used to override individual environment variables without re-specifying the entire array                   | `[]`                                                          |
+| `replicas`                           | Number of replicas for this component                                                                      | `nil`                                                         |
 | `resources`                          | CPU/Memory resource requests/limits                                                                        | Each component will have a default memory limit set           |
 | `schedulingRules.nodeSelector`       | Node labels for pod assignment                                                                             | `{}`                                                          |
 | `schedulingRules.affinity`           | Man of node/pod affinities                                                                                 | `{}`                                                          |

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -118,7 +118,7 @@ component.
 | `ports`                              | Array of ports to open for deployment and service of this component                                        | `[]`                                                          |
 | `env`                                | Array of environment variables added to this component                                                     | Each component will have its own set of environment variables |
 | `envOverrides`                       | Used to override individual environment variables without re-specifying the entire array                   | `[]`                                                          |
-| `replicas`                           | Number of replicas for this component                                                                      | `nil`                                                         |
+| `replicas`                           | Number of replicas for this component                                                                      | `1` for ffsPostgres, kafka, and redis ; `nil` otherwise       |
 | `resources`                          | CPU/Memory resource requests/limits                                                                        | Each component will have a default memory limit set           |
 | `schedulingRules.nodeSelector`       | Node labels for pod assignment                                                                             | `{}`                                                          |
 | `schedulingRules.affinity`           | Man of node/pod affinities                                                                                 | `{}`                                                          |

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -508,6 +509,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -560,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -570,6 +572,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -632,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -642,6 +645,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -712,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -722,6 +726,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -770,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -780,6 +785,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -830,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -840,6 +846,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -910,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -920,6 +927,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -974,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -984,6 +992,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1036,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1046,6 +1055,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1118,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1128,6 +1138,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1204,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1214,6 +1225,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1270,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1280,6 +1292,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1340,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1350,6 +1363,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1402,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1412,6 +1426,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1462,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1472,6 +1487,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1526,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1536,6 +1552,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1592,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1602,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1650,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1660,6 +1678,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -508,6 +509,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -560,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -570,6 +572,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -632,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -642,6 +645,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -712,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -722,6 +726,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -770,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -780,6 +785,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -830,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -840,6 +846,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -910,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -920,6 +927,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -974,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -984,6 +992,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1036,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1046,6 +1055,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1118,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1128,6 +1138,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1204,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1214,6 +1225,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1270,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1280,6 +1292,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1340,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1350,6 +1363,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1402,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1412,6 +1426,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1462,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1472,6 +1487,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1526,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1536,6 +1552,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1592,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1602,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1650,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1660,6 +1678,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -500,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -510,6 +511,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -564,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -574,6 +576,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -638,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -648,6 +651,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -720,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -730,6 +734,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -780,7 +785,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -790,6 +795,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -842,7 +848,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -852,6 +858,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -924,7 +931,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -934,6 +941,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -988,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -998,6 +1006,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1052,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1062,6 +1071,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1136,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1146,6 +1156,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1222,7 +1233,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1232,6 +1243,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1288,7 +1300,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1298,6 +1310,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1360,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1370,6 +1383,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1424,7 +1438,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1434,6 +1448,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1486,7 +1501,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1496,6 +1511,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1552,7 +1568,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1562,6 +1578,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1620,7 +1637,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1630,6 +1647,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1678,7 +1696,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1688,6 +1706,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -508,6 +509,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -560,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -570,6 +572,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -632,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -642,6 +645,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -712,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -722,6 +726,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -770,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -780,6 +785,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -830,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -840,6 +846,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -910,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -920,6 +927,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -974,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -984,6 +992,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1036,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1046,6 +1055,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1118,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1128,6 +1138,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1204,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1214,6 +1225,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1270,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1280,6 +1292,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1340,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1350,6 +1363,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1402,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1412,6 +1426,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1462,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1472,6 +1487,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1526,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1536,6 +1552,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1592,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1602,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1650,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1660,6 +1678,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -446,6 +446,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -508,6 +509,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -560,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -570,6 +572,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -632,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -642,6 +645,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -712,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -722,6 +726,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -770,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -780,6 +785,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -830,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -840,6 +846,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -910,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -920,6 +927,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -974,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -984,6 +992,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1036,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1046,6 +1055,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1118,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1128,6 +1138,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1204,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1214,6 +1225,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1270,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1280,6 +1292,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1340,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1350,6 +1363,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1402,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1412,6 +1426,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1462,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1472,6 +1487,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1526,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1536,6 +1552,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1592,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1602,6 +1619,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1650,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1660,6 +1678,7 @@ metadata:
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   selector:
     matchLabels:
       
@@ -1710,7 +1729,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.25.8
+    helm.sh/chart: opentelemetry-demo-0.25.9
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -1,3 +1,6 @@
+{{/*
+Demo component Deployment template
+*/}}
 {{- define "otel-demo.deployment" }}
 ---
 apiVersion: apps/v1
@@ -7,6 +10,7 @@ metadata:
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .replicas | default .defaultValues.replicas }}
   selector:
     matchLabels:
       {{- include "otel-demo.selectorLabels" . | nindent 6 }}
@@ -77,6 +81,9 @@ spec:
       {{- end}}
 {{- end }}
 
+{{/*
+Demo component Service template
+*/}}
 {{- define "otel-demo.service" }}
 {{- if or .ports .service}}
 {{- $service := .service | default dict }}
@@ -114,6 +121,10 @@ spec:
     {{- include "otel-demo.selectorLabels" . | nindent 4 }}
 {{- end}}
 {{- end}}
+
+{{/*
+Demo component ConfigMap template
+*/}}
 {{- define "otel-demo.configmap" }}
 {{- if .configuration}}
 ---
@@ -130,6 +141,9 @@ data:
 {{- end}}
 {{- end}}
 
+{{/*
+Demo component Ingress template
+*/}}
 {{- define "otel-demo.ingress" }}
 {{- $hasIngress := false}}
 {{- if .ingress }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -138,6 +138,9 @@
         "imageOverride": {
           "$ref": "#/definitions/Image"
         },
+        "replicas": {
+          "type": "integer"
+        },
         "service": {
           "$ref": "#/definitions/Service"
         },
@@ -257,6 +260,9 @@
           "items": {
             "$ref": "#/definitions/Env"
           }
+        },
+        "replicas": {
+          "type": "integer"
         },
         "image": {
           "$ref": "#/definitions/Image"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -1,5 +1,5 @@
 default:
-  # list of environment variables applied to all components
+  # List of environment variables applied to all components
   env:
     - name: OTEL_SERVICE_NAME
       valueFrom:
@@ -23,11 +23,16 @@ default:
     tag: ""
     pullPolicy: IfNotPresent
     pullSecrets: []
+  # Default # of replicas for all components
+  replicas: 1
+  # Default schedulingRules for all components
   schedulingRules:
     nodeSelector: {}
     affinity: {}
     tolerations: []
+  # Default securityContext for all components
   securityContext: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -516,6 +521,7 @@ components:
     imageOverride:
       repository: "postgres"
       tag: "14"
+    replicas: 1
     ports:
       - name: postgres
         value: 5432
@@ -538,6 +544,7 @@ components:
     enabled: true
     useDefault:
       env: true
+    replicas: 1
     ports:
       - name: plaintext
         value: 9092
@@ -565,6 +572,7 @@ components:
     imageOverride:
       repository: "redis"
       tag: "alpine"
+    replicas: 1
     ports:
       - name: redis
         value: 6379

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -131,6 +131,8 @@ components:
   #     - name: <init-container-name>
   #       image: <init-container-image>
   #       command: [list of commands for the init container to run]
+  # # Replicas for the component
+  #  replicas: 1
   accountingService:
     enabled: true
     useDefault:


### PR DESCRIPTION
Adds support to specify the number of replicas for all components or specifically for individual ones. Allowing to set replicas and various load generator settings allows the demo to be deployed in more complex performance-affected scenarios where observability tooling can be used to diagnose the root cause.

Shared demo components such as Redis, Postgres, and Kafka have a `replicas: 1` setting specified at the component level. All other components do not set/override this value, which will inherit from default (1).