### PR TITLE
Added environment variable and increased memory limit

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.26.0
+version: 0.27.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1337,6 +1337,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "false"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1345,7 +1347,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1353,7 +1355,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1418,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1479,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1544,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1670,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1337,6 +1337,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "false"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1345,7 +1347,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1353,7 +1355,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1418,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1479,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1544,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1670,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +785,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +848,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +931,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1146,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1233,7 +1233,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1300,7 +1300,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1355,6 +1355,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "false"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1367,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1373,7 +1375,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1501,7 +1503,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1568,7 +1570,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1637,7 +1639,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1696,7 +1698,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1337,6 +1337,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "false"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1345,7 +1347,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1353,7 +1355,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1418,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1479,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1544,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1670,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1337,6 +1337,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "false"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1345,7 +1347,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1353,7 +1355,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1418,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1479,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1544,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1670,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1731,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -411,13 +411,15 @@ components:
         value: "false"
       - name: LOCUST_AUTOSTART
         value: "true"
+      - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+        value: "false"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
-        memory: 120Mi
+        memory: 1Gi
 
   paymentService:
     enabled: true


### PR DESCRIPTION
In this PR, we aim to add the environment variable `LOCUST_BROWSER_TRAFFIC_ENABLED` and increase the memory limit for the load generation. The main reason is to be able to run playwright in locust and generate web browser traffic. For more information, please have a look at the [corresponding PR](https://github.com/open-telemetry/opentelemetry-demo/pull/1266)