### PR TITLE
Add OTEL_RESOURCE_ATTRIBUTES to frontendProxy

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.27.2
+version: 0.28.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -356,6 +356,11 @@ components:
     service:
       port: 8080
     env:
+      - name: OTEL_SERVICE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: "metadata.labels['app.kubernetes.io/component']"
       - name: ENVOY_PORT
         value: "8080"
       - name: FRONTEND_PORT
@@ -384,6 +389,8 @@ components:
         value: "4318"
       - name: OTEL_COLLECTOR_HOST
         value: $(OTEL_COLLECTOR_NAME)
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
     resources:
       limits:
         memory: 50Mi


### PR DESCRIPTION
This PR is missing updating the examples, as I'd like to have it merged just after #1007.

It adds `OTEL_RESOURCE_ATTRIBUTES` to `frontendProxy` as it was introduced here: https://github.com/open-telemetry/opentelemetry-demo/pull/1291
