### PR TITLE
Added environment variable and increased memory limit

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -411,13 +411,15 @@ components:
         value: "false"
       - name: LOCUST_AUTOSTART
         value: "true"
+      - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+        value: "false"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
-        memory: 120Mi
+        memory: 1Gi
 
   paymentService:
     enabled: true


### PR DESCRIPTION
In this PR, we aim to add the environment variable `LOCUST_BROWSER_TRAFFIC_ENABLED` and increase the memory limit for the load generation. The main reason is to be able to run playwright in locust and generate web browser traffic. For more information, please have a look at the [corresponding PR](https://github.com/open-telemetry/opentelemetry-demo/pull/1264)
