### PR TITLE
[operator] Use appVersion as operator image version by default

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.45.1
+version: 0.45.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -39,7 +39,7 @@ spec:
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.90.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.91.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.45.1
+    helm.sh/chart: opentelemetry-operator-0.45.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.91.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               value: {{ $value | quote -}}
             {{- end }}
           {{- end }}
-          image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+          image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
           name: manager
           ports:
             - containerPort: {{ .Values.manager.ports.metricsPort }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -29,7 +29,7 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: v0.90.0
+    tag: ""
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
     tag: 0.92.0


### PR DESCRIPTION
I noticed that the chart had the operator;s image tag hard-coded in the values.yaml instead of using the chart's `appVersion`.