### PR TITLE
Add k8s infra monitorig demo example

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.26.0
+version: 0.27.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.27.0
+version: 0.26.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/README.md
+++ b/charts/opentelemetry-demo/examples/README.md
@@ -6,6 +6,7 @@ Here is a collection of common configurations for the OpenTelemetry demo.  Each 
 - [Bring your own Observability](bring-your-own-observability)
 - [Collector as a Daemonset](collector-as-daemonset)
 - [Custom Environment Variables](custom-environment-variables)
+- [Kubernetes Infrastructure Monitoring](kubernetes-infra-monitoring)
 - [Public Hosted Ingress](public-hosted-ingress)
 
 The manifests are rendered using the `helm template` command and the specific example folder's values.yaml.

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +785,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +848,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +931,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1146,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1233,7 +1233,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1300,7 +1300,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1438,7 +1438,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1501,7 +1501,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1568,7 +1568,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1637,7 +1637,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1696,7 +1696,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +785,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +848,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +931,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1146,7 +1146,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1233,7 +1233,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1300,7 +1300,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1438,7 +1438,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1501,7 +1501,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1568,7 +1568,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1637,7 +1637,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1696,7 +1696,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -1,0 +1,1724 @@
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-adservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-adservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-adservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-cartservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-cartservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-cartservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-checkoutservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-checkoutservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-checkoutservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-currencyservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-currencyservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-currencyservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-emailservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-emailservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-emailservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-featureflagservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-featureflagservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 50053
+      name: grpc
+      targetPort: 50053
+    - port: 8081
+      name: http
+      targetPort: 8081
+  selector:
+    
+    opentelemetry.io/name: example-featureflagservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-ffspostgres
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      name: postgres
+      targetPort: 5432
+  selector:
+    
+    opentelemetry.io/name: example-ffspostgres
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-frontend
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-frontend
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-frontend
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-frontendproxy
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-frontendproxy
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-frontendproxy
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-kafka
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-kafka
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9092
+      name: plaintext
+      targetPort: 9092
+    - port: 9093
+      name: controller
+      targetPort: 9093
+  selector:
+    
+    opentelemetry.io/name: example-kafka
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-loadgenerator
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-loadgenerator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8089
+      name: tcp-service
+      targetPort: 8089
+  selector:
+    
+    opentelemetry.io/name: example-loadgenerator
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-paymentservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-paymentservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-paymentservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-productcatalogservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-productcatalogservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-productcatalogservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-quoteservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-quoteservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-quoteservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-recommendationservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-recommendationservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-recommendationservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-redis
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-redis
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      name: redis
+      targetPort: 6379
+  selector:
+    
+    opentelemetry.io/name: example-redis
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-shippingservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-shippingservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: tcp-service
+      targetPort: 8080
+  selector:
+    
+    opentelemetry.io/name: example-shippingservice
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-accountingservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-accountingservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: accountingservice
+    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-accountingservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-accountingservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: accountingservice
+        app.kubernetes.io/name: example-accountingservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: accountingservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-accountingservice'
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: KAFKA_SERVICE_ADDR
+            value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 example-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-adservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-adservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: adservice
+    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-adservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-adservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: adservice
+        app.kubernetes.io/name: example-adservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: adservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-adservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: AD_SERVICE_PORT
+            value: "8080"
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_LOGS_EXPORTER
+            value: otlp
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 300Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-cartservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-cartservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: cartservice
+    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-cartservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-cartservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: cartservice
+        app.kubernetes.io/name: example-cartservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: cartservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-cartservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CART_SERVICE_PORT
+            value: "8080"
+          - name: ASPNETCORE_URLS
+            value: http://*:$(CART_SERVICE_PORT)
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
+          - name: REDIS_ADDR
+            value: 'example-redis:6379'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 160Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 example-redis 6379; do echo waiting
+            for redis; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-redis
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-checkoutservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-checkoutservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: checkoutservice
+    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-checkoutservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-checkoutservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: checkoutservice
+        app.kubernetes.io/name: example-checkoutservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: checkoutservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-checkoutservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CHECKOUT_SERVICE_PORT
+            value: "8080"
+          - name: CART_SERVICE_ADDR
+            value: 'example-cartservice:8080'
+          - name: CURRENCY_SERVICE_ADDR
+            value: 'example-currencyservice:8080'
+          - name: EMAIL_SERVICE_ADDR
+            value: http://example-emailservice:8080
+          - name: PAYMENT_SERVICE_ADDR
+            value: 'example-paymentservice:8080'
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: SHIPPING_SERVICE_ADDR
+            value: 'example-shippingservice:8080'
+          - name: KAFKA_SERVICE_ADDR
+            value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 example-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-currencyservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-currencyservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: currencyservice
+    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-currencyservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-currencyservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: currencyservice
+        app.kubernetes.io/name: example-currencyservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: currencyservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-currencyservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: CURRENCY_SERVICE_PORT
+            value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-emailservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-emailservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: emailservice
+    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-emailservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-emailservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: emailservice
+        app.kubernetes.io/name: example-emailservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: emailservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-emailservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: EMAIL_SERVICE_PORT
+            value: "8080"
+          - name: APP_ENV
+            value: production
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 100Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-featureflagservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-featureflagservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: featureflagservice
+    app.kubernetes.io/name: example-featureflagservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-featureflagservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-featureflagservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: featureflagservice
+        app.kubernetes.io/name: example-featureflagservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: featureflagservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-featureflagservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 50053
+            name: grpc
+          - containerPort: 8081
+            name: http
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FEATURE_FLAG_SERVICE_PORT
+            value: "8081"
+          - name: FEATURE_FLAG_GRPC_SERVICE_PORT
+            value: "50053"
+          - name: DATABASE_URL
+            value: ecto://ffs:ffs@example-ffspostgres:5432/ffs
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+            value: grpc
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 175Mi
+          livenessProbe:
+            httpGet:
+              path: /featureflags/
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 example-ffspostgres 5432; do echo
+            waiting for ffspostgres; sleep 2; done
+          image: busybox:latest
+          name: wait-for-ffspostgres
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-ffspostgres
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-ffspostgres
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-ffspostgres
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: ffspostgres
+        app.kubernetes.io/name: example-ffspostgres
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: ffspostgres
+          image: 'postgres:14'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 5432
+            name: postgres
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: POSTGRES_DB
+            value: ffs
+          - name: POSTGRES_USER
+            value: ffs
+          - name: POSTGRES_PASSWORD
+            value: ffs
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 120Mi
+          securityContext:
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-frauddetectionservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-frauddetectionservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: frauddetectionservice
+    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-frauddetectionservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-frauddetectionservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: frauddetectionservice
+        app.kubernetes.io/name: example-frauddetectionservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: frauddetectionservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-frauddetectionservice'
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: KAFKA_SERVICE_ADDR
+            value: 'example-kafka:9092'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 200Mi
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 example-kafka 9092; do echo waiting
+            for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-frontend
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-frontend
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-frontend
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-frontend
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: example-frontend
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: frontend
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-frontend'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: FRONTEND_PORT
+            value: "8080"
+          - name: FRONTEND_ADDR
+            value: :8080
+          - name: AD_SERVICE_ADDR
+            value: 'example-adservice:8080'
+          - name: CART_SERVICE_ADDR
+            value: 'example-cartservice:8080'
+          - name: CHECKOUT_SERVICE_ADDR
+            value: 'example-checkoutservice:8080'
+          - name: CURRENCY_SERVICE_ADDR
+            value: 'example-currencyservice:8080'
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: 'example-recommendationservice:8080'
+          - name: SHIPPING_SERVICE_ADDR
+            value: 'example-shippingservice:8080'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: WEB_OTEL_SERVICE_NAME
+            value: frontend-web
+          - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://localhost:8080/otlp-http/v1/traces
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 200Mi
+          securityContext:
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-frontendproxy
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-frontendproxy
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: frontendproxy
+    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-frontendproxy
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-frontendproxy
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: frontendproxy
+        app.kubernetes.io/name: example-frontendproxy
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: frontendproxy
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-frontendproxy'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: ENVOY_PORT
+            value: "8080"
+          - name: FRONTEND_PORT
+            value: "8080"
+          - name: FRONTEND_HOST
+            value: 'example-frontend'
+          - name: FEATURE_FLAG_SERVICE_PORT
+            value: "8081"
+          - name: FEATURE_FLAG_SERVICE_HOST
+            value: 'example-featureflagservice'
+          - name: LOCUST_WEB_PORT
+            value: "8089"
+          - name: LOCUST_WEB_HOST
+            value: 'example-loadgenerator'
+          - name: GRAFANA_SERVICE_PORT
+            value: "80"
+          - name: GRAFANA_SERVICE_HOST
+            value: 'example-grafana'
+          - name: JAEGER_SERVICE_PORT
+            value: "16686"
+          - name: JAEGER_SERVICE_HOST
+            value: 'example-jaeger-query'
+          - name: OTEL_COLLECTOR_PORT_GRPC
+            value: "4317"
+          - name: OTEL_COLLECTOR_PORT_HTTP
+            value: "4318"
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 50Mi
+          securityContext:
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 101
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-kafka
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-kafka
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-kafka
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-kafka
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: example-kafka
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: kafka
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-kafka'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 9092
+            name: plaintext
+          - containerPort: 9093
+            name: controller
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: KAFKA_ADVERTISED_LISTENERS
+            value: PLAINTEXT://example-kafka:9092
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: KAFKA_HEAP_OPTS
+            value: -Xmx200M -Xms200M
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 500Mi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-loadgenerator
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-loadgenerator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: loadgenerator
+    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-loadgenerator
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-loadgenerator
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: loadgenerator
+        app.kubernetes.io/name: example-loadgenerator
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: loadgenerator
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-loadgenerator'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8089
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: LOCUST_WEB_PORT
+            value: "8089"
+          - name: LOCUST_USERS
+            value: "10"
+          - name: LOCUST_SPAWN_RATE
+            value: "1"
+          - name: LOCUST_HOST
+            value: http://example-frontendproxy:8080
+          - name: LOCUST_HEADLESS
+            value: "false"
+          - name: LOCUST_AUTOSTART
+            value: "true"
+          - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+            value: python
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 120Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-paymentservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-paymentservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: paymentservice
+    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-paymentservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-paymentservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: paymentservice
+        app.kubernetes.io/name: example-paymentservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: paymentservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-paymentservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: PAYMENT_SERVICE_PORT
+            value: "8080"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 120Mi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-productcatalogservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-productcatalogservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: productcatalogservice
+    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-productcatalogservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-productcatalogservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: productcatalogservice
+        app.kubernetes.io/name: example-productcatalogservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: productcatalogservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-productcatalogservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: PRODUCT_CATALOG_SERVICE_PORT
+            value: "8080"
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-quoteservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-quoteservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: quoteservice
+    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-quoteservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-quoteservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: quoteservice
+        app.kubernetes.io/name: example-quoteservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: quoteservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-quoteservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: QUOTE_SERVICE_PORT
+            value: "8080"
+          - name: OTEL_PHP_AUTOLOAD_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 40Mi
+          securityContext:
+            runAsGroup: 33
+            runAsNonRoot: true
+            runAsUser: 33
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-recommendationservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-recommendationservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: recommendationservice
+    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-recommendationservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-recommendationservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: recommendationservice
+        app.kubernetes.io/name: example-recommendationservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: recommendationservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-recommendationservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: RECOMMENDATION_SERVICE_PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: 'example-productcatalogservice:8080'
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: 'example-featureflagservice:50053'
+          - name: OTEL_PYTHON_LOG_CORRELATION
+            value: "true"
+          - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+            value: python
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 500Mi
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-redis
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-redis
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-redis
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-redis
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: redis
+        app.kubernetes.io/name: example-redis
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: redis
+          image: 'redis:alpine'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 6379
+            name: redis
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 999
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-shippingservice
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example-shippingservice
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: shippingservice
+    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: example-shippingservice
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: example-shippingservice
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: shippingservice
+        app.kubernetes.io/name: example-shippingservice
+    spec:
+      serviceAccountName: example
+      containers:
+        - name: shippingservice
+          image: 'ghcr.io/open-telemetry/demo:1.6.0-shippingservice'
+          imagePullPolicy: IfNotPresent
+          ports:
+          
+          - containerPort: 8080
+            name: service
+          env:
+          - name: OTEL_SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: OTEL_COLLECTOR_NAME
+            value: 'example-otelcol'
+          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+            value: cumulative
+          - name: SHIPPING_SERVICE_PORT
+            value: "8080"
+          - name: QUOTE_SERVICE_ADDR
+            value: http://example-quoteservice:8080
+          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4317/v1/traces
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
+          resources:
+            limits:
+              memory: 20Mi

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -1,0 +1,7437 @@
+---
+# Source: opentelemetry-demo/templates/grafana-dashboards.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-grafana-dashboards
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  
+  demo-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 14,
+          "panels": [],
+          "title": "Metrics",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "rate(process_runtime_cpython_cpu_time_seconds_total{type=~\"system\"}[$__rate_interval])*100",
+              "hide": false,
+              "interval": "2m",
+              "legendFormat": "{{job}} ({{type}})",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "rate(process_runtime_cpython_cpu_time_seconds_total{type=~\"user\"}[$__rate_interval])*100",
+              "hide": false,
+              "interval": "2m",
+              "legendFormat": "{{job}} ({{type}})",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Python services (CPU%)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "opentelemetry-demo/(.*)",
+                "renamePattern": "$1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "process_runtime_cpython_memory_bytes{type=\"rss\"}",
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Python services (Memory)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "opentelemetry-demo/(.*)",
+                "renamePattern": "$1"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "rate(app_recommendations_counter_total{recommendation_type=\"catalog\"}[$__rate_interval])",
+              "interval": "2m",
+              "legendFormat": "recommendations",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Recommendations Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": " sum by (span_name) (rate(calls_total{status_code=\"STATUS_CODE_ERROR\", service_name=\"${service}\"}[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "{{ span_name }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Error Rate for ${service} by span name",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "dtdurationms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.50, sum(rate(duration_milliseconds_bucket{service_name=\"${service}\"}[$__rate_interval])) by (le))",
+              "legendFormat": "quantile50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{service_name=\"${service}\"}[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "quantile95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.99, sum(rate(duration_milliseconds_bucket{service_name=\"${service}\"}[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "quantile99",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.999, sum(rate(duration_milliseconds_bucket{service_name=\"${service}\"}[$__rate_interval])) by (le))",
+              "hide": false,
+              "legendFormat": "quantile999",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Latency for ${service}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum by (span_name) (rate(duration_milliseconds_count{service_name=\"${service}\"}[$__rate_interval]))",
+              "legendFormat": "{{ span_name }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Requests Rate for ${service} by span name",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "rate(otel_trace_span_processor_spans{job=\"opentelemetry-demo/quoteservice\"}[2m])*120",
+              "interval": "2m",
+              "legendFormat": "{{state}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Quote Service batch span processor",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "",
+      "revision": 1,
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": "",
+            "current": {
+              "selected": false,
+              "text": "frontend",
+              "value": "frontend"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "duration_milliseconds_bucket",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "service",
+            "options": [],
+            "query": {
+              "query": "duration_milliseconds_bucket",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "/.*service_name=\\\"([^\\\"]+)\\\".*/",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Demo Dashboard",
+      "uid": "W2gX2zHVk",
+      "version": 1,
+      "weekStart": ""
+    }
+  opentelemetry-collector-data-flow.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "otelcol metrics dashboard",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 6,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 8,
+          "panels": [],
+          "title": "Process",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Otel Collector Instance",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 0,
+            "y": 1
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "count(count(otelcol_process_cpu_seconds{service_instance_id=~\".*\"}) by (service_instance_id))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Instance",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_process_cpu_seconds",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 1
+          },
+          "id": 24,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(rate(otelcol_process_cpu_seconds{}[$__rate_interval])*100) by (instance)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cpu",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Memory Rss\navg(otelcol_process_memory_rss{}) by (instance)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 6,
+            "y": 1
+          },
+          "id": 38,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(otelcol_process_memory_rss{}) by (instance)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Memory",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 4,
+            "w": 15,
+            "x": 9,
+            "y": 1
+          },
+          "id": 32,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "## Opentelemetry Collector Data Ingress/Egress\n\n`service_version:` ${service_version}\n\n`opentelemetry collector:` contrib\n\n",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.1.0",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 10,
+          "panels": [],
+          "title": "Trace Pipeline",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "(avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range]))) / avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))) ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 3,
+            "x": 0,
+            "y": 6
+          },
+          "id": 55,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "export"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "acc"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "(avg(sum by(job) (rate(otelcol_exporter_sent_spans{}[$__range]))) / avg(sum by(job) (rate(otelcol_receiver_accepted_spans{}[$__range])))) ",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Export Ratio",
+          "transformations": [],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 21,
+            "x": 3,
+            "y": 6
+          },
+          "id": 4,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(label_join(\n(rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"\", \"transport\", \"receiver\")\n, \"title\", \"\", \"transport\", \"receiver\")\n\nor\n\nlabel_replace(label_replace(\nsum by(service_name) (rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"processor\", \"dummynode\", \"\")\n, \"title\", \"processor\", \"dummynode\", \"\")\n\nor\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n, \"id\", \"$0\", \"processor\", \".*\")\n, \"title\", \"$0\", \"processor\", \".*\")\n\nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_spans{}[$__interval]))\n, \"id\", \"exporter\", \"dummynode\", \"\")\n, \"title\", \"exporter\", \"dummynode\", \"\")\n        \nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_spans{}[$__interval]))\n, \"id\", \"$0\", \"exporter\", \".*\")\n, \"title\", \"$0\", \"exporter\", \".*\")",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_join(\n(rate(otelcol_receiver_accepted_spans{}[$__interval]))\n\n ,\"source\",\"\",\"transport\",\"receiver\")\n,\"target\",\"processor\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\n  or\n\n  label_join(\nlabel_replace(label_replace(\n  (rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n ,\"source\",\"processor\",\"\",\"\")\n,\"target\",\"$0\",\"processor\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\n  label_join(\nlabel_replace(label_replace(\n    (rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n ,\"source\",\"$0\",\"processor\",\".*\")\n,\"target\",\"exporter\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\n  label_join(\nlabel_replace(label_replace(\n   (rate(otelcol_exporter_sent_spans{}[$__interval]))\n ,\"source\",\"exporter\",\"\",\"\")\n,\"target\",\"$0\",\"exporter\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\n",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Spans Accepted by Receiver and Transport",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 3,
+            "y": 17
+          },
+          "id": 12,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_spans{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Accepted",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Spans Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 8,
+            "y": 17
+          },
+          "id": 13,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_spans{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Batch Processed",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 11,
+            "y": 17
+          },
+          "id": 15,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_processor_batch_batch_send_size_sum{}[$__rate_interval]))  by (processor)",
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Batch",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 16,
+            "y": 17
+          },
+          "id": 14,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_spans{}[$__interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 17
+          },
+          "id": 30,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_spans{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sent",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 3,
+            "y": 22
+          },
+          "id": 17,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_spans{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Refused",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Spans Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 8,
+            "y": 22
+          },
+          "id": 18,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_spans{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 16,
+            "y": 22
+          },
+          "id": 19,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_spans{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter\notelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 19,
+            "y": 22
+          },
+          "id": 20,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_spans{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 22,
+          "panels": [],
+          "title": "Metrics Pipeline",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range]))) versus avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range])))",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 19,
+            "w": 3,
+            "x": 0,
+            "y": 26
+          },
+          "id": 54,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/.*/",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "export"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range])))",
+              "format": "time_series",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "acc"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "( avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[$__range]))) /avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[$__range]))))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Export Ratio",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "percent",
+                "binary": {
+                  "left": "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[3600s])))",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[3600s])))"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )": true,
+                  "Time": true,
+                  "avg(sum by(job) (rate(otelcol_exporter_sent_metric_points{}[3600s])))": true,
+                  "avg(sum by(job) (rate(otelcol_receiver_accepted_metric_points{}[3600s])))": true,
+                  "{instance=\"otelcol:9464\", job=\"otel\"}": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Time": "",
+                  "percent": "Percent",
+                  "{exporter=\"debug\", instance=\"otelcol:8888\", job=\"otel-collector\", service_instance_id=\"fbfa720a-ebf9-45c8-a79a-9d3b6021a663\", service_name=\"otelcol-contrib\", service_version=\"0.70.0\"}": ""
+                }
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Metrics Signalling Pipelines",
+          "gridPos": {
+            "h": 11,
+            "w": 21,
+            "x": 3,
+            "y": 26
+          },
+          "id": 25,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "\nlabel_join(label_join(\n(rate(otelcol_receiver_accepted_metric_points{}[$__interval]))\n, \"id\", \"\", \"transport\", \"receiver\")\n, \"title\", \"\", \"transport\", \"receiver\")\n\nor\n\nlabel_replace(label_replace(\nsum by(service_name) (rate(otelcol_receiver_accepted_spans{}[$__interval]))\n, \"id\", \"processor\", \"dummynode\", \"\")\n, \"title\", \"processor\", \"dummynode\", \"\")\n\n\n\nor\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n, \"id\", \"$0\", \"processor\", \".*\")\n, \"title\", \"$0\", \"processor\", \".*\")\n\n\n\n\n\nor\nlabel_replace(label_replace(\nsum (rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n, \"id\", \"exporter\", \"dummynode\", \"\")\n, \"title\", \"exporter\", \"dummynode\", \"\")\n\nor\nlabel_replace(label_replace(\nsum by(exporter) (rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n, \"id\", \"$0\", \"exporter\", \".*\")\n, \"title\", \"$0\", \"exporter\", \".*\")",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_join(\n(rate(otelcol_receiver_accepted_metric_points{}[$__interval]))\n\n,\"source\",\"\",\"transport\",\"receiver\")\n,\"target\",\"processor\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\n\nor\n\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n,\"source\",\"processor\",\"\",\"\")\n,\"target\",\"$0\",\"processor\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")\n\n\n\n\n\nor\n\n\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_processor_batch_batch_send_size_count{}[$__interval]))\n,\"source\",\"$0\",\"processor\",\".*\")\n,\"target\",\"exporter\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")\n\nor\nlabel_join(\nlabel_replace(label_replace(\n(rate(otelcol_exporter_sent_metric_points{}[$__interval]))\n,\"source\",\"exporter\",\"\",\"\")\n,\"target\",\"$0\",\"exporter\",\".*\")\n,\"id\",\"-\",\"source\",\"target\")",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_receiver_accepted_metric_points",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 3,
+            "y": 37
+          },
+          "id": 26,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_metric_points{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Accepted",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol_receiver_accepted_metric_points\nTotal Accepted ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 8,
+            "y": 37
+          },
+          "id": 27,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_accepted_metric_points{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 11,
+            "y": 37
+          },
+          "id": 28,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_processor_batch_batch_send_size_sum{}[$__rate_interval]))  by (processor)",
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Batch",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Export ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 16,
+            "y": 37
+          },
+          "id": 29,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_metric_points{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 37
+          },
+          "id": 16,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_sent_metric_points{}[$__rate_interval])) by (exporter) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sent",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "noValue": "no data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 3,
+            "y": 42
+          },
+          "id": 47,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) by (receiver,transport)",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Refused",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Refused \nsum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 8,
+            "y": 42
+          },
+          "id": 48,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(otelcol_receiver_refused_metric_points{}[$__rate_interval])) ",
+              "legendFormat": "{{receiver}}-{{transport}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total ",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Total Failed Export ",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 16,
+            "y": 42
+          },
+          "id": 49,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_metric_points{}[$__rate_interval])) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter\notelcol_exporter_send_failed_spans",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 19,
+            "y": 42
+          },
+          "id": 50,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(otelcol_exporter_send_failed_metric_points{}[$__rate_interval])) by (exporter)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{processor}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Failed",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 35,
+          "panels": [],
+          "title": "Prometheus Scrape",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "otelcol prometheus exporter 9464 export rate versus prometheus scrape metrics",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-blue",
+                    "value": null
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "dark-blue",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "super-light-orange",
+                    "value": 1.2
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 2.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 0,
+            "y": 46
+          },
+          "id": 53,
+          "options": {
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/.*/",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "(sum_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/ count_over_time(scrape_samples_scraped{job=\"otel\"}[$__range])/(5*30)) ",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "accepted"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "expr": "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[$__rate_interval])) )",
+              "format": "time_series",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exported/Scraped",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "percent",
+                "binary": {
+                  "left": "{instance=\"otelcol:9464\", job=\"otel\"}",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "(sum(rate(otelcol_exporter_sent_metric_points{exporter=\"prometheus\"}[1m0s])) )": true,
+                  "Time": true,
+                  "{instance=\"otelcol:9464\", job=\"otel\"}": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "percent": "Percent"
+                }
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 3,
+            "y": 46
+          },
+          "id": 37,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])/(5*30)",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{job}}/{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Samples Scraped",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "scrape_samples_scraped{job!=\"\"}\nTotal Samples Scraped",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 8,
+            "y": 46
+          },
+          "id": 42,
+          "options": {
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum_over_time(scrape_samples_scraped[$__range])/ count_over_time(scrape_samples_scraped[$__range])/(5*30)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Total",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "{instance=\"otelcol:9464\", job=\"otel\"}",
+                    "{instance=\"otelcol:8888\", job=\"otel-collector\"}"
+                  ],
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 11,
+            "y": 46
+          },
+          "id": 41,
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_replace(label_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"}) by (instance)\n, \"id\", \"$0\", \"instance\", \".*\")\n, \"title\", \"$0\", \"instance\", \".*\")\n,\"mainstat\",\"\",\"\",\"\")\n\nor \n\nlabel_replace(label_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"})\n, \"id\", \"prometheus\", \"\", \"\")\n, \"title\", \"prometheus\", \"\", \"\")\n,\"mainstat\",\"\",\"\",\"\")\n",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "label_join(\nlabel_replace(label_replace(\nsum (scrape_samples_scraped{job!=\"\"}) by (instance)\n,\"source\",\"$0\",\"instance\",\".*\")\n,\"target\",\"prometheus\",\"\",\"\")\n,\"id\",\"-\",\"source\",\"target\")",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "Sent by Exporter",
+          "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 19,
+            "y": 46
+          },
+          "id": 52,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "\n \n## Prometheus Config\n\n`evaluation_interval:` 30s\n\n`scrape_interval:` 5s",
+            "mode": "markdown"
+          },
+          "pluginVersion": "9.1.0",
+          "type": "text"
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "0.70.0",
+              "value": "0.70.0"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(sum(otelcol_process_uptime{}) by (service_version))\n",
+            "hide": 2,
+            "includeAll": false,
+            "label": "service_version",
+            "multi": true,
+            "name": "service_version",
+            "options": [],
+            "query": {
+              "query": "query_result(sum(otelcol_process_uptime{}) by (service_version))\n",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "/.*service_version=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Opentelemetry Collector Data Flow",
+      "uid": "rl5_tea4k",
+      "version": 2,
+      "weekStart": ""
+    }
+  opentelemetry-collector.json: |-
+    {
+      "__inputs": [],
+      "__elements": {},
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "10.0.3"
+        },
+        {
+          "type": "panel",
+          "id": "heatmap",
+          "name": "Heatmap",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "nodeGraph",
+          "name": "Node Graph",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "text",
+          "name": "Text",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Visualize OpenTelemetry (OTEL) collector metrics (tested with OTEL contrib v0.84.0)",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": 15983,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 23,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Receivers",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Accepted: count/rate of spans successfully pushed into the pipeline.\nRefused: count/rate of spans that could not be pushed into the pipeline.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Refused.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 28,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_accepted_spans{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Accepted: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_refused_spans{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Refused: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Spans ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Accepted: count/rate of metric points successfully pushed into the pipeline.\nRefused: count/rate of metric points that could not be pushed into the pipeline.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Refused.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 32,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_accepted_metric_points{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Accepted: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_refused_metric_points{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Refused: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Metric Points ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Accepted: count/rate of log records successfully pushed into the pipeline.\nRefused: count/rate of log records that could not be pushed into the pipeline.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Refused.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 47,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_accepted_log_records{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Accepted: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_receiver_refused_log_records{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])) by (receiver $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Refused: {{receiver}} {{transport}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Log Records ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 34,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Processors",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*Refused.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*Dropped.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 18
+          },
+          "id": 36,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_processor_batch_batch_send_size_count{processor=~\"$processor\",job=\"$job\"}[$__rate_interval])) by (processor)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Batch send size count: {{processor}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_processor_batch_batch_send_size_sum{processor=~\"$processor\",job=\"$job\"}[$__rate_interval])) by (processor)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Batch send size sum: {{processor}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Batch Metrics",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Number of units in the batch",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 18
+          },
+          "id": 49,
+          "interval": "$minstep",
+          "links": [],
+          "maxDataPoints": 50,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": true,
+              "scale": "exponential",
+              "scheme": "Reds",
+              "steps": 57
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
+            }
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(otelcol_processor_batch_batch_send_size_bucket{processor=~\"$processor\",job=\"$job\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "hide": false,
+              "instant": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Batch Send Size Heatmap",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Number of times the batch was sent due to a size trigger. Number of times the batch was sent due to a timeout trigger.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*Refused.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*Dropped.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 18
+          },
+          "id": 56,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_processor_batch_batch_size_trigger_send{processor=~\"$processor\",job=\"$job\"}[$__rate_interval])) by (processor)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Batch sent due to a size trigger: {{processor}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_processor_batch_timeout_trigger_send{processor=~\"$processor\"}[$__rate_interval])) by (processor)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Batch sent due to a timeout trigger: {{processor}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Batch Metrics",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 25,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Exporters",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Sent: count/rate of spans successfully sent to destination.\nEngueue: count/rate of spans failed to be added to the sending queue.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Failed:.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 27
+          },
+          "id": 37,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_sent_spans{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Sent: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_enqueue_failed_spans{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Enqueue: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_send_failed_spans{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Failed: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Spans ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Sent: count/rate of metric points successfully sent to destination.\nEngueue: count/rate of metric points failed to be added to the sending queue.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Failed:.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 27
+          },
+          "id": 38,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_sent_metric_points{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Sent: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_enqueue_failed_metric_points{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Enqueue: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_send_failed_metric_points{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Failed: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Metric Points ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Sent: count/rate of log records successfully sent to destination.\nEngueue: count/rate of log records failed to be added to the sending queue.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/Failed:.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 27
+          },
+          "id": 48,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_sent_log_records{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Sent: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_enqueue_failed_log_records{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Enqueue: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(${metric:value}(otelcol_exporter_send_failed_log_records{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])) by (exporter $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Failed: {{exporter}} {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Log Records ${metric:text}",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Current size of the retry queue (in batches)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 10,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(otelcol_exporter_queue_size{exporter=~\"$exporter\",job=\"$job\"}) by (exporter)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Max queue size: {{exporter}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exporter Queue Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Fixed capacity of the retry queue (in batches)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 55,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(otelcol_exporter_queue_capacity{exporter=~\"$exporter\",job=\"$job\"}) by (exporter)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Queue capacity: {{exporter}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exporter Queue Capacity",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 21,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Collector",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Total physical memory (resident set size)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Avg Memory RSS "
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Min Memory RSS "
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 46
+          },
+          "id": 40,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(otelcol_process_memory_rss{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Max Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "avg(otelcol_process_memory_rss{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Avg Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(otelcol_process_memory_rss{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Min Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Total RSS Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Avg Memory RSS "
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Min Memory RSS "
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 46
+          },
+          "id": 52,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(otelcol_process_runtime_total_sys_memory_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Max Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "avg(otelcol_process_runtime_total_sys_memory_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Avg Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(otelcol_process_runtime_total_sys_memory_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Min Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Total Runtime Sys Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Avg Memory RSS "
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg Memory RSS "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Min Memory RSS "
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 46
+          },
+          "id": 53,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(otelcol_process_runtime_heap_alloc_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Max Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "avg(otelcol_process_runtime_heap_alloc_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Avg Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(otelcol_process_runtime_heap_alloc_bytes{job=\"$job\"}) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Min Memory RSS {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Total Runtime Heap Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Total CPU user and system time in percentage",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max CPU usage "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Avg CPU usage "
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 20
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg CPU usage "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Min CPU usage "
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min CPU usage "
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 55
+          },
+          "id": 39,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(rate(otelcol_process_cpu_seconds{job=\"$job\"}[$__rate_interval])*100) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Max CPU usage {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "avg(rate(otelcol_process_cpu_seconds{job=\"$job\"}[$__rate_interval])*100) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Avg CPU usage {{service_instance_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "min(rate(otelcol_process_cpu_seconds{job=\"$job\"}[$__rate_interval])*100) by (job $grouping)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Min CPU usage {{service_instance_id}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Number of service instances, which are reporting metrics",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 55
+          },
+          "id": 41,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "count(count(otelcol_process_cpu_seconds{service_instance_id=~\".*\",job=\"$job\"}) by (service_instance_id))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Service instance count",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Service Instance Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 55
+          },
+          "id": 54,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max(otelcol_process_uptime{service_instance_id=~\".*\",job=\"$job\"}) by (service_instance_id)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "Service instance uptime: {{service_instance_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Uptime by Service Instance",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 64
+          },
+          "id": 57,
+          "interval": "$minstep",
+          "links": [],
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(otelcol_process_uptime{service_instance_id=~\".*\",job=\"$job\"}) by (service_instance_id,service_name,service_version)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "$minstep",
+              "intervalFactor": 1,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "B"
+            }
+          ],
+          "title": "Service Instance Details",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Value": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 69
+          },
+          "id": 59,
+          "panels": [],
+          "title": "Data Flows",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Receivers -> Processor(s) -> Exporters (Node Graph panel is beta, so this panel may not show data correctly).",
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 70
+          },
+          "id": 58,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers\nlabel_replace(\n  label_join(\n    label_join(\n      sum(${metric:value}(\n        otelcol_receiver_accepted_spans{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])\n      ) by (receiver)\n      , \"id\", \"-rcv-\", \"transport\", \"receiver\"\n    )\n    , \"title\", \"\", \"transport\", \"receiver\"\n  )\n  , \"icon\", \"arrow-to-right\", \"\", \"\"\n)\n\n# dummy processor\nor\nlabel_replace(\n  label_replace(\n    label_replace(\n      (sum(rate(otelcol_process_uptime{job=\"$job\"}[$__interval])))\n      , \"id\", \"processor\", \"\", \"\"\n    )\n    , \"title\", \"Processor(s)\", \"\", \"\"\n  )\n  , \"icon\", \"arrow-random\", \"\", \"\"\n)\n\n# exporters\nor\nlabel_replace(\n  label_join(\n    label_join(\n      sum(${metric:value}(\n        otelcol_exporter_sent_spans{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])\n      ) by (exporter)\n      , \"id\", \"-exp-\", \"transport\", \"exporter\"\n    )\n    , \"title\", \"\", \"transport\", \"exporter\"\n  )\n  , \"icon\", \"arrow-from-right\", \"\", \"\"\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers -> processor\r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_receiver_accepted_spans{job=\"$job\"}[$__interval])) by (receiver))\r\n            ,\"source\", \"-rcv-\", \"transport\", \"receiver\"\r\n        )\r\n        ,\"target\", \"processor\", \"\", \"\"\r\n    )\r\n    , \"id\", \"-\", \"source\", \"target\"\r\n)\r\n\r\n# processor -> exporters\r\nor\r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_exporter_sent_spans{job=\"$job\"}[$__interval])) by (exporter))\r\n            , \"target\", \"-exp-\", \"transport\", \"exporter\"\r\n        )\r\n        , \"source\", \"processor\", \"\", \"\"\r\n    )\r\n    , \"id\", \"-\", \"source\", \"target\"\r\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "title": "Spans Flow",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "Value",
+                "renamePattern": "mainstat"
+              }
+            },
+            {
+              "disabled": true,
+              "id": "calculateField",
+              "options": {
+                "alias": "secondarystat",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "mainstat"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Receivers -> Processor(s) -> Exporters (Node Graph panel is beta, so this panel may not show data correctly).",
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 70
+          },
+          "id": 60,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers\nlabel_replace(\n  label_join(\n    label_join(\n      (sum(\n        ${metric:value}(otelcol_receiver_accepted_metric_points{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])\n      ) by (receiver))\n      , \"id\", \"-rcv-\", \"transport\", \"receiver\"\n    )\n    , \"title\", \"\", \"transport\", \"receiver\"\n  )\n  , \"icon\", \"arrow-to-right\", \"\", \"\"\n)\n\n# dummy processor\nor\nlabel_replace(\n  label_replace(\n    label_replace(\n      (sum(rate(otelcol_process_uptime{job=\"$job\"}[$__interval])))\n      , \"id\", \"processor\", \"\", \"\"\n    )\n    , \"title\", \"Processor(s)\", \"\", \"\"\n  )\n  , \"icon\", \"arrow-random\", \"\", \"\"\n)\n\n# exporters\nor\nlabel_replace(\n  label_join(\n    label_join(\n      (sum(\n        ${metric:value}(otelcol_exporter_sent_metric_points{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])\n      ) by (exporter))\n      , \"id\", \"-exp-\", \"transport\", \"exporter\"\n    )\n    , \"title\", \"\", \"transport\", \"exporter\"\n  )\n  , \"icon\", \"arrow-from-right\", \"\", \"\"\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers -> processor\r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_receiver_accepted_metric_points{job=\"$job\"}[$__interval])) by (receiver))\r\n            , \"source\", \"-rcv-\", \"transport\", \"receiver\"\r\n        )\r\n        , \"target\", \"processor\", \"\", \"\"\r\n    )\r\n    , \"id\", \"-\", \"source\", \"target\"\r\n)\r\n\r\n# processor -> exporters\r\nor \r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_exporter_sent_metric_points{job=\"$job\"}[$__interval])) by (exporter))\r\n            , \"target\", \"-exp-\", \"transport\", \"exporter\"\r\n        )\r\n        , \"source\", \"processor\", \"\", \"\"\r\n    )\r\n    , \"id\", \"-\", \"source\", \"target\"\r\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "title": "Metric Points Flow",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "Value",
+                "renamePattern": "mainstat"
+              }
+            },
+            {
+              "disabled": true,
+              "id": "calculateField",
+              "options": {
+                "alias": "secondarystat",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Value #nodes"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Receivers -> Processor(s) -> Exporters (Node Graph panel is beta, so this panel may not show data correctly).",
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 70
+          },
+          "id": 61,
+          "options": {
+            "nodes": {
+              "mainStatUnit": "flops"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers\nlabel_replace(\n  label_join(\n    label_join(\n      sum(${metric:value}(\n        otelcol_receiver_accepted_log_records{receiver=~\"$receiver\",job=\"$job\"}[$__rate_interval])\n      ) by (receiver)\n      , \"id\", \"-rcv-\", \"transport\", \"receiver\"\n    )\n    , \"title\", \"\", \"transport\", \"receiver\"\n  )\n  , \"icon\", \"arrow-to-right\", \"\", \"\"\n)\n\n# dummy processor\nor\nlabel_replace(\n  label_replace(\n    label_replace(\n      (sum(rate(otelcol_process_uptime{job=\"$job\"}[$__interval])))\n      , \"id\", \"processor\", \"\", \"\"\n    )\n    , \"title\", \"Processor(s)\", \"\", \"\"\n  )\n  , \"icon\", \"arrow-random\", \"\", \"\"\n)\n\n# exporters\nor\nlabel_replace(\n  label_join(\n    label_join(\n      sum(${metric:value}(\n        otelcol_exporter_sent_log_records{exporter=~\"$exporter\",job=\"$job\"}[$__rate_interval])\n      ) by (exporter)\n      , \"id\", \"-exp-\", \"transport\", \"exporter\"\n    )\n    , \"title\", \"\", \"transport\", \"exporter\"\n  )\n  , \"icon\", \"arrow-from-right\", \"\", \"\"\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "nodes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "# receivers -> processor\r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_receiver_accepted_log_records{job=\"$job\"}[$__interval])) by (receiver))\r\n            , \"source\", \"-rcv-\", \"transport\", \"receiver\"\r\n        )\r\n        , \"target\", \"processor\", \"\", \"\"\r\n    )\r\n    , \"id\", \"-edg-\", \"source\", \"target\"\r\n)\r\n\r\n# processor -> exporters\r\nor \r\nlabel_join(\r\n    label_replace(\r\n        label_join(\r\n            (sum(rate(otelcol_exporter_sent_log_records{job=\"$job\"}[$__interval])) by (exporter))\r\n            ,\"target\",\"-exp-\",\"transport\",\"exporter\"\r\n        )\r\n        ,\"source\",\"processor\",\"\",\"\"\r\n    )\r\n    ,\"id\",\"-edg-\",\"source\",\"target\"\r\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "edges"
+            }
+          ],
+          "title": "Log Records Flow",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "Value",
+                "renamePattern": "mainstat"
+              }
+            },
+            {
+              "disabled": true,
+              "id": "calculateField",
+              "options": {
+                "alias": "secondarystat",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "mainstat"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "type": "nodeGraph"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editable": true,
+          "error": false,
+          "gridPos": {
+            "h": 3,
+            "w": 24,
+            "x": 0,
+            "y": 79
+          },
+          "id": 45,
+          "links": [],
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<a href=\"http://www.monitoringartist.com\" target=\"_blank\" title=\"Dashboard maintained by Monitoring Artist - DevOps / Docker / Kubernetes / AWS ECS / Google GCP / Zabbix / Zenoss / Terraform / Monitoring\"><img src=\"https://monitoringartist.github.io/monitoring-artist-logo-grafana.png\" height=\"30px\" /></a> | \n<a target=\"_blank\" href=\"https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#metrics\">OTEL collector troubleshooting (how to enable telemetry metrics)</a> | \n<a target=\"_blank\" href=\"https://opentelemetry.io/docs/collector/scaling/\">Scaling the Collector (metrics to watch)</a> | \n<a target=\"_blank\" href=\"https://grafana.com/grafana/dashboards/15983-opentelemetry-collector/\">Installed from Grafana.com dashboards</a>",
+            "mode": "html"
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Documentation",
+          "type": "text"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [
+        "opentelemetry",
+        "monitoring"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
+            "definition": "label_values(otelcol_process_uptime, job)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Job",
+            "multi": false,
+            "name": "job",
+            "options": [],
+            "query": {
+              "query": "label_values(otelcol_process_uptime, job)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "auto": true,
+            "auto_count": 300,
+            "auto_min": "10s",
+            "current": {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval_minstep"
+            },
+            "hide": 0,
+            "label": "Min step",
+            "name": "minstep",
+            "options": [
+              {
+                "selected": true,
+                "text": "auto",
+                "value": "$__auto_interval_minstep"
+              },
+              {
+                "selected": false,
+                "text": "10s",
+                "value": "10s"
+              },
+              {
+                "selected": false,
+                "text": "30s",
+                "value": "30s"
+              },
+              {
+                "selected": false,
+                "text": "1m",
+                "value": "1m"
+              },
+              {
+                "selected": false,
+                "text": "5m",
+                "value": "5m"
+              }
+            ],
+            "query": "10s,30s,1m,5m",
+            "queryValue": "",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "Rate",
+              "value": "rate"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Base metric",
+            "multi": false,
+            "name": "metric",
+            "options": [
+              {
+                "selected": true,
+                "text": "Rate",
+                "value": "rate"
+              },
+              {
+                "selected": false,
+                "text": "Count",
+                "value": "increase"
+              }
+            ],
+            "query": "Rate : rate, Count : increase",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "allValue": ".*",
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
+            "definition": "label_values(receiver)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Receiver",
+            "multi": false,
+            "name": "receiver",
+            "options": [],
+            "query": {
+              "query": "label_values(receiver)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
+            "definition": "label_values(processor)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Processor",
+            "multi": false,
+            "name": "processor",
+            "options": [],
+            "query": {
+              "query": "label_values(processor)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
+            "definition": "label_values(exporter)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Exporter",
+            "multi": false,
+            "name": "exporter",
+            "options": [],
+            "query": {
+              "query": "label_values(exporter)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "None (basic metrics)",
+              "value": ""
+            },
+            "description": "Detailed metrics must be configured in the collector configuration. They add grouping by transport protocol (http/grpc) for receivers. ",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Additional groupping",
+            "multi": false,
+            "name": "grouping",
+            "options": [
+              {
+                "selected": true,
+                "text": "None (basic metrics)",
+                "value": ""
+              },
+              {
+                "selected": false,
+                "text": "By transport (detailed metrics)",
+                "value": ",transport"
+              },
+              {
+                "selected": false,
+                "text": "By service instance id",
+                "value": ",service_instance_id"
+              }
+            ],
+            "query": "None (basic metrics) :  , By transport (detailed metrics) : \\,transport, By service instance id : \\,service_instance_id",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "utc",
+      "title": "OpenTelemetry Collector",
+      "uid": "BKf2sowmj",
+      "version": 72,
+      "weekStart": ""
+    }
+  spanmetrics-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Spanmetrics way of demo application view.",
+      "author": {
+        "name": "devrimdemiroz"
+        },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 24,
+          "panels": [],
+          "title": "Service Level - Throughput and Latencies",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 64
+                  },
+                  {
+                    "color": "orange",
+                    "value": 128
+                  },
+                  {
+                    "color": "red",
+                    "value": 256
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 20,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "interval": "5m",
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.50, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{service_name}}-quantile_0.50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,service_name)))",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{le}} - {{service_name}}",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.99, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile99",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.999, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile999",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Top 3x3 - Service Latency - quantile95",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "super-light-blue",
+                    "value": 1
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 2
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 4,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,sum by (service_name) (rate(calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])))",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{service_name}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Services Mean Rate over Range",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-reds"
+              },
+              "decimals": 4,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 15
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 15,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,sum(rate(calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (service_name))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{service_name}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Services Mean ERROR Rate over Range",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 14,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "span_names Level - Throughput",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "bRate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlYlRd"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "eRate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-RdYlGr"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error Rate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 663
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 667
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Service"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": null
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "id": 22,
+          "interval": "5m",
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "exemplar": false,
+              "expr": "topk(7, sum(rate(calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name)) ",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "Rate"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "exemplar": false,
+              "expr": "topk(7, sum(rate(calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name))",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "Error Rate"
+            }
+          ],
+          "title": "Top 7 span_names and Errors  (APM Table)",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "span_name"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value #Error Rate": "Error Rate",
+                  "Value #Rate": "Rate",
+                  "service_name 1": "Rate in Service",
+                  "service_name 2": "Error Rate in Service"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "bRate",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Rate"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "eRate",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Error Rate"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Error Rate": true,
+                  "Rate": true,
+                  "bRate": false
+                },
+                "indexByName": {
+                  "Error Rate": 4,
+                  "Error Rate in Service": 6,
+                  "Rate": 1,
+                  "Rate in Service": 5,
+                  "bRate": 2,
+                  "eRate": 3,
+                  "span_name": 0
+                },
+                "renameByName": {
+                  "Rate in Service": "Service",
+                  "bRate": "Rate",
+                  "eRate": "Error Rate",
+                  "span_name": "span_name Name"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Rate"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 20,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "span_name Level - Latencies",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 64
+                  },
+                  {
+                    "color": "orange",
+                    "value": 128
+                  },
+                  {
+                    "color": "red",
+                    "value": 256
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 25,
+          "interval": "5m",
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.50, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{service_name}}-quantile_0.50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7,histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,span_name)))",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{span_name}}",
+              "range": false,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.99, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile99",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.999, sum(rate(duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "quantile999",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Top 3x3 - span_name Latency - quantile95",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlYlRd"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 10,
+          "interval": "5m",
+          "options": {
+            "displayMode": "lcd",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "9.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(7, sum by (span_name,service_name)(increase(duration_milliseconds_sum{service_name=~\"${service}\", span_name=~\"$span_name\"}[5m]) / increase(duration_milliseconds_count{service_name=~\"${service}\",span_name=~\"$span_name\"}[5m\n])))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{span_name}} [{{service_name}}]",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Highest Endpoint Latencies  Mean Over Range ",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 47
+          },
+          "id": 16,
+          "interval": "5m",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "logmin",
+                "max",
+                "delta"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "webstore-metrics"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "topk(7,sum by (span_name,service_name)(increase(duration_milliseconds_sum{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval]) / increase(duration_milliseconds_count{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "[{{service_name}}]  {{span_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Top 7 Latencies Over Range ",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "5m",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(count by (service_name)(count_over_time(calls_total[$__range])))",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "service",
+            "options": [],
+            "query": {
+              "query": "query_result(count by (service_name)(count_over_time(calls_total[$__range])))",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "/.*service_name=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "webstore-metrics"
+            },
+            "definition": "query_result(sum ({__name__=~\".*calls_total\",service_name=~\"$service\"})  by (span_name))",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "span_name",
+            "options": [],
+            "query": {
+              "query": "query_result(sum ({__name__=~\".*calls_total\",service_name=~\"$service\"})  by (span_name))",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "/.*span_name=\"(.*)\".*/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Spanmetrics Demo Dashboard",
+      "uid": "W2gX2zHVk48",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -1,0 +1,13 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+  name: example-grafana-clusterrole
+rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: example-grafana-clusterrolebinding
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-grafana
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: example-grafana-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -1,0 +1,69 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+data:
+  grafana.ini: |
+    [analytics]
+    check_for_updates = true
+    [auth]
+    disable_login_form = true
+    [auth.anonymous]
+    enabled = true
+    org_name = Main Org.
+    org_role = Admin
+    [grafana_net]
+    url = https://grafana.net
+    [log]
+    mode = console
+    [paths]
+    data = /var/lib/grafana/
+    logs = /var/log/grafana
+    plugins = /var/lib/grafana/plugins
+    provisioning = /etc/grafana/provisioning
+    [server]
+    domain = ''
+    root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
+    serve_from_sub_path = true
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+    - editable: true
+      isDefault: true
+      jsonData:
+        exemplarTraceIdDestinations:
+        - datasourceUid: webstore-traces
+          name: trace_id
+        - name: trace_id
+          url: http://localhost:8080/jaeger/ui/trace/$${__value.raw}
+          urlDisplayLabel: View in Jaeger UI
+      name: Prometheus
+      type: prometheus
+      uid: webstore-metrics
+      url: http://example-prometheus-server:9090
+    - editable: true
+      isDefault: false
+      name: Jaeger
+      type: jaeger
+      uid: webstore-traces
+      url: http://example-jaeger-query:16686/jaeger/ui
+  dashboardproviders.yaml: |
+    apiVersion: 1
+    providers:
+    - disableDeletion: false
+      editable: true
+      folder: ""
+      name: default
+      options:
+        path: /var/lib/grafana/dashboards/default
+      orgId: 1
+      type: file

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/instance: example
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/instance: example
+      annotations:
+        checksum/config: bf85ecabfb7f23796f805365fa03d7682cf248f835fed87e5fc1396f54aaa7f6
+        checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/secret: 89476c1fedba0c6f5dea8300e74e37195d0c5e333c83c13bf656db57d5dcb2ba
+        kubectl.kubernetes.io/default-container: grafana
+    spec:
+      
+      serviceAccountName: example-grafana
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 472
+        runAsGroup: 472
+        runAsNonRoot: true
+        runAsUser: 472
+      enableServiceLinks: true
+      containers:
+        - name: grafana
+          image: "docker.io/grafana/grafana:10.1.5"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: "/etc/grafana/grafana.ini"
+              subPath: grafana.ini
+            - name: storage
+              mountPath: "/var/lib/grafana"
+            - name: dashboards-default
+              mountPath: "/var/lib/grafana/dashboards/default"
+            - name: config
+              mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
+              subPath: "datasources.yaml"
+            - name: config
+              mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
+              subPath: "dashboardproviders.yaml"
+          ports:
+            - name: grafana
+              containerPort: 3000
+              protocol: TCP
+            - name: gossip-tcp
+              containerPort: 9094
+              protocol: TCP
+            - name: gossip-udp
+              containerPort: 9094
+              protocol: UDP
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: example-grafana
+                  key: admin-user
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: example-grafana
+                  key: admin-password
+            - name: GF_PATHS_DATA
+              value: /var/lib/grafana/
+            - name: GF_PATHS_LOGS
+              value: /var/log/grafana
+            - name: GF_PATHS_PLUGINS
+              value: /var/lib/grafana/plugins
+            - name: GF_PATHS_PROVISIONING
+              value: /etc/grafana/provisioning
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+          resources:
+            limits:
+              memory: 150Mi
+      volumes:
+        - name: config
+          configMap:
+            name: example-grafana
+        - name: dashboards-default
+          configMap:
+            name: example-grafana-dashboards
+        - name: storage
+          emptyDir: {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -1,0 +1,14 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -1,0 +1,21 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-grafana
+subjects:
+- kind: ServiceAccount
+  name: example-grafana
+  namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -1,0 +1,18 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  admin-user: "YWRtaW4="
+  admin-password: "YWRtaW4="
+  ldap-toml: ""

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-grafana
+  namespace: default
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: service
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+  name: example-grafana
+  namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-configmap.yaml
@@ -1,0 +1,24 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/tests/test-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-grafana-test
+  namespace: default
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+data:
+  run.sh: |-
+    @test "Test Health" {
+      url="http://example-grafana/api/health"
+
+      code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
+      [ "$code" == "200" ]
+    }

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-serviceaccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/tests/test-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+  name: example-grafana-test
+  namespace: default
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test.yaml
@@ -1,0 +1,32 @@
+---
+# Source: opentelemetry-demo/charts/grafana/templates/tests/test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-grafana-test
+  labels:
+    helm.sh/chart: grafana-7.0.2
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "10.1.5"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+  namespace: default
+spec:
+  serviceAccountName: example-grafana-test
+  containers:
+    - name: example-test
+      image: "docker.io/bats/bats:v1.4.1"
+      imagePullPolicy: "IfNotPresent"
+      command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+        - mountPath: /tests
+          name: tests
+          readOnly: true
+  volumes:
+    - name: tests
+      configMap:
+        name: example-grafana-test
+  restartPolicy: Never

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -1,0 +1,35 @@
+---
+# Source: opentelemetry-demo/charts/jaeger/templates/allinone-agent-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-jaeger-agent
+  labels:
+    helm.sh/chart: jaeger-0.72.0
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: service-agent
+spec:
+  clusterIP: None
+  ports:
+    - name: zk-compact-trft
+      port: 5775
+      protocol: UDP
+      targetPort: 0
+    - name: config-rest
+      port: 5778
+      targetPort: 0
+    - name: jg-compact-trft
+      port: 6831
+      protocol: UDP
+      targetPort: 0
+    - name: jg-binary-trft
+      port: 6832
+      protocol: UDP
+      targetPort: 0
+  selector:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -1,0 +1,38 @@
+---
+# Source: opentelemetry-demo/charts/jaeger/templates/allinone-collector-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-jaeger-collector
+  labels:
+    helm.sh/chart: jaeger-0.72.0
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: service-collector
+spec:
+  clusterIP: None
+  ports:
+    - name: http-zipkin
+      port: 9411
+      targetPort: 0
+    - name: grpc-http
+      port: 14250
+      targetPort: 0
+    - name: c-tchan-trft
+      port: 14267
+      targetPort: 0
+    - name: http-c-binary-trft
+      port: 14268
+      targetPort: 0
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 0
+    - name: otlp-http
+      port: 4318
+      targetPort: 0
+  selector:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -1,0 +1,100 @@
+---
+# Source: opentelemetry-demo/charts/jaeger/templates/allinone-deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-jaeger
+  labels:
+    helm.sh/chart: jaeger-0.72.0
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: all-in-one
+    prometheus.io/port: "14269"
+    prometheus.io/scrape: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/instance: example
+      app.kubernetes.io/component: all-in-one
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: all-in-one
+      annotations:
+        prometheus.io/port: "14269"
+        prometheus.io/scrape: "true"
+    spec:    
+      containers:
+        - env:
+            - name: METRICS_STORAGE_TYPE
+              value: prometheus
+            - name: SPAN_STORAGE_TYPE
+              value: memory
+            - name: COLLECTOR_ZIPKIN_HOST_PORT
+              value: :9411
+            - name: JAEGER_DISABLED
+              value: "false"
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          image: jaegertracing/all-in-one:1.51.0
+          imagePullPolicy: IfNotPresent
+          name: jaeger
+          args:
+            - "--memory.max-traces=8000"
+            - "--query.base-path=/jaeger/ui"
+            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.query.normalize-calls=true"
+            - "--prometheus.query.normalize-duration=true"
+          ports:
+            - containerPort: 5775
+              protocol: UDP
+            - containerPort: 6831
+              protocol: UDP
+            - containerPort: 6832
+              protocol: UDP
+            - containerPort: 5778
+              protocol: TCP
+            - containerPort: 16686
+              protocol: TCP
+            - containerPort: 16685
+              protocol: TCP
+            - containerPort: 9411
+              protocol: TCP
+            - containerPort: 4317
+              protocol: TCP
+            - containerPort: 4318
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14269
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 14269
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 300Mi
+          volumeMounts:
+      serviceAccountName: example-jaeger
+      volumes:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-demo/charts/jaeger/templates/allinone-query-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-jaeger-query
+  labels:
+    helm.sh/chart: jaeger-0.72.0
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: service-query
+spec:
+  clusterIP: None
+  ports:
+    - name: http-query
+      port: 16686
+      targetPort: 16686
+    - name: grpc-query
+      port: 16685
+      targetPort: 16685
+  selector:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -1,0 +1,13 @@
+---
+# Source: opentelemetry-demo/charts/jaeger/templates/allinone-sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-jaeger
+  labels:
+    helm.sh/chart: jaeger-0.72.0
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
@@ -1,0 +1,25 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-otelcol
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.73.1
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/stats"]
+    verbs: ["get", "watch", "list"]

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-otelcol
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.73.1
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-otelcol
+subjects:
+- kind: ServiceAccount
+  name: example-otelcol
+  namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -1,0 +1,289 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-otelcol-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.73.1
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    connectors:
+      spanmetrics: null
+    exporters:
+      debug: {}
+      logging: {}
+      otlp:
+        endpoint: 'example-jaeger-collector:4317'
+        tls:
+          insecure: true
+      otlphttp/prometheus:
+        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        tls:
+          insecure: true
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check: {}
+      memory_ballast:
+        size_in_percentage: 40
+    processors:
+      batch: {}
+      filter/ottl:
+        error_mode: ignore
+        metrics:
+          metric:
+          - name == "rpc.server.duration"
+      k8sattributes:
+        extract:
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: insert
+          from_attribute: k8s.pod.uid
+          key: service.instance.id
+      transform:
+        metric_statements:
+        - context: metric
+          statements:
+          - set(description, "") where name == "queueSize"
+          - set(description, "") where name == "rpc.server.duration"
+          - set(description, "") where name == "http.client.duration"
+    receivers:
+      filelog:
+        exclude:
+        - /var/log/pods/default_example-otelcol*_*/opentelemetry-collector/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 102400
+          output: extract_metadata_from_filepath
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 102400
+          output: extract_metadata_from_filepath
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - id: extract_metadata_from_filepath
+          parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          to: body
+          type: move
+        start_at: end
+        storage: file_storage
+      hostmetrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory: null
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 20s
+        endpoint: ${env:K8S_NODE_NAME}:10250
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            cors:
+              allowed_origins:
+              - http://*
+              - https://*
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      - file_storage
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - filelog
+        metrics:
+          exporters:
+          - otlphttp/prometheus
+          - debug
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - filter/ottl
+          - transform
+          - resource
+          - batch
+          receivers:
+          - otlp
+          - spanmetrics
+          - hostmetrics
+          - kubeletstats
+        traces:
+          exporters:
+          - otlp
+          - debug
+          - spanmetrics
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - resource
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          address: ${env:MY_POD_IP}:8888

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -1,0 +1,137 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-otelcol-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.73.1
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: d58650f3b5664bc8a35a5b9cf53addbb5f560030697b8fd0343b8b477c15e573
+        opentelemetry_community_demo: "true"
+        prometheus.io/port: "9464"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      
+      serviceAccountName: example-otelcol
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "otel/opentelemetry-collector-contrib:0.88.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: prometheus
+              containerPort: 9464
+              protocol: TCP
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              memory: 200Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: example-otelcol-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: hostfs
+          hostPath:
+            path: /
+      hostNetwork: false

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-otelcol
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.73.1
+    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -1,0 +1,52 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: example-prometheus-server
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -1,0 +1,36 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+  namespace: default
+data:
+  allow-snippet-annotations: "false"
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs: []
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -1,0 +1,97 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: example
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: v2.47.2
+        helm.sh/chart: prometheus-25.4.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: example-prometheus-server
+      containers:
+
+        - name: prometheus-server
+          image: "quay.io/prometheus/prometheus:v2.47.2"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --enable-feature=exemplar-storage
+            - --enable-feature=otlp-write-receiver
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            limits:
+              memory: 300Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      dnsPolicy: ClusterFirst
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: example-prometheus-server
+        - name: storage-volume
+          emptyDir:
+            {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -1,0 +1,27 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+  sessionAffinity: None
+  type: "ClusterIP"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-demo/charts/prometheus/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: v2.47.2
+    helm.sh/chart: prometheus-25.4.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: example-prometheus-server
+  namespace: default
+  annotations:
+    {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-demo/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.26.0
+    
+    opentelemetry.io/name: example
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/name: example
+    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/values.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/values.yaml
@@ -1,0 +1,13 @@
+opentelemetry-collector:
+  mode: "daemonset"
+  presets:
+    kubernetesAttributes:
+      enabled: true
+    kubeletMetrics:
+      enabled: true
+    hostMetrics:
+      enabled: true
+    logsCollection:
+      enabled: true
+      includeCollectorLogs: false
+      storeCheckpoints: true

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -499,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -562,7 +562,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -635,7 +635,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -716,7 +716,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -775,7 +775,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -836,7 +836,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -917,7 +917,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -982,7 +982,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1045,7 +1045,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1128,7 +1128,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1215,7 +1215,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1282,7 +1282,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1353,7 +1353,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1416,7 +1416,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1477,7 +1477,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1609,7 +1609,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1668,7 +1668,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.26.0
+    helm.sh/chart: opentelemetry-demo-0.27.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.27.0
+    helm.sh/chart: opentelemetry-demo-0.26.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example


### PR DESCRIPTION
This PR adds a new example for the `opentelemetry-demo` chart.
This example aims to provide a way to enable Kubernetes cluster monitoring by setting the proper collector's components.

Note that only node level metrics can be enabled because `clusterMetrics` requires `deployment` mode instead of `daemonset`. However, it would be nice if we could combine `clusterMetrics` as well so any ideas more than welcome. I guess this would require to edit the chart a bit so as to add an additional collector running as Deployment?