### PR TITLE
Adding namespace scope to webhook config

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.42.1
+version: 0.42.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.42.2
+version: 0.42.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -88,7 +88,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -33,6 +33,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -54,6 +55,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -75,6 +77,7 @@ webhooks:
           - UPDATE
         resources:
           - pods
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
 ---
@@ -112,6 +115,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -132,6 +136,7 @@ webhooks:
           - DELETE
         resources:
           - instrumentations
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -153,6 +158,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -173,5 +179,6 @@ webhooks:
           - DELETE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -88,7 +88,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.1
+    helm.sh/chart: opentelemetry-operator-0.42.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.42.2
+    helm.sh/chart: opentelemetry-operator-0.42.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.88.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -36,6 +36,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -65,6 +66,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -94,6 +96,7 @@ webhooks:
           - UPDATE
         resources:
           - pods
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 ---
@@ -134,6 +137,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -162,6 +166,7 @@ webhooks:
           - DELETE
         resources:
           - instrumentations
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -191,6 +196,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -219,6 +225,7 @@ webhooks:
           - DELETE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -69,6 +69,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -103,6 +104,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -137,6 +139,7 @@ webhooks:
           - UPDATE
         resources:
           - pods
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 ---
@@ -182,6 +185,7 @@ webhooks:
         - UPDATE
       resources:
         - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -215,6 +219,7 @@ webhooks:
           - DELETE
         resources:
           - instrumentations
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -249,6 +254,7 @@ webhooks:
           - UPDATE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
   - admissionReviewVersions:
@@ -282,6 +288,7 @@ webhooks:
           - DELETE
         resources:
           - opentelemetrycollectors
+        scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 {{- end }}


### PR DESCRIPTION
This PR explicitly defines the rule scope for the admission-webhook configurations.
Since the rules are only defining one resource type per rule, I chose to explicitly define the scope instead of providing variables that would allow customization.

This fixes #939 

Thanks in advance!