### PR TITLE
[demo] - release 1.8.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -33,3 +33,4 @@ runs:
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add jaeger https://jaegertracing.github.io/helm-charts
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts

--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -25,4 +25,5 @@ jobs:
           --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
           --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
           --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts"
+          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
+          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,8 @@ jobs:
           --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
           --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
           --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts"
+          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
+          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"
 
       - name: Run make check-examples
         run: make check-examples

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add jaeger https://jaegertracing.github.io/helm-charts
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 7.3.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.17.2
+  version: 2.17x.2
 digest: sha256:e129e604f866fa2e38796bfccdc73b9d5e64f4f9622f37ff97802630b839f23d
 generated: "2024-02-01T18:42:44.053455-05:00"

--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,15 +1,18 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.78.0
+  version: 0.80.1
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.73.1
+  version: 0.74.1
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.8.2
+  version: 25.11.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 7.2.1
-digest: sha256:484dba15dc44971890d1e7c33d8d2893e2f1ecc976478a75c326b5884bcc1dd8
-generated: "2024-01-16T18:53:08.919148-05:00"
+  version: 7.3.0
+- name: opensearch
+  repository: https://opensearch-project.github.io/helm-charts
+  version: 2.17.2
+digest: sha256:e129e604f866fa2e38796bfccdc73b9d5e64f4f9622f37ff97802630b839f23d
+generated: "2024-02-01T18:42:44.053455-05:00"

--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.80.1
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 0.74.1
+  version: 1.0.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.11.0
+  version: 25.12.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 7.3.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.17x.2
-digest: sha256:e129e604f866fa2e38796bfccdc73b9d5e64f4f9622f37ff97802630b839f23d
-generated: "2024-02-01T18:42:44.053455-05:00"
+  version: 2.17.2
+digest: sha256:3f338e28c048d248b87ea2357d23342e71e0cfc76d0a4e9c81d2ff65d4623856
+generated: "2024-02-18T00:49:24.628921-05:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -30,6 +30,6 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: opensearch
-    version: 2.17.3
+    version: 2.17.2
     repository: https://opensearch-project.github.io/helm-charts
     condition: opensearch.enabled

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -18,11 +18,11 @@ dependencies:
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 0.74.1
+    version: 1.0.0
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 25.11.0
+    version: 25.12.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
@@ -30,6 +30,6 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: opensearch
-    version: 2.17.2
+    version: 2.17.3
     repository: https://opensearch-project.github.io/helm-charts
     condition: opensearch.enabled

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.28.1
+version: 0.29.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -11,21 +11,25 @@ maintainers:
   - name: puckpuck
   - name: tylerhelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: "1.7.0"
+appVersion: "1.8.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.78.0
+    version: 0.80.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 0.73.1
+    version: 0.74.1
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 25.8.2
+    version: 25.11.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 7.2.1
+    version: 7.3.0
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
+  - name: opensearch
+    version: 2.17.2
+    repository: https://opensearch-project.github.io/helm-charts
+    condition: opensearch.enabled

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1120,6 +1120,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1357,6 +1359,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1369,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -501,13 +501,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -528,7 +528,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -566,13 +566,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -641,13 +641,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -668,7 +668,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -724,13 +724,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -751,7 +751,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -785,13 +785,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -812,7 +812,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -848,13 +848,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -875,7 +875,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -931,13 +931,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -985,10 +985,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -998,13 +994,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1025,7 +1021,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1063,13 +1059,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1086,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1148,13 +1144,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1175,7 +1171,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1237,13 +1233,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1264,7 +1260,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1306,13 +1302,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1333,7 +1329,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1379,13 +1375,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1406,7 +1402,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1444,13 +1440,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1471,7 +1467,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1507,13 +1503,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1534,7 +1530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1574,13 +1570,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1601,7 +1597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1643,13 +1639,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1704,13 +1700,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1731,7 +1727,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -549,7 +549,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -771,6 +771,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1036,7 +1038,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1283,7 +1285,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -1120,6 +1120,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1357,6 +1359,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1369,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -501,13 +501,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -528,7 +528,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -566,13 +566,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -641,13 +641,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -668,7 +668,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -724,13 +724,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -751,7 +751,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -785,13 +785,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -812,7 +812,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -848,13 +848,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -875,7 +875,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -931,13 +931,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -985,10 +985,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -998,13 +994,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1025,7 +1021,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1063,13 +1059,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1086,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1148,13 +1144,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1175,7 +1171,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1237,13 +1233,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1264,7 +1260,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1306,13 +1302,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1333,7 +1329,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1379,13 +1375,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1406,7 +1402,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1444,13 +1440,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1471,7 +1467,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1507,13 +1503,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1534,7 +1530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1574,13 +1570,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1601,7 +1597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1643,13 +1639,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1704,13 +1700,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1731,7 +1727,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -549,7 +549,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -771,6 +771,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1036,7 +1038,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1283,7 +1285,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,17 +6,17 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:
   
