### PR TITLE
fix: chart-testing ci

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,14 +11,14 @@ runs:
     - name: Set up Helm
       uses: azure/setup-helm@v3.5
       with:
-        version: v3.9.0
+        version: v3.12.1
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@v2.6.0
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.5.0


### PR DESCRIPTION
Looks like current chart-testing CI is failing with error:
> INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
>      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
> ERROR: Unable to validate cosign version: 'v2.0.0'


Example: https://github.com/open-telemetry/opentelemetry-helm-charts/actions/runs/6739935370/job/18332086909?pr=940

Newer version chart testing action has fixed this.
