### PR TITLE
create featureflags table and populate it

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.28.1
+version: 0.28.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +534,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +599,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +757,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +818,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +881,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +964,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -990,7 +1023,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -998,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1101,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1275,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1379,7 +1417,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1444,7 +1482,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1507,7 +1545,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1574,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1643,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1704,7 +1742,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +534,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +599,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +757,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +818,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +881,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +964,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -990,7 +1023,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -998,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1101,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1275,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1379,7 +1417,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1444,7 +1482,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1507,7 +1545,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1574,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1643,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1704,7 +1742,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -503,7 +536,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +603,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -647,7 +680,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -732,7 +765,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -795,7 +828,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -860,7 +893,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -945,7 +978,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1004,7 +1037,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1012,7 +1050,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1079,7 +1117,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1166,7 +1204,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1255,7 +1293,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1324,7 +1362,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1399,7 +1437,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1466,7 +1504,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1531,7 +1569,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1600,7 +1638,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1671,7 +1709,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1732,7 +1770,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +534,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +599,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +757,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +818,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +881,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +964,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -990,7 +1023,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -998,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1101,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1275,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1379,7 +1417,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1444,7 +1482,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1507,7 +1545,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1574,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1643,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1704,7 +1742,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +534,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +599,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +757,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +818,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +881,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +964,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -990,7 +1023,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -998,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1101,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1275,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1379,7 +1417,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1444,7 +1482,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1507,7 +1545,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1574,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1643,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1704,7 +1742,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1,11 +1,44 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-ffspostgres-init-scripts
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.28.2
+    
+    opentelemetry.io/name: example-ffspostgres
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: ffspostgres
+    app.kubernetes.io/name: example-ffspostgres
+    app.kubernetes.io/version: "1.7.0"
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  10-ffs_schema.sql: |
+    CREATE TABLE public.featureflags (
+        name character varying(255),
+        description character varying(255),
+        enabled double precision DEFAULT 0.0 NOT NULL
+    );
+    ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+    CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+  20-ffs_data.sql: |
+    -- Feature Flags created and initialized on startup
+    INSERT INTO public.featureflags (name, description, enabled)
+    VALUES
+        ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+        ('recommendationCache', 'Cache recommendations', 0),
+        ('adServiceFailure', 'Fail ad service requests', 0),
+        ('cartServiceFailure', 'Fail cart service requests', 0);
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +63,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +88,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +113,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +138,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +163,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +191,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +216,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +241,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +266,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +294,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +319,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +344,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +369,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +394,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +419,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +444,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +469,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +534,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +599,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +674,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +757,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -785,7 +818,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -848,7 +881,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -931,7 +964,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -990,7 +1023,12 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
       volumes:
+        - name: init-scripts
+          configMap:
+            name: example-ffspostgres-init-scripts
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -998,7 +1036,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1101,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1186,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1275,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1344,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1379,7 +1417,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1444,7 +1482,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1507,7 +1545,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1574,7 +1612,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1643,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1704,7 +1742,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1767,7 +1805,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.28.1
+    helm.sh/chart: opentelemetry-demo-0.28.2
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -559,6 +559,26 @@ components:
       runAsUser: 999  # postgres
       runAsGroup: 999
       runAsNonRoot: true
+    mountedConfigMaps:
+      - name: init-scripts
+        mountPath: /docker-entrypoint-initdb.d
+        data:
+          10-ffs_schema.sql: |
+            CREATE TABLE public.featureflags (
+                name character varying(255),
+                description character varying(255),
+                enabled double precision DEFAULT 0.0 NOT NULL
+            );
+            ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
+            CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+          20-ffs_data.sql: |
+            -- Feature Flags created and initialized on startup
+            INSERT INTO public.featureflags (name, description, enabled)
+            VALUES
+                ('productCatalogFailure', 'Fail product catalog service on a specific product', 0),
+                ('recommendationCache', 'Cache recommendations', 0),
+                ('adServiceFailure', 'Fail ad service requests', 0),
+                ('cartServiceFailure', 'Fail cart service requests', 0);
 
   kafka:
     enabled: true


### PR DESCRIPTION
The postgres database used by the featureflagservice is not initialized / migrated any more by ecto.  This PR tries to mimic the behavior of the `docker-compose.yml` of the `opentelemetry-demo` project.