### PR TITLE
upgrade to 0.88 include bridge

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -18,7 +18,7 @@ runs:
         python-version: 3.7
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@v2.6.0
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.5.0

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -26,6 +26,11 @@ jobs:
       - name: Install Openshift route crd
         run: kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deploy/route_crd.yaml
 
+      - name: Install Prometheus CRDs
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+
       - name: Install cert-manager
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -47,12 +47,14 @@ jobs:
 
       - name: Use public target-allocator image in tests
         run: |
+          appVersion=$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p')
           LOCAL_TARGET_ALLOCATOR_IMG="local\/opentelemetry-operator-targetallocator:e2e"
-          PUBLIC_TARGET_ALLOCATOR_IMG="ghcr.io\/open-telemetry\/opentelemetry-operator\/target-allocator:0.1.0"
+          PUBLIC_TARGET_ALLOCATOR_IMG="ghcr.io\/open-telemetry\/opentelemetry-operator\/target-allocator:$appVersion"
 
           sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/smoke-targetallocator/*.yaml
           sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/targetallocator-features/00-install.yaml
           sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/prometheus-config-validation/*.yaml
+          sed -i "s/$LOCAL_TARGET_ALLOCATOR_IMG/${PUBLIC_TARGET_ALLOCATOR_IMG}/g" ./opentelemetry-operator/tests/e2e/targetallocator-prometheuscr/00-install.yaml
 
       - name: Install kuttl
         run: |

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ update-operator-crds:
 	APP_VERSION=$$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p') ; \
 	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml ; \
 	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_instrumentations.yaml
+	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opampbridges.yaml
 
 .PHONY: check-operator-crds
 check-operator-crds:
@@ -65,6 +66,7 @@ check-operator-crds:
 	mkdir -p ${TMP_DIRECTORY}/crds; \
 	curl -s -o "${TMP_DIRECTORY}/crds/crd-opentelemetrycollector.yaml" https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml; \
 	curl -s -o "${TMP_DIRECTORY}/crds/crd-opentelemetryinstrumentation.yaml" https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_instrumentations.yaml; \
+	curl -s -o "${TMP_DIRECTORY}/crds/crd-opentelemetry.io_opampbridges.yaml" https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opampbridges.yaml; \
 	if diff ${TMP_DIRECTORY}/crds ./charts/opentelemetry-operator/crds > /dev/null; then \
 		echo "Passed"; \
 		rm -rf ${TMP_DIRECTORY}; \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ check-examples:
 update-operator-crds:
 	APP_VERSION=$$(cat ./charts/opentelemetry-operator/Chart.yaml | sed -nr 's/appVersion: ([0-9]+\.[0-9]+\.[0-9]+)/\1/p') ; \
 	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml ; \
-	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_instrumentations.yaml
+	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_instrumentations.yaml ; \
 	curl -s -o ./charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v$${APP_VERSION}/config/crd/bases/opentelemetry.io_opampbridges.yaml
 
 .PHONY: check-operator-crds

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.41.0
+version: 0.42.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.87.0
+appVersion: 0.88.0

--- a/charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -1,0 +1,1 @@
+404: Not Found

--- a/charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -1,1 +1,2823 @@
-404: Not Found
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: opampbridges.opentelemetry.io
+spec:
+  group: opentelemetry.io
+  names:
+    kind: OpAMPBridge
+    listKind: OpAMPBridgeList
+    plural: opampbridges
+    singular: opampbridge
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: OpenTelemetry Version
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpAMPBridge is the Schema for the opampbridges API.
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values.
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpAMPBridgeSpec defines the desired state of OpAMPBridge.
+            properties:
+              affinity:
+                description: If specified, indicates the pod's scheduling constraints
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector.
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: 'This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose '
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-locate
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: 'This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose '
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector.
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: 'This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose '
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-locate
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: 'This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose '
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              capabilities:
+                additionalProperties:
+                  type: boolean
+                description: Capabilities supported by the OpAMP Bridge
+                type: object
+              componentsAllowed:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: ComponentsAllowed is a list of allowed OpenTelemetry
+                  components for each pipeline type (receiver, processor, etc.)
+                type: object
+              endpoint:
+                description: OpAMP backend Server endpoint
+                type: string
+              env:
+                description: ENV vars to set on the OpAMPBridge Pods.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables.
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: List of sources to populate environment variables on
+                  the OpAMPBridge Pods.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
+                type: boolean
+              image:
+                description: Image indicates the container image to use for the OpAMPBridge.
+                type: string
+              imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image (Always, Never, IfNotPresent)
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to schedule OpAMPBridge pods.
+                type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: PodAnnotations is the set of annotations that will be
+                  attached to OpAMPBridge pods.
+                type: object
+              podSecurityContext:
+                description: PodSecurityContext will be set as the pod security context.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod.
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work.
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID,
+                      the fsGroup (if specified), and group memberships defined in
+                      the container image for th
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                        type: string
+                    type: object
+                type: object
+              ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service.
+                items:
+                  description: ServicePort contains information on service's port.
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This is
+                        used as a hint for implementations to offer richer behavior
+                        for protocols that they understand. This field follows standard
+                        Kubernetes label syntax.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names.
+                      type: string
+                    nodePort:
+                      description: The port on each node on which this service is
+                        exposed when type is NodePort or LoadBalancer.  Usually assigned
+                        by the system.
+                      format: int32
+                      type: integer
+                    port:
+                      description: The port that will be exposed by this service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      default: TCP
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Number or name of the port to access on the pods
+                        targeted by the service. Number must be in the range 1 to
+                        65535. Name must be an IANA_SVC_NAME.
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - port
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              priorityClassName:
+                description: If specified, indicates the pod's priority. If not specified,
+                  the pod priority will be default or zero if there is no default.
+                type: string
+              replicas:
+                description: Replicas is the number of pod instances for the OpAMPBridge.
+                format: int32
+                maximum: 1
+                type: integer
+              resources:
+                description: Resources to set on the OpAMPBridge pods.
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum amount of compute
+                      resources required.
+                    type: object
+                type: object
+              securityContext:
+                description: SecurityContext will be set as the container security
+                  context.
+                properties:
+                  allowPrivilegeEscalation:
+                    description: AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process.
+                    type: boolean
+                  capabilities:
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
+                  privileged:
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
+                  procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                    type: string
+                  readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false. Note that this field cannot be set when spec.os.name
+                      is windows.
+                    type: boolean
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in PodSecurityContext.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in PodSecurityContext.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work.
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will
+                      be used.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                        type: string
+                    type: object
+                type: object
+              serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance. When set, the operator will not
+                  automatically create a ServiceAccount for the OpAMPBridge.
+                type: string
+              tolerations:
+                description: Toleration to schedule OpAMPBridge pods.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: TopologySpreadConstraints embedded kubernetes pod configuration
+                  option, controls how pods are spread across your cluster among failure-domains
+                  such as regions, zones, nodes, and other user-defined top
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: LabelSelector is used to find matching pods. Pods
+                        that match this label selector are counted to determine the
+                        number of pods in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    maxSkew:
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
+                      format: int32
+                      type: integer
+                    minDomains:
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
+                      format: int32
+                      type: integer
+                    nodeAffinityPolicy:
+                      description: NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew.
+                      type: string
+                    nodeTaintsPolicy:
+                      description: NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew.
+                      type: string
+                    topologyKey:
+                      description: TopologyKey is the key of node labels. Nodes that
+                        have a label with this key and identical values are considered
+                        to be in the same topology.
+                      type: string
+                    whenUnsatisfiable:
+                      description: WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn't satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it.
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
+                  type: object
+                type: array
+              upgradeStrategy:
+                description: UpgradeStrategy represents how the operator will handle
+                  upgrades to the CR when a newer version of the operator is deployed
+                enum:
+                - automatic
+                - none
+                type: string
+              volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying OpAMPBridge deployment(s)
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  OpAMPBridge deployment(s).
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'awsElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs".'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1".'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly value true will force the readOnly
+                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'volumeID is unique ID of the persistent disk
+                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: azureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          description: fsType is Filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set).'
+                          type: string
+                        readOnly:
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: azureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: 'user is optional: User is the rados user name,
+                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                            be "ext4" if unspecified.'
+                          type: string
+                        readOnly:
+                          description: 'readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is optional: points to a secret
+                            object containing parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: 'volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: items if unspecified, each key-value pair in
+                            the Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers (Beta
+                        feature).
+                      properties:
+                        driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated
+                            CSI driver which will determine the default filesystem
+                            to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: nodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: readOnly specifies a read-only configuration
+                            for the volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: volumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a Optional: mode bits used to set
+                            permissions on created files by default.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file, must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'emptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: medium represents what type of storage medium
+                            should back this directory. The default is "" which means
+                            to use the node's default medium. Must be an empty string
+                            (default) or Memory.
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume. The size limit is also
+                            applicable for memory medium.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
+                      properties:
+                        volumeClaimTemplate:
+                          description: Will be used to create a stand-alone PVC to
+                            provision the volume. The pod in which this EphemeralVolumeSource
+                            is embedded will be the owner of the PVC, i.e.
+                          properties:
+                            metadata:
+                              description: May contain labels and annotations that
+                                will be copied into the PVC when creating it. No other
+                                fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: The specification for the PersistentVolumeClaim.
+                                The entire content is copied unchanged into the PVC
+                                that gets created from this template.
+                              properties:
+                                accessModes:
+                                  description: 'accessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  description: 'dataSource field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: dataSourceRef specifies the object
+                                    from which to populate the volume with data, if
+                                    a non-empty volume is desired.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of resource
+                                        being referenced Note that when a namespace
+                                        is specified, a gateway.networking.k8s.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: resources represents the minimum resources
+                                    the volume should have.
+                                  properties:
+                                    claims:
+                                      description: "Claims lists the names of resources,
+                                        defined in spec.resourceClaims, that are used
+                                        by this container. \n This is an alpha field
+                                        and requires enabling the DynamicResourceAllocation
+                                        feature gate."
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: Name must match the name
+                                              of one entry in pod.spec.resourceClaims
+                                              of the Pod where this field is used.
+                                              It makes that resource available inside
+                                              a container.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: 'storageClassName is the name of the
+                                    StorageClass required by the claim. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem
+                                    is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'wwids Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: flexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                            on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'readOnly is Optional: defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is Optional: secretRef is reference
+                            to the secret object containing sensitive information
+                            to pass to the plugin scripts. This may be empty if no
+                            secret object is specified.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: datasetName is Name of the dataset stored as
+                            metadata -> name on the dataset for Flocker should be
+                            considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'gcePersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.'
+                      properties:
+                        fsType:
+                          description: 'fsType is filesystem type of the volume that
+                            you want to mount. Tip: Ensure that the filesystem type
+                            is supported by the host operating system. Examples: "ext4",
+                            "xfs", "ntfs".'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1".'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'pdName is unique name of the PD resource in
+                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'gitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated.'
+                      properties:
+                        directory:
+                          description: directory is the target directory name. Must
+                            not contain or start with '..'.  If '.' is supplied, the
+                            volume directory will be the git repository.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'endpoints is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: hostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                      properties:
+                        path:
+                          description: 'path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'iscsi represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs".'
+                          type: string
+                        initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iscsiInterface is the interface Name that uses
+                            an iSCSI transport. Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: portals is the iSCSI Target Portal List. The
+                            portal is either an IP or ip_addr:port if the port is
+                            other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: targetPortal is iSCSI Target Portal. The Portal
+                            is either an IP or ip_addr:port if the port is other than
+                            default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'name of the volume. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'nfs represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'persistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.'
+                      properties:
+                        claimName:
+                          description: 'claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: readOnly Will force the ReadOnly setting in
+                            VolumeMounts. Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: sources is the list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token.
+                                    type: string
+                                  expirationSeconds:
+                                    description: expirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
+                      properties:
+                        group:
+                          description: group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: readOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: user to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: 'rbd represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs".'
+                          type: string
+                        image:
+                          description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        pool:
+                          description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: 'user is the rados user name. Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: volumeName is the name of a volume already
+                            created in the ScaleIO system that is associated with
+                            this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: items If unspecified, each key-value pair in
+                            the Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: 'secretName is the name of the secret in the
+                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
+                      type: object
+                    storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: volumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - capabilities
+            - endpoint
+            type: object
+          status:
+            description: OpAMPBridgeStatus defines the observed state of OpAMPBridge.
+            properties:
+              version:
+                description: Version of the managed OpAMP Bridge (operand)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
@@ -331,7 +331,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -498,7 +498,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -775,7 +775,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -943,7 +943,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -1223,7 +1223,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -1390,7 +1390,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -1574,7 +1574,7 @@ spec:
                     - type: integer
                     - type: string
                     description: VolumeSizeLimit defines size limit for volume used
-                      for auto-instrumentation. The default size is 150Mi.
+                      for auto-instrumentation. The default size is 200Mi.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -85,9 +85,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -188,6 +188,32 @@ rules:
       - patch
       - update
   - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
     - route.openshift.io
     resources:
     - routes

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -226,9 +226,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -244,9 +244,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -33,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.87.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.88.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.87.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.88.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
+    helm.sh/chart: opentelemetry-operator-0.42.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -183,6 +183,32 @@ rules:
       - patch
       - update
   - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
     - route.openshift.io
     resources:
     - routes

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -46,8 +46,8 @@ spec:
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
             - --collector-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
-            {{- if and .Values.manager.operatorOpampBridgeImage.repository .Values.manager.operatorOpampBridgeImage.tag }}
-            - --operator-opamp-bridge-image={{ .Values.manager.operatorOpampBridgeImage.repository }}:{{ .Values.manager.operatorOpampBridgeImage.tag }}
+            {{- if and .Values.manager.opampBridgeImage.repository .Values.manager.opampBridgeImage.tag }}
+            - --operator-opamp-bridge-image={{ .Values.manager.opampBridgeImage.repository }}:{{ .Values.manager.opampBridgeImage.tag }}
             {{- end }}
             {{- if and .Values.manager.targetAllocatorImage.repository .Values.manager.targetAllocatorImage.tag }}
             - --target-allocator-image={{ .Values.manager.targetAllocatorImage.repository }}:{{ .Values.manager.targetAllocatorImage.tag }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             {{- if and .Values.manager.collectorImage.repository .Values.manager.collectorImage.tag }}
             - --collector-image={{ .Values.manager.collectorImage.repository }}:{{ .Values.manager.collectorImage.tag }}
             {{- end }}
+            {{- if and .Values.manager.operatorOpampBridgeImage.repository .Values.manager.operatorOpampBridgeImage.tag }}
+            - --operator-opamp-bridge-image={{ .Values.manager.operatorOpampBridgeImage.repository }}:{{ .Values.manager.operatorOpampBridgeImage.tag }}
+            {{- end }}
             {{- if and .Values.manager.targetAllocatorImage.repository .Values.manager.targetAllocatorImage.tag }}
             - --target-allocator-image={{ .Values.manager.targetAllocatorImage.repository }}:{{ .Values.manager.targetAllocatorImage.tag }}
             {{- end }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -101,6 +101,7 @@
             "required": [
                 "image",
                 "collectorImage",
+                "operatorOpampBridgeImage",
                 "targetAllocatorImage",
                 "autoInstrumentationImage",
                 "ports",
@@ -177,6 +178,37 @@
                     "examples": [{
                         "repository": "otel/opentelemetry-collector-contrib",
                         "tag": "0.77.0"
+                    }]
+                },
+                "operatorOpampBridgeImage": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The operatorOpampBridgeImage Schema",
+                    "required": [
+                        "repository",
+                        "tag"
+                    ],
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The repository Schema",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The tag Schema",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "repository": "",
+                        "tag": ""
                     }]
                 },
                 "targetAllocatorImage": {

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -101,7 +101,7 @@
             "required": [
                 "image",
                 "collectorImage",
-                "operatorOpampBridgeImage",
+                "opampBridgeImage",
                 "targetAllocatorImage",
                 "autoInstrumentationImage",
                 "ports",
@@ -180,10 +180,10 @@
                         "tag": "0.77.0"
                     }]
                 },
-                "operatorOpampBridgeImage": {
+                "opampBridgeImage": {
                     "type": "object",
                     "default": {},
-                    "title": "The operatorOpampBridgeImage Schema",
+                    "title": "The opampBridgeImage Schema",
                     "required": [
                         "repository",
                         "tag"

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -29,10 +29,10 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.87.0
+    tag: v0.88.0
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.87.0
+    tag: 0.88.0
   operatorOpampBridgeImage:
     repository: ""
     tag: ""

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -33,6 +33,9 @@ manager:
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
     tag: 0.87.0
+  operatorOpampBridgeImage:
+    repository: ""
+    tag: ""
   targetAllocatorImage:
     repository: ""
     tag: ""

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -33,7 +33,7 @@ manager:
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
     tag: 0.88.0
-  operatorOpampBridgeImage:
+  opampBridgeImage:
     repository: ""
     tag: ""
   targetAllocatorImage:


### PR DESCRIPTION
With the merging of the [operator release](https://github.com/open-telemetry/opentelemetry-operator/pull/2297#pullrequestreview-1708409527), the opamp-bridge has now been released. This PR upgrades the helm chart to the latest version and includes the bridge CRD.

Also had to update testing action. see [here](https://github.com/helm/chart-testing-action/issues/132) 