### PR TITLE
[opentelemetry-collector] Fix calculation for gomemlimit

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -33,3 +33,4 @@ runs:
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add jaeger https://jaegertracing.github.io/helm-charts
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git

--- a/.github/workflows/collector-test.yaml
+++ b/.github/workflows/collector-test.yaml
@@ -2,7 +2,7 @@ name: Test Collector Chart
 
 on:
   pull_request:
-    paths: 
+    paths:
     - 'charts/opentelemetry-collector/**'
     branches:
       - main
@@ -19,6 +19,9 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+
+      - name: Run unit tests
+        run: helm unittest charts/opentelemetry-collector --strict
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-collector

--- a/charts/opentelemetry-collector/.helmignore
+++ b/charts/opentelemetry-collector/.helmignore
@@ -21,3 +21,7 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Ignore unittest
+tests/
+*/__snapshot__/*

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -164,35 +164,40 @@ Allow the release namespace to be overridden
 {{- end -}}
 
 {{/*
-Convert memory value to numeric value in MiB to be used by otel memory_limiter processor.
-*/}}
-{{- define "opentelemetry-collector.convertMemToMib" -}}
-{{- $mem := lower . -}}
-{{- if hasSuffix "e" $mem -}}
-{{- trimSuffix "e" $mem | atoi | mul 1000 | mul 1000 | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "ei" $mem -}}
-{{- trimSuffix "ei" $mem | atoi | mul 1024 | mul 1024 | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "p" $mem -}}
-{{- trimSuffix "p" $mem | atoi | mul 1000 | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "pi" $mem -}}
-{{- trimSuffix "pi" $mem | atoi | mul 1024 | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "t" $mem -}}
-{{- trimSuffix "t" $mem | atoi | mul 1000 | mul 1000 -}}
-{{- else if hasSuffix "ti" $mem -}}
-{{- trimSuffix "ti" $mem | atoi | mul 1024 | mul 1024 -}}
-{{- else if hasSuffix "g" $mem -}}
-{{- trimSuffix "g" $mem | atoi | mul 1000 -}}
-{{- else if hasSuffix "gi" $mem -}}
-{{- trimSuffix "gi" $mem | atoi | mul 1024 -}}
-{{- else if hasSuffix "m" $mem -}}
-{{- div (trimSuffix "m" $mem | atoi | mul 1000) 1024 -}}
-{{- else if hasSuffix "mi" $mem -}}
-{{- trimSuffix "mi" $mem | atoi -}}
-{{- else if hasSuffix "k" $mem -}}
-{{- div (trimSuffix "k" $mem | atoi) 1000 -}}
-{{- else if hasSuffix "ki" $mem -}}
-{{- div (trimSuffix "ki" $mem | atoi) 1024 -}}
-{{- else -}}
-{{- div (div ($mem | atoi) 1024) 1024 -}}
-{{- end -}}
-{{- end -}}
+  This helper converts the input value of memory to MiB.
+  Input needs to be a valid value as supported by k8s memory resource field.
+ */}}
+{{- define "opentelemetry-collector.convertMemToBytes" }}
+  {{- $mem := lower . -}}
+  {{- if hasSuffix "e" $mem -}}
+    {{- $mem = mulf (trimSuffix "e" $mem | float64) 1e18 -}}
+  {{- else if hasSuffix "ei" $mem -}}
+    {{- $mem = mulf (trimSuffix "e" $mem | float64) 0x1p60 -}}
+  {{- else if hasSuffix "p" $mem -}}
+    {{- $mem = mulf (trimSuffix "p" $mem | float64) 1e15 -}}
+  {{- else if hasSuffix "pi" $mem -}}
+    {{- $mem = mulf (trimSuffix "pi" $mem | float64) 0x1p50 -}}
+  {{- else if hasSuffix "t" $mem -}}
+    {{- $mem = mulf (trimSuffix "t" $mem | float64) 1e12 -}}
+  {{- else if hasSuffix "ti" $mem -}}
+    {{- $mem = mulf (trimSuffix "ti" $mem | float64) 0x1p40 -}}
+  {{- else if hasSuffix "g" $mem -}}
+    {{- $mem = mulf (trimSuffix "g" $mem | float64) 1e9 -}}
+  {{- else if hasSuffix "gi" $mem -}}
+    {{- $mem = mulf (trimSuffix "gi" $mem | float64) 0x1p30 -}}
+  {{- else if hasSuffix "m" $mem -}}
+    {{- $mem = mulf (trimSuffix "m" $mem | float64) 1e6 -}}
+  {{- else if hasSuffix "mi" $mem -}}
+    {{- $mem = mulf (trimSuffix "mi" $mem | float64) 0x1p20 -}}
+  {{- else if hasSuffix "k" $mem -}}
+    {{- $mem = mulf (trimSuffix "k" $mem | float64) 1e3 -}}
+  {{- else if hasSuffix "ki" $mem -}}
+    {{- $mem = mulf (trimSuffix "ki" $mem | float64) 0x1p10 -}}
+  {{- end }}
+{{- $mem }}
+{{- end }}
+
+{{- define "opentelemetry-collector.gomemlimit" }}
+{{- $memlimitBytes := include "opentelemetry-collector.convertMemToBytes" . | mulf 0.8 -}}
+{{- printf "%dMiB" (divf $memlimitBytes 0x1p20 | floor | int64) -}}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -29,7 +29,7 @@ containers:
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-    
+
     {{- $ports := include "opentelemetry-collector.podPortsConfig" . }}
     {{- if $ports }}
     ports:
@@ -49,7 +49,7 @@ containers:
       {{- end }}
       {{- if and (.Values.useGOMEMLIMIT) ((((.Values.resources).limits).memory))  }}
       - name: GOMEMLIMIT
-        value: {{ div (mul (include "opentelemetry-collector.convertMemToMib" .Values.resources.limits.memory) 80) 100 }}MiB
+        value: {{ include "opentelemetry-collector.gomemlimit" .Values.resources.limits.memory | quote }}
       {{- end }}
       {{- with .Values.extraEnvs }}
       {{- . | toYaml | nindent 6 }}

--- a/charts/opentelemetry-collector/tests/gomemlimit_test.yaml
+++ b/charts/opentelemetry-collector/tests/gomemlimit_test.yaml
@@ -1,0 +1,51 @@
+suite: splunk-otel-collector.convertMemToMib
+templates:
+  - "deployment.yaml"
+  - "configmap.yaml"
+set:
+  mode: "deployment"
+tests:
+- it: convert floating-point memory limit (Gi to Mi)
+  set:
+    resources.limits.memory: 2Gi
+  templates:
+    - "deployment.yaml"
+  asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: GOMEMLIMIT
+          value: "1638MiB"
+- it: convert integer memory limit (M to Mi)
+  set:
+    resources.limits.memory: 1000M
+  templates:
+    - "deployment.yaml"
+  asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: GOMEMLIMIT
+          value: "762MiB"
+- it: convert integer memory limit (Ki to Mi)
+  set:
+    resources.limits.memory: 1680Ki
+  templates:
+    - "deployment.yaml"
+  asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: GOMEMLIMIT
+          value: "1MiB"
+- it: convert floating-point memory limit (Gi to Mi)
+  set:
+    resources.limits.memory: 0.5Gi
+  templates:
+    - "deployment.yaml"
+  asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: GOMEMLIMIT
+          value: "409MiB"


### PR DESCRIPTION
GOMEMLIMIT is set to 0 when the memory limit is floating point value. Similar problem raised in this [issue](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1006). This PR updates the calculation to work with floats and adds "unit tests" to verify the env var is set correctly.