### PR TITLE
fix: #961 for cartservice disable reload on config change

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -180,6 +180,8 @@ components:
         value: "8080"
       - name: ASPNETCORE_URLS
         value: http://*:$(CART_SERVICE_PORT)
+      - name: DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE
+        value: "false"
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
       - name: REDIS_ADDR


### PR DESCRIPTION
Prevent cart service from watching the file system for changes and reloading to resolve #961. See details and rationale in #961.