-  demo-dashboard.json: |-
+  demo-dashboard.json: |
     {
       "annotations": {
         "list": [
@@ -475,7 +475,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"
@@ -563,7 +563,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -67,7 +67,8 @@ data:
         logLevelField: severity
         logMessageField: body
         pplEnabled: true
-        timeField: '@timestamp'
+        timeField: observedTimestamp
+        version: 2.11.1
       name: OpenSearch
       type: grafana-opensearch-datasource
       url: http://otel-demo-opensearch:9200/

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   
+  plugins: grafana-opensearch-datasource
   grafana.ini: |
     [analytics]
     check_for_updates = true
@@ -57,6 +58,19 @@ data:
       type: jaeger
       uid: webstore-traces
       url: http://example-jaeger-query:16686/jaeger/ui
+    - access: proxy
+      editable: true
+      isDefault: false
+      jsonData:
+        database: otel
+        flavor: opensearch
+        logLevelField: severity
+        logMessageField: body
+        pplEnabled: true
+        timeField: '@timestamp'
+      name: OpenSearch
+      type: grafana-opensearch-datasource
+      url: http://otel-demo-opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 6ed234d37b51db8079340220e18b2d85ed4af929793369ba445677a901992c5b
+        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
@@ -42,7 +42,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.2.3"
+          image: "docker.io/grafana/grafana:10.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: example-grafana
                   key: admin-password
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: example-grafana
+                  key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
             - name: GF_PATHS_LOGS

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
+        checksum/config: 085545e0f9f0ec8ab9cf9b08fa8e4ce19f9925e12c0ea44a7c22479bbbbdf715
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.51.0
+          image: jaegertracing/all-in-one:1.53.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -94,7 +94,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
           volumeMounts:
       serviceAccountName: example-jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces=8000"
+            - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
             - "--prometheus.server-url=http://example-prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -19,6 +19,12 @@ data:
     exporters:
       debug: {}
       logging: {}
+      opensearch:
+        http:
+          endpoint: http://otel-demo-opensearch:9200
+          tls:
+            insecure: true
+        logs_index: otel
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:
@@ -28,14 +34,10 @@ data:
         tls:
           insecure: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       batch: {}
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-          - name == "rpc.server.duration"
       k8sattributes:
         extract:
           metadata:
@@ -70,13 +72,6 @@ data:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
-      transform:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(description, "") where name == "queueSize"
-          - set(description, "") where name == "rpc.server.duration"
-          - set(description, "") where name == "http.client.duration"
     receivers:
       jaeger:
         protocols:
@@ -112,10 +107,12 @@ data:
       pipelines:
         logs:
           exporters:
+          - opensearch
           - debug
           processors:
           - k8sattributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -126,8 +123,6 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/ottl
-          - transform
           - resource
           - batch
           receivers:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 305e8f1a044e6411137e3f4bb136f16c29c90d8d5347f6d844835e191d05c09e
+        checksum/config: 9b32bc93027d198d114bf83dada827bd962799c7b136d4444820f5e82acd38f6
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.92.0"
+          image: "otel/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -89,7 +89,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: GOMEMLIMIT
-              value: 160MiB
+              value: "160MiB"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9b32bc93027d198d114bf83dada827bd962799c7b136d4444820f5e82acd38f6
+        checksum/config: 52fc8a99d54702d170aa956bbfe61f7f39b7c1b476d25b4d54a70e3e000110a4
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.49.1
-        helm.sh/chart: prometheus-25.11.0
+        helm.sh/chart: prometheus-25.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.48.1
-        helm.sh/chart: prometheus-25.8.2
+        app.kubernetes.io/version: v2.49.1
+        helm.sh/chart: prometheus-25.11.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -40,7 +40,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.48.1"
+          image: "quay.io/prometheus/prometheus:v2.49.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1136,6 +1136,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1375,6 +1377,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1385,7 +1389,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -503,13 +503,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -530,7 +530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -570,13 +570,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -647,13 +647,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -674,7 +674,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -732,13 +732,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -759,7 +759,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -795,13 +795,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -822,7 +822,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -860,13 +860,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -887,7 +887,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -945,13 +945,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -972,7 +972,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -999,10 +999,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -1012,13 +1008,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1039,7 +1035,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1079,13 +1075,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1106,7 +1102,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1166,13 +1162,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1193,7 +1189,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1255,13 +1251,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1282,7 +1278,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1324,13 +1320,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1351,7 +1347,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1399,13 +1395,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1426,7 +1422,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1466,13 +1462,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1493,7 +1489,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1531,13 +1527,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1558,7 +1554,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1600,13 +1596,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1627,7 +1623,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1671,13 +1667,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1732,13 +1728,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1759,7 +1755,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -551,7 +551,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: TEAM_NAME
@@ -779,6 +779,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1050,7 +1052,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: TEAM_NAME
             value: orion
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1301,7 +1303,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,17 +6,17 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:
   
-  demo-dashboard.json: |-
+  demo-dashboard.json: |
     {
       "annotations": {
         "list": [
@@ -475,7 +475,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"
@@ -563,7 +563,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -67,7 +67,8 @@ data:
         logLevelField: severity
         logMessageField: body
         pplEnabled: true
-        timeField: '@timestamp'
+        timeField: observedTimestamp
+        version: 2.11.1
       name: OpenSearch
       type: grafana-opensearch-datasource
       url: http://otel-demo-opensearch:9200/

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   
+  plugins: grafana-opensearch-datasource
   grafana.ini: |
     [analytics]
     check_for_updates = true
@@ -57,6 +58,19 @@ data:
       type: jaeger
       uid: webstore-traces
       url: http://example-jaeger-query:16686/jaeger/ui
+    - access: proxy
+      editable: true
+      isDefault: false
+      jsonData:
+        database: otel
+        flavor: opensearch
+        logLevelField: severity
+        logMessageField: body
+        pplEnabled: true
+        timeField: '@timestamp'
+      name: OpenSearch
+      type: grafana-opensearch-datasource
+      url: http://otel-demo-opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 6ed234d37b51db8079340220e18b2d85ed4af929793369ba445677a901992c5b
+        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
@@ -42,7 +42,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.2.3"
+          image: "docker.io/grafana/grafana:10.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: example-grafana
                   key: admin-password
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: example-grafana
+                  key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
             - name: GF_PATHS_LOGS

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
+        checksum/config: 085545e0f9f0ec8ab9cf9b08fa8e4ce19f9925e12c0ea44a7c22479bbbbdf715
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.51.0
+          image: jaegertracing/all-in-one:1.53.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -94,7 +94,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
           volumeMounts:
       serviceAccountName: example-jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces=8000"
+            - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
             - "--prometheus.server-url=http://example-prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -19,6 +19,12 @@ data:
     exporters:
       debug: {}
       logging: {}
+      opensearch:
+        http:
+          endpoint: http://otel-demo-opensearch:9200
+          tls:
+            insecure: true
+        logs_index: otel
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:
@@ -28,7 +34,8 @@ data:
         tls:
           insecure: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       attributes:
         actions:
@@ -40,11 +47,6 @@ data:
           services:
           - frontend-proxy
       batch: {}
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-          - name == "rpc.server.duration"
       k8sattributes:
         extract:
           metadata:
@@ -77,13 +79,6 @@ data:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
-      transform:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(description, "") where name == "queueSize"
-          - set(description, "") where name == "rpc.server.duration"
-          - set(description, "") where name == "http.client.duration"
     receivers:
       jaeger:
         protocols:
@@ -119,10 +114,12 @@ data:
       pipelines:
         logs:
           exporters:
+          - opensearch
           - debug
           processors:
           - k8sattributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -133,8 +130,6 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/ottl
-          - transform
           - resource
           - batch
           receivers:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 977215c1d75979384f945105472734adf703d8cfe7b798c835f5ef2df67f21d3
+        checksum/config: 6903a6b737e81b9e878bd12bf4ff2bb41026dec86f787c1991e8e0949ed1a232
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d3462234cdafb8ff0ad497c0baa0f38fff6dc510169bf167bcdabf5f14705078
+        checksum/config: 977215c1d75979384f945105472734adf703d8cfe7b798c835f5ef2df67f21d3
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -46,7 +46,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.92.0"
+          image: "otel/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -81,7 +81,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
             - name: GOMEMLIMIT
-              value: 160MiB
+              value: "160MiB"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.49.1
-        helm.sh/chart: prometheus-25.11.0
+        helm.sh/chart: prometheus-25.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.48.1
-        helm.sh/chart: prometheus-25.8.2
+        app.kubernetes.io/version: v2.49.1
+        helm.sh/chart: prometheus-25.11.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -40,7 +40,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.48.1"
+          image: "quay.io/prometheus/prometheus:v2.49.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1120,6 +1120,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1357,6 +1359,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1369,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -501,13 +501,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -528,7 +528,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -566,13 +566,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -641,13 +641,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -668,7 +668,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -724,13 +724,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -751,7 +751,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -785,13 +785,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -812,7 +812,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -848,13 +848,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -875,7 +875,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -931,13 +931,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -985,10 +985,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -998,13 +994,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1025,7 +1021,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1063,13 +1059,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1086,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1148,13 +1144,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1175,7 +1171,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1237,13 +1233,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1264,7 +1260,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1306,13 +1302,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1333,7 +1329,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1379,13 +1375,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1406,7 +1402,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1444,13 +1440,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1471,7 +1467,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1507,13 +1503,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1534,7 +1530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1574,13 +1570,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1601,7 +1597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1643,13 +1639,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1704,13 +1700,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1731,7 +1727,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -549,7 +549,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -771,6 +771,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1036,7 +1038,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1283,7 +1285,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,17 +6,17 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:
   
-  demo-dashboard.json: |-
+  demo-dashboard.json: |
     {
       "annotations": {
         "list": [
@@ -475,7 +475,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"
@@ -563,7 +563,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -67,7 +67,8 @@ data:
         logLevelField: severity
         logMessageField: body
         pplEnabled: true
-        timeField: '@timestamp'
+        timeField: observedTimestamp
+        version: 2.11.1
       name: OpenSearch
       type: grafana-opensearch-datasource
       url: http://otel-demo-opensearch:9200/

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   
+  plugins: grafana-opensearch-datasource
   grafana.ini: |
     [analytics]
     check_for_updates = true
@@ -57,6 +58,19 @@ data:
       type: jaeger
       uid: webstore-traces
       url: http://example-jaeger-query:16686/jaeger/ui
+    - access: proxy
+      editable: true
+      isDefault: false
+      jsonData:
+        database: otel
+        flavor: opensearch
+        logLevelField: severity
+        logMessageField: body
+        pplEnabled: true
+        timeField: '@timestamp'
+      name: OpenSearch
+      type: grafana-opensearch-datasource
+      url: http://otel-demo-opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 6ed234d37b51db8079340220e18b2d85ed4af929793369ba445677a901992c5b
+        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
@@ -42,7 +42,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.2.3"
+          image: "docker.io/grafana/grafana:10.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: example-grafana
                   key: admin-password
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: example-grafana
+                  key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
             - name: GF_PATHS_LOGS

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
+        checksum/config: 085545e0f9f0ec8ab9cf9b08fa8e4ce19f9925e12c0ea44a7c22479bbbbdf715
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.51.0
+          image: jaegertracing/all-in-one:1.53.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -94,7 +94,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
           volumeMounts:
       serviceAccountName: example-jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces=8000"
+            - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
             - "--prometheus.server-url=http://example-prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -19,6 +19,12 @@ data:
     exporters:
       debug: {}
       logging: {}
+      opensearch:
+        http:
+          endpoint: http://otel-demo-opensearch:9200
+          tls:
+            insecure: true
+        logs_index: otel
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:
@@ -28,14 +34,10 @@ data:
         tls:
           insecure: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       batch: {}
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-          - name == "rpc.server.duration"
       k8sattributes:
         extract:
           metadata:
@@ -68,13 +70,6 @@ data:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
-      transform:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(description, "") where name == "queueSize"
-          - set(description, "") where name == "rpc.server.duration"
-          - set(description, "") where name == "http.client.duration"
     receivers:
       jaeger:
         protocols:
@@ -110,10 +105,12 @@ data:
       pipelines:
         logs:
           exporters:
+          - opensearch
           - debug
           processors:
           - k8sattributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -124,8 +121,6 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/ottl
-          - transform
           - resource
           - batch
           receivers:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d2d1620fe68690754eb7ce44954d67a60fd4b16edc98b0eeb86902bdabcf9beb
+        checksum/config: e7d46b1885b94258f2a1aa6a7e6b7a7ff21e76ec99df11187e3a7cd5d596964f
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -46,7 +46,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.92.0"
+          image: "otel/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -81,7 +81,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
             - name: GOMEMLIMIT
-              value: 160MiB
+              value: "160MiB"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e7d46b1885b94258f2a1aa6a7e6b7a7ff21e76ec99df11187e3a7cd5d596964f
+        checksum/config: 02892493e6e4a9ef245700d031d6c184ddeab5f9dbfbd473e3fb2738563ff806
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.49.1
-        helm.sh/chart: prometheus-25.11.0
+        helm.sh/chart: prometheus-25.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.48.1
-        helm.sh/chart: prometheus-25.8.2
+        app.kubernetes.io/version: v2.49.1
+        helm.sh/chart: prometheus-25.11.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -40,7 +40,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.48.1"
+          image: "quay.io/prometheus/prometheus:v2.49.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -1120,6 +1120,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1357,6 +1359,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1369,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -501,13 +501,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -528,7 +528,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -566,13 +566,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -641,13 +641,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -668,7 +668,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -724,13 +724,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -751,7 +751,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -785,13 +785,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -812,7 +812,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -848,13 +848,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -875,7 +875,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -931,13 +931,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -985,10 +985,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -998,13 +994,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1025,7 +1021,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1063,13 +1059,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1086,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1148,13 +1144,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1175,7 +1171,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1237,13 +1233,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1264,7 +1260,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1306,13 +1302,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1333,7 +1329,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1379,13 +1375,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1406,7 +1402,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1444,13 +1440,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1471,7 +1467,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1507,13 +1503,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1534,7 +1530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1574,13 +1570,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1601,7 +1597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1643,13 +1639,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1704,13 +1700,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1731,7 +1727,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -549,7 +549,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -771,6 +771,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1036,7 +1038,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1283,7 +1285,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,17 +6,17 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:
   
-  demo-dashboard.json: |-
+  demo-dashboard.json: |
     {
       "annotations": {
         "list": [
@@ -475,7 +475,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"
@@ -563,7 +563,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -67,7 +67,8 @@ data:
         logLevelField: severity
         logMessageField: body
         pplEnabled: true
-        timeField: '@timestamp'
+        timeField: observedTimestamp
+        version: 2.11.1
       name: OpenSearch
       type: grafana-opensearch-datasource
       url: http://otel-demo-opensearch:9200/

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   
+  plugins: grafana-opensearch-datasource
   grafana.ini: |
     [analytics]
     check_for_updates = true
@@ -57,6 +58,19 @@ data:
       type: jaeger
       uid: webstore-traces
       url: http://example-jaeger-query:16686/jaeger/ui
+    - access: proxy
+      editable: true
+      isDefault: false
+      jsonData:
+        database: otel
+        flavor: opensearch
+        logLevelField: severity
+        logMessageField: body
+        pplEnabled: true
+        timeField: '@timestamp'
+      name: OpenSearch
+      type: grafana-opensearch-datasource
+      url: http://otel-demo-opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 6ed234d37b51db8079340220e18b2d85ed4af929793369ba445677a901992c5b
+        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
@@ -42,7 +42,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.2.3"
+          image: "docker.io/grafana/grafana:10.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: example-grafana
                   key: admin-password
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: example-grafana
+                  key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
             - name: GF_PATHS_LOGS

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
+        checksum/config: 085545e0f9f0ec8ab9cf9b08fa8e4ce19f9925e12c0ea44a7c22479bbbbdf715
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.51.0
+          image: jaegertracing/all-in-one:1.53.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -94,7 +94,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
           volumeMounts:
       serviceAccountName: example-jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces=8000"
+            - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
             - "--prometheus.server-url=http://example-prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -19,6 +19,12 @@ data:
     exporters:
       debug: {}
       logging: {}
+      opensearch:
+        http:
+          endpoint: http://otel-demo-opensearch:9200
+          tls:
+            insecure: true
+        logs_index: otel
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:
@@ -30,14 +36,10 @@ data:
     extensions:
       file_storage:
         directory: /var/lib/otelcol
-      health_check: {}
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       batch: {}
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-          - name == "rpc.server.duration"
       k8sattributes:
         extract:
           metadata:
@@ -72,13 +74,6 @@ data:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
-      transform:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(description, "") where name == "queueSize"
-          - set(description, "") where name == "rpc.server.duration"
-          - set(description, "") where name == "http.client.duration"
     receivers:
       filelog:
         exclude:
@@ -157,6 +152,8 @@ data:
         - from: attributes.log
           to: body
           type: move
+        retry_on_failure:
+          enabled: true
         start_at: end
         storage: file_storage
       hostmetrics:
@@ -244,10 +241,12 @@ data:
       pipelines:
         logs:
           exporters:
+          - opensearch
           - debug
           processors:
           - k8sattributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -259,8 +258,6 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/ottl
-          - transform
           - resource
           - batch
           receivers:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8ff37533f26f3076e8241fa1e33eb74c34f8c841517f09f0d0d2c6eb8e507f8a
+        checksum/config: 31105ca6f597e1846e5fecafaba9047513949d43f283f1daf6df2dcf20173ddf
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8165705f27dbfec474b8d087fdbf44f78a1d908f4b83733a5d6160447b904eb9
+        checksum/config: 8ff37533f26f3076e8241fa1e33eb74c34f8c841517f09f0d0d2c6eb8e507f8a
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          image: "otel/opentelemetry-collector-contrib:0.92.0"
+          image: "otel/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -90,7 +90,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: GOMEMLIMIT
-              value: 160MiB
+              value: "160MiB"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.49.1
-        helm.sh/chart: prometheus-25.11.0
+        helm.sh/chart: prometheus-25.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.48.1
-        helm.sh/chart: prometheus-25.8.2
+        app.kubernetes.io/version: v2.49.1
+        helm.sh/chart: prometheus-25.11.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -40,7 +40,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.48.1"
+          image: "quay.io/prometheus/prometheus:v2.49.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1120,6 +1120,8 @@ spec:
             value: 'example-recommendationservice:8080'
           - name: SHIPPING_SERVICE_ADDR
             value: 'example-shippingservice:8080'
+          - name: OTEL_COLLECTOR_HOST
+            value: $(OTEL_COLLECTOR_NAME)
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
           - name: WEB_OTEL_SERVICE_NAME
@@ -1357,6 +1359,8 @@ spec:
             value: "false"
           - name: LOCUST_AUTOSTART
             value: "true"
+          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+            value: "true"
           - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
             value: python
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1365,7 +1369,7 @@ spec:
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
             limits:
-              memory: 120Mi
+              memory: 1Gi
           volumeMounts:
       volumes:
 ---

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,13 +5,13 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -30,13 +30,13 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -55,13 +55,13 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -80,13 +80,13 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -105,13 +105,13 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -130,13 +130,13 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -158,13 +158,13 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -183,13 +183,13 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -208,13 +208,13 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -233,13 +233,13 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -261,13 +261,13 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -286,13 +286,13 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -311,13 +311,13 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -336,13 +336,13 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -361,13 +361,13 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -386,13 +386,13 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -411,13 +411,13 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,13 +436,13 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
     app.kubernetes.io/name: example-accountingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -463,7 +463,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-accountingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-accountingservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -501,13 +501,13 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
     app.kubernetes.io/name: example-adservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -528,7 +528,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-adservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -566,13 +566,13 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
     app.kubernetes.io/name: example-cartservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -593,7 +593,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-cartservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -641,13 +641,13 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
     app.kubernetes.io/name: example-checkoutservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -668,7 +668,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-checkoutservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -724,13 +724,13 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
     app.kubernetes.io/name: example-currencyservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -751,7 +751,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-currencyservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -785,13 +785,13 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
     app.kubernetes.io/name: example-emailservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -812,7 +812,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-emailservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -848,13 +848,13 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
     app.kubernetes.io/name: example-featureflagservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -875,7 +875,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: featureflagservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-featureflagservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-featureflagservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -931,13 +931,13 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
     app.kubernetes.io/name: example-ffspostgres
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ffspostgres
-          image: 'postgres:16.1'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-ffspostgres'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -985,10 +985,6 @@ spec:
           resources:
             limits:
               memory: 120Mi
-          securityContext:
-            runAsGroup: 999
-            runAsNonRoot: true
-            runAsUser: 999
           volumeMounts:
       volumes:
 ---
@@ -998,13 +994,13 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
     app.kubernetes.io/name: example-frauddetectionservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1025,7 +1021,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frauddetectionservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frauddetectionservice'
           imagePullPolicy: IfNotPresent
           env:
           - name: OTEL_SERVICE_NAME
@@ -1063,13 +1059,13 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: example-frontend
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1086,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontend'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1148,13 +1144,13 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1175,7 +1171,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-frontendproxy'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1237,13 +1233,13 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: example-kafka
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1264,7 +1260,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-kafka'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1306,13 +1302,13 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
     app.kubernetes.io/name: example-loadgenerator
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1333,7 +1329,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-loadgenerator'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1379,13 +1375,13 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
     app.kubernetes.io/name: example-paymentservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1406,7 +1402,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-paymentservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1444,13 +1440,13 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
     app.kubernetes.io/name: example-productcatalogservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1471,7 +1467,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-productcatalogservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1507,13 +1503,13 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
     app.kubernetes.io/name: example-quoteservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1534,7 +1530,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-quoteservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1574,13 +1570,13 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
     app.kubernetes.io/name: example-recommendationservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1601,7 +1597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-recommendationservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1643,13 +1639,13 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: example-redis
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1704,13 +1700,13 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
     app.kubernetes.io/name: example-shippingservice
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1731,7 +1727,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.7.0-shippingservice'
+          image: 'ghcr.io/open-telemetry/demo:1.8.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
           
@@ -1767,13 +1763,13 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
     app.kubernetes.io/name: example-frontendproxy
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -549,7 +549,7 @@ spec:
           - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
             value: 'example-featureflagservice:50053'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_LOGS_EXPORTER
             value: otlp
           - name: OTEL_RESOURCE_ATTRIBUTES
@@ -771,6 +771,8 @@ spec:
             value: "8080"
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: http://$(OTEL_COLLECTOR_NAME):4317
+          - name: VERSION
+            value: '1.8.0'
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1036,7 +1038,7 @@ spec:
           - name: KAFKA_SERVICE_ADDR
             value: 'example-kafka:9092'
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo
           resources:
@@ -1283,7 +1285,7 @@ spec:
           - name: KAFKA_ADVERTISED_LISTENERS
             value: PLAINTEXT://example-kafka:9092
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
           - name: KAFKA_HEAP_OPTS
             value: -Xmx200M -Xms200M
           - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,17 +6,17 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:
   
-  demo-dashboard.json: |-
+  demo-dashboard.json: |
     {
       "annotations": {
         "list": [
@@ -475,7 +475,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"
@@ -563,7 +563,7 @@ data:
                   "type": "count"
                 }
               ],
-              "query": "search source=otel\n| where serviceName=\"${service}\"",
+              "query": "search source=otel\n| where resource.service.name=\"${service}\"",
               "queryType": "PPL",
               "refId": "A",
               "timeField": "time"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -67,7 +67,8 @@ data:
         logLevelField: severity
         logMessageField: body
         pplEnabled: true
-        timeField: '@timestamp'
+        timeField: observedTimestamp
+        version: 2.11.1
       name: OpenSearch
       type: grafana-opensearch-datasource
       url: http://otel-demo-opensearch:9200/

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   
+  plugins: grafana-opensearch-datasource
   grafana.ini: |
     [analytics]
     check_for_updates = true
@@ -57,6 +58,19 @@ data:
       type: jaeger
       uid: webstore-traces
       url: http://example-jaeger-query:16686/jaeger/ui
+    - access: proxy
+      editable: true
+      isDefault: false
+      jsonData:
+        database: otel
+        flavor: opensearch
+        logLevelField: severity
+        logMessageField: body
+        pplEnabled: true
+        timeField: '@timestamp'
+      name: OpenSearch
+      type: grafana-opensearch-datasource
+      url: http://otel-demo-opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: 6ed234d37b51db8079340220e18b2d85ed4af929793369ba445677a901992c5b
+        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
@@ -42,7 +42,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.2.3"
+          image: "docker.io/grafana/grafana:10.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -90,6 +90,11 @@ spec:
                 secretKeyRef:
                   name: example-grafana
                   key: admin-password
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: example-grafana
+                  key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
             - name: GF_PATHS_LOGS

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: edb1beb0083efa4d7e989e12c2b0c927067acafe79f6fda4b85b914fed7306c6
+        checksum/config: 085545e0f9f0ec8ab9cf9b08fa8e4ce19f9925e12c0ea44a7c22479bbbbdf715
         checksum/sc-dashboard-provider-config: 593c0a8778b83f11fe80ccb21dfb20bc46705e2be3178df1dc4c89d164c8cd9c
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-7.2.1
+    helm.sh/chart: grafana-7.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "10.2.3"
+    app.kubernetes.io/version: "10.3.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-agent
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-collector
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one
     prometheus.io/port: "14269"
@@ -44,7 +44,7 @@ spec:
               value: "false"
             - name: COLLECTOR_OTLP_ENABLED
               value: "true"
-          image: jaegertracing/all-in-one:1.51.0
+          image: jaegertracing/all-in-one:1.53.0
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -94,7 +94,7 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: 300Mi
+              memory: 400Mi
           volumeMounts:
       serviceAccountName: example-jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: jaeger
           args:
-            - "--memory.max-traces=8000"
+            - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
             - "--prometheus.server-url=http://example-prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: service-query
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.73.1
+    helm.sh/chart: jaeger-0.74.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "1.51.0"
+    app.kubernetes.io/version: "1.53.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: all-in-one

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-0.74.1
+    helm.sh/chart: jaeger-1.0.0
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-demo-opensearch-config
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+data:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    
+    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+    network.host: 0.0.0.0
+    
+    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+    # Implicitly done if ".singleNode" is set to "true".
+    # discovery.type: single-node
+    
+    # Start OpenSearch Security Demo Configuration
+    # WARNING: revise all the lines below before you go into production
+    plugins:
+      security:
+        ssl:
+          transport:
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+            enforce_hostname_verification: false
+          http:
+            enabled: true
+            pemcert_filepath: esnode.pem
+            pemkey_filepath: esnode-key.pem
+            pemtrustedcas_filepath: root-ca.pem
+        allow_unsafe_democertificates: true
+        allow_default_init_securityindex: true
+        authcz:
+          admin_dn:
+            - CN=kirk,OU=client,O=client,L=test,C=de
+        audit.type: internal_opensearch
+        enable_snapshot_restore_privilege: true
+        check_snapshot_restore_write_privileges: true
+        restapi:
+          roles_enabled: ["all_access", "security_rest_api_access"]
+        system_indices:
+          enabled: true
+          indices:
+            [
+              ".opendistro-alerting-config",
+              ".opendistro-alerting-alert*",
+              ".opendistro-anomaly-results*",
+              ".opendistro-anomaly-detector*",
+              ".opendistro-anomaly-checkpoints",
+              ".opendistro-anomaly-detection-state",
+              ".opendistro-reports-*",
+              ".opendistro-notifications-*",
+              ".opendistro-notebooks",
+              ".opendistro-asynchronous-search-response*",
+            ]
+    ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "otel-demo-opensearch-pdb"
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
@@ -1,0 +1,56 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: otel-demo-opensearch-headless
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: opentelemetry-demo/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-demo-opensearch
+  labels:
+    helm.sh/chart: opensearch-2.17.2
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "2.11.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-demo-opensearch
+  annotations:
+    majorVersion: "2"
+spec:
+  serviceName: otel-demo-opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: example
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: "otel-demo-opensearch"
+      labels:
+        helm.sh/chart: opensearch-2.17.2
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "2.11.1"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: otel-demo-opensearch
+      annotations:
+        configchecksum: 168039ffc030115a8030f635c84ded4af2a940945fe7335048dcd1ca425966f
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - example
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - opensearch
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: otel-demo-opensearch-config
+      enableServiceLinks: true
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "opensearchproject/opensearch:2.11.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 100Mi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.seed_hosts
+          value: "opensearch-cluster-master-headless"
+        - name: cluster.name
+          value: "demo-cluster"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: discovery.type
+          value: "single-node"
+        - name: bootstrap.memory_lock
+          value: "true"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_SECURITY_PLUGIN
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
@@ -94,6 +94,8 @@ spec:
         - name: metrics
           containerPort: 9600
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 1000m
             memory: 100Mi
@@ -109,7 +111,7 @@ spec:
         - name: network.host
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms512m -Xmx512m"
+          value: "-Xms300m -Xmx300m"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         - name: discovery.type

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -19,6 +19,12 @@ data:
     exporters:
       debug: {}
       logging: {}
+      opensearch:
+        http:
+          endpoint: http://otel-demo-opensearch:9200
+          tls:
+            insecure: true
+        logs_index: otel
       otlp:
         endpoint: 'example-jaeger-collector:4317'
         tls:
@@ -28,14 +34,10 @@ data:
         tls:
           insecure: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       batch: {}
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-          - name == "rpc.server.duration"
       k8sattributes:
         extract:
           metadata:
@@ -68,13 +70,6 @@ data:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
-      transform:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(description, "") where name == "queueSize"
-          - set(description, "") where name == "rpc.server.duration"
-          - set(description, "") where name == "http.client.duration"
     receivers:
       jaeger:
         protocols:
@@ -110,10 +105,12 @@ data:
       pipelines:
         logs:
           exporters:
+          - opensearch
           - debug
           processors:
           - k8sattributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -124,8 +121,6 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/ottl
-          - transform
           - resource
           - batch
           receivers:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d2d1620fe68690754eb7ce44954d67a60fd4b16edc98b0eeb86902bdabcf9beb
+        checksum/config: e7d46b1885b94258f2a1aa6a7e6b7a7ff21e76ec99df11187e3a7cd5d596964f
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -46,7 +46,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.92.0"
+          image: "otel/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -81,7 +81,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
             - name: GOMEMLIMIT
-              value: 160MiB
+              value: "160MiB"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e7d46b1885b94258f2a1aa6a7e6b7a7ff21e76ec99df11187e3a7cd5d596964f
+        checksum/config: 02892493e6e4a9ef245700d031d6c184ddeab5f9dbfbd473e3fb2738563ff806
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.78.0
+    helm.sh/chart: opentelemetry-collector-0.80.1
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.92.0"
+    app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: v2.49.1
-        helm.sh/chart: prometheus-25.11.0
+        helm.sh/chart: prometheus-25.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
@@ -30,8 +30,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.48.1
-        helm.sh/chart: prometheus-25.8.2
+        app.kubernetes.io/version: v2.49.1
+        helm.sh/chart: prometheus-25.11.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -40,7 +40,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.48.1"
+          image: "quay.io/prometheus/prometheus:v2.49.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: v2.49.1
-    helm.sh/chart: prometheus-25.11.0
+    helm.sh/chart: prometheus-25.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.48.1
-    helm.sh/chart: prometheus-25.8.2
+    app.kubernetes.io/version: v2.49.1
+    helm.sh/chart: prometheus-25.11.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,11 +5,11 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.29.0
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/name: example
-    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/grafana-dashboards/demo-dashboard.json
+++ b/charts/opentelemetry-demo/grafana-dashboards/demo-dashboard.json
@@ -456,7 +456,7 @@
               "type": "count"
             }
           ],
-          "query": "search source=otel\n| where serviceName=\"${service}\"\n| stats count() by severityText",
+          "query": "search source=otel\n| where resource.service.name=\"${service}\"\n| stats count() by severity.text",
           "queryType": "PPL",
           "refId": "A",
           "timeField": "time"
@@ -544,7 +544,7 @@
               "type": "count"
             }
           ],
-          "query": "search source=otel\n| where serviceName=\"${service}\"",
+          "query": "search source=otel\n| where resource.service.name=\"${service}\"",
           "queryType": "PPL",
           "refId": "A",
           "timeField": "time"

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -44,6 +44,9 @@
     },
     "grafana": {
       "type": "object"
+    },
+    "opensearch": {
+      "type": "object"
     }
   },
   "required": [

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -353,6 +353,8 @@ components:
         value: '{{ include "otel-demo.name" . }}-recommendationservice:8080'
       - name: SHIPPING_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-shippingservice:8080'
+      - name: OTEL_COLLECTOR_HOST
+        value: $(OTEL_COLLECTOR_NAME)
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
       - name: WEB_OTEL_SERVICE_NAME
@@ -429,13 +431,15 @@ components:
         value: "false"
       - name: LOCUST_AUTOSTART
         value: "true"
+      - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+        value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
-        memory: 120Mi
+        memory: 1Gi
 
   paymentService:
     enabled: true
@@ -681,7 +685,7 @@ jaeger:
   allInOne:
     enabled: true
     args:
-      - "--memory.max-traces=8000"
+      - "--memory.max-traces=5000"
       - "--query.base-path=/jaeger/ui"
       - "--prometheus.server-url=http://{{ include \"otel-demo.name\" . }}-prometheus-server:9090"
       - "--prometheus.query.normalize-calls=true"
@@ -823,7 +827,7 @@ opensearch:
   clusterName: demo-cluster
   nodeGroup: otel-demo
   singleNode: true
-  opensearchJavaOpts: "-Xms512m -Xmx512m"
+  opensearchJavaOpts: "-Xms300m -Xmx300m"
   persistence:
     enabled: false
   extraEnvs:
@@ -833,3 +837,6 @@ opensearch:
       value: "true"
     - name: "DISABLE_SECURITY_PLUGIN"
       value: "true"
+  resources:
+    limits:
+      memory: 1Gi

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -180,7 +180,7 @@ components:
       - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-featureflagservice:50053'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
+        value: http://$(OTEL_COLLECTOR_NAME):4318
       - name: OTEL_LOGS_EXPORTER
         value: otlp
     resources:
@@ -256,6 +256,8 @@ components:
         value: "8080"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
+      - name: VERSION
+        value: "{{ .Chart.AppVersion }}"
     resources:
       limits:
         memory: 20Mi
@@ -319,7 +321,7 @@ components:
       - name: KAFKA_SERVICE_ADDR
         value: '{{ include "otel-demo.name" . }}-kafka:9092'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
+        value: http://$(OTEL_COLLECTOR_NAME):4318
     resources:
       limits:
         memory: 200Mi
@@ -571,7 +573,7 @@ components:
       - name: KAFKA_ADVERTISED_LISTENERS
         value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(OTEL_COLLECTOR_NAME):4317
+        value: http://$(OTEL_COLLECTOR_NAME):4318
       - name: KAFKA_HEAP_OPTS
         value: "-Xmx200M -Xms200M"
     resources:
@@ -695,7 +697,7 @@ jaeger:
         value: prometheus
     resources:
       limits:
-        memory: 300Mi
+        memory: 400Mi
   storage:
     type: none
   agent:
@@ -802,7 +804,8 @@ grafana:
             logLevelField: severity
             logMessageField: body
             pplEnabled: true
-            timeField: "@timestamp"
+            timeField: observedTimestamp
+            version: 2.11.1
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -538,9 +538,6 @@ components:
     enabled: true
     useDefault:
       env: true
-    imageOverride:
-      repository: "postgres"
-      tag: "16.1"
     replicas: 1
     ports:
       - name: postgres
@@ -555,10 +552,6 @@ components:
     resources:
       limits:
         memory: 120Mi
-    securityContext:
-      runAsUser: 999  # postgres
-      runAsGroup: 999
-      runAsNonRoot: true
 
   kafka:
     enabled: true
@@ -651,6 +644,12 @@ opentelemetry-collector:
         endpoint: 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090/api/v1/otlp'
         tls:
           insecure: true
+      opensearch:
+        logs_index: otel
+        http:
+          endpoint: "http://otel-demo-opensearch:9200"
+          tls:
+            insecure: true
 
     processors:
       resource:
@@ -658,25 +657,6 @@ opentelemetry-collector:
         - key: service.instance.id
           from_attribute: k8s.pod.uid
           action: insert
-      filter/ottl:
-        error_mode: ignore
-        metrics:
-          metric:
-            # FIXME: remove when a Metrics View is implemented in the checkout and productcatalog components
-            # or when this issue is resolved: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3071
-            - 'name == "rpc.server.duration"'
-      transform:
-        metric_statements:
-          - context: metric
-            statements:
-              # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-java/issues/4834
-              - set(description, "") where name == "queueSize"
-              # FIXME: remove when these 2 issues are resolved:
-              # Java: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9478
-              # Go: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4301
-              - set(description, "") where name == "rpc.server.duration"
-              # FIXME: remove when this issue is resolved: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1958
-              - set(description, "") where name == "http.client.duration"
 
     connectors:
       spanmetrics:
@@ -688,8 +668,11 @@ opentelemetry-collector:
           exporters: [otlp, debug, spanmetrics]
         metrics:
           receivers: [otlp, spanmetrics]
-          processors: [memory_limiter, filter/ottl, transform, resource, batch]
+          processors: [memory_limiter, resource, batch]
           exporters: [otlphttp/prometheus, debug]
+        logs:
+          processors: [memory_limiter, resource, batch]
+          exporters: [opensearch, debug]
 
 jaeger:
   enabled: true
@@ -775,6 +758,8 @@ grafana:
       root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
       serve_from_sub_path: true
   adminPassword: admin
+  plugins:
+    - grafana-opensearch-datasource
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -800,6 +785,20 @@ grafana:
           url: 'http://{{ include "otel-demo.name" . }}-jaeger-query:16686/jaeger/ui'
           editable: true
           isDefault: false
+
+        - name: OpenSearch
+          type: grafana-opensearch-datasource
+          url: 'http://otel-demo-opensearch:9200/'
+          access: proxy
+          editable: true
+          isDefault: false
+          jsonData:
+            database: otel
+            flavor: opensearch
+            logLevelField: severity
+            logMessageField: body
+            pplEnabled: true
+            timeField: "@timestamp"
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1
@@ -817,3 +816,20 @@ grafana:
   resources:
     limits:
       memory: 150Mi
+
+opensearch:
+  enabled: true
+  fullnameOverride: otel-demo-opensearch
+  clusterName: demo-cluster
+  nodeGroup: otel-demo
+  singleNode: true
+  opensearchJavaOpts: "-Xms512m -Xmx512m"
+  persistence:
+    enabled: false
+  extraEnvs:
+    - name: "bootstrap.memory_lock"
+      value: "true"
+    - name: "DISABLE_INSTALL_DEMO_CONFIG"
+      value: "true"
+    - name: "DISABLE_SECURITY_PLUGIN"
+      value: "true"


### PR DESCRIPTION
This release adds a new subchart: OpenSearch.

The demo has added Logs support, and it was decided to use OpenSearch for the logging backend. This sets up a single-node OpenSearch cluster as part of the helm chart.

I have a concern that the OpenSearch chart doesn't use the Helm Chart Release name for the service and pod names, nor does it allow us to template inline variables as part of the `nameOverride` or `fullnameOverride` properties. As such, we end up with a hardcoded prefix of `otel-demo` for the OpenSearch pod and service names.