### PR TITLE
fix(doc): flag name used to enable certManager

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.47.0
+version: 0.47.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -14,7 +14,7 @@ At this point, it has [OpenTelemetry Collector](https://github.com/open-telemetr
 In Kubernetes, in order for the API server to communicate with the webhook component, the webhook requires a TLS
 certificate that the API server is configured to trust. There are a few different ways you can use to generate/configure the required TLS certificate.
 
-  - The easiest and default method is to install the [cert-manager](https://cert-manager.io/docs/) and set `admissionWebhooks.certManager.create` to `true`.
+  - The easiest and default method is to install the [cert-manager](https://cert-manager.io/docs/) and set `admissionWebhooks.certManager.enabled` to `true`.
     In this way, cert-manager will generate a self-signed certificate. _See [cert-manager installation](https://cert-manager.io/docs/installation/kubernetes/) for more details._
   - You can provide your own Issuer by configuring the `admissionWebhooks.certManager.issuerRef` value. You will need
     to specify the `kind` (Issuer or ClusterIssuer) and the `name`. Note that this method also requires the installation of cert-manager.

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -253,7 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -271,7 +271,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.47.0
+    helm.sh/chart: opentelemetry-operator-0.47.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Create flag is only used in doc (https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-helm-charts+%22certManager.create%22&type=code), but enabled seems be the correct name for the flag (https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-helm-charts%20%22certManager.enabled%22&type=code)