### PR TITLE
Set Port for the webhook

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.44.0
+version: 0.44.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -21,6 +21,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /mutate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
     failurePolicy: Fail
     name: minstrumentation.kb.io
     rules:
@@ -43,6 +44,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /mutate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: 443
     failurePolicy: Fail
     name: mopentelemetrycollector.kb.io
     rules:
@@ -65,6 +67,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /mutate-v1-pod
+        port: 443
     failurePolicy: Ignore
     name: mpod.kb.io
     rules:
@@ -103,6 +106,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
     failurePolicy: Fail
     name: vinstrumentationcreateupdate.kb.io
     rules:
@@ -125,6 +129,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
     failurePolicy: Ignore
     name: vinstrumentationdelete.kb.io
     rules:
@@ -146,6 +151,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: 443
     failurePolicy: Fail
     name: vopentelemetrycollectorcreateupdate.kb.io
     rules:
@@ -168,6 +174,7 @@ webhooks:
         name: example-opentelemetry-operator-webhook
         namespace: default
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: 443
     failurePolicy: Ignore
     name: vopentelemetrycollectordelete.kb.io
     rules:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.0
+    helm.sh/chart: opentelemetry-operator-0.44.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -16,6 +16,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: minstrumentation.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -46,6 +47,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: mopentelemetrycollector.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -76,6 +78,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-v1-pod
+        port: {{ .Values.admissionWebhooks.servicePort }}
     {{- if .Values.admissionWebhooks.namespaceSelector }}
     namespaceSelector:
     {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
@@ -117,6 +120,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: vinstrumentationcreateupdate.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -147,6 +151,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: Ignore
     name: vinstrumentationdelete.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -176,6 +181,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: vopentelemetrycollectorcreateupdate.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -206,6 +212,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: Ignore
     name: vopentelemetrycollectordelete.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -42,6 +42,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: minstrumentation.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -73,6 +74,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: mopentelemetrycollector.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -104,6 +106,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /mutate-v1-pod
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
     name: mpod.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -146,6 +149,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy:  {{ .Values.admissionWebhooks.failurePolicy }}
     name: vinstrumentationcreateupdate.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -177,6 +181,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: Ignore
     name: vinstrumentationdelete.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -207,6 +212,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: {{ .Values.admissionWebhooks.failurePolicy }}
     name: vopentelemetrycollectorcreateupdate.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}
@@ -238,6 +244,7 @@ webhooks:
         name: {{ template "opentelemetry-operator.fullname" . }}-webhook
         namespace: {{ .Release.Namespace }}
         path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+        port: {{ .Values.admissionWebhooks.servicePort }}
     failurePolicy: Ignore
     name: vopentelemetrycollectordelete.kb.io
     {{- if .Values.admissionWebhooks.namespaceSelector }}


### PR DESCRIPTION
Although we can set the port on the service, we need to change the validating and mutating webhook configuration as well. cc @TylerHelmuth