### PR TITLE
[opentelemetry-operator] fix `opentelemetry-operator.WebhookCert` nil pointer

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.44.2
+version: 0.44.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.44.2
+    helm.sh/chart: opentelemetry-operator-0.44.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.90.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -97,7 +97,9 @@ a cert is loaded from an existing secret or is provided via `.Values`
 {{- $caCertEnc = index $prevSecret "data" "ca.crt" }}
 {{- if not $caCertEnc }}
 {{- $prevHook := (lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" .Release.Namespace (print (include "opentelemetry-operator.MutatingWebhookName" . ) "-mutation")) }}
+{{- if not (eq (toString $prevHook) "<nil>") }}
 {{- $caCertEnc = (first $prevHook.webhooks).clientConfig.caBundle }}
+{{- end }}
 {{- end }}
 {{- else }}
 {{- $altNames := list ( printf "%s-webhook.%s" (include "opentelemetry-operator.fullname" .) .Release.Namespace ) ( printf "%s-webhook.%s.svc" (include "opentelemetry-operator.fullname" .) .Release.Namespace ) -}}


### PR DESCRIPTION
Reproduction step:
1. helm install with `autoGenerateCert`

```bash
helm install my-opentelemetry-operator charts/opentelemetry-operator --set admissionWebhooks.certManager.enabled=false --set admissionWebhooks.autoGenerateCert.recreate=false -n insight-system
```

2.  uninstall the released chart:
```bash
helm uninstall my-opentelemetry-operator
```

3. re-install with `autoGenerateCert`

```bash
helm install my-opentelemetry-operator charts/opentelemetry-operator --set admissionWebhooks.certManager.enabled=false --set admissionWebhooks.autoGenerateCert.recreate=false -n insight-system
```

Error occurs：

```bash
`opentelemetry-operator/templates/_helpers.tpl:100:18: executing "opentelemetry-operator.WebhookCert" at <first $prevHook.webhooks>: error calling first: runtime error: invalid memory address or nil pointer dereference`
```

This is because the resources generated by the hook are not controlled by the helm, `tls secrets` generated by the hook are not cleaned up when the helm is uninstalled.  However, the `opentelemetry-operator.WebhookCert` logic will lookup and get value from the removed `MutatingWebhookConfiguration` resource, resulting in `nil` and thus blocking helm installation.