### PR TITLE
[demo] append to otel resource attributes

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.29.0
+version: 0.29.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -787,7 +787,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -850,7 +850,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -933,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1148,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1306,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1381,7 +1381,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1446,7 +1446,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1509,7 +1509,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1576,7 +1576,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1645,7 +1645,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1706,7 +1706,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -787,7 +787,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -850,7 +850,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -933,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1148,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1306,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1381,7 +1381,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1446,7 +1446,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1509,7 +1509,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1576,7 +1576,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1645,7 +1645,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1706,7 +1706,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -503,7 +503,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -647,7 +647,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -732,7 +732,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -862,7 +862,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -947,7 +947,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -1010,7 +1010,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1077,7 +1077,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1166,7 +1166,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1255,7 +1255,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1324,7 +1324,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1401,7 +1401,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1468,7 +1468,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1533,7 +1533,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1602,7 +1602,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1673,7 +1673,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1734,7 +1734,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -787,7 +787,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -850,7 +850,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -933,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1148,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1306,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1381,7 +1381,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1446,7 +1446,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1509,7 +1509,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1576,7 +1576,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1645,7 +1645,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1706,7 +1706,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -787,7 +787,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -850,7 +850,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -933,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1148,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1306,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1381,7 +1381,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1446,7 +1446,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1509,7 +1509,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1576,7 +1576,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1645,7 +1645,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1706,7 +1706,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -566,7 +566,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -641,7 +641,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -724,7 +724,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -787,7 +787,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -850,7 +850,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-featureflagservice
     app.kubernetes.io/instance: example
@@ -933,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-ffspostgres
     app.kubernetes.io/instance: example
@@ -996,7 +996,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1148,7 +1148,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1306,7 +1306,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1381,7 +1381,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1446,7 +1446,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1509,7 +1509,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1576,7 +1576,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1645,7 +1645,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-redis
     app.kubernetes.io/instance: example
@@ -1706,7 +1706,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1769,7 +1769,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.29.0
+    helm.sh/chart: opentelemetry-demo-0.29.1
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/templates/_pod.tpl
+++ b/charts/opentelemetry-demo/templates/_pod.tpl
@@ -1,12 +1,16 @@
 {{/*
 Get Pod Env
-Merges default environment variables (if used) with component environment variables.
-If using defaults, will pull out OTEL_RESOURCE_ATTRIBUTES from the list and add it to the end.
-The OTEL_RESOURCES_ATTRIBUTES environment variable uses Kubernetes environment variable expansion and should be last.
+- Merges default environment variables (if used) with component environment variables.
+- If using defaults, will pull out OTEL_RESOURCE_ATTRIBUTES from the list to be reused later.
+- An environment variable named OTEL_RESOURCE_ATTRIBUTES_EXTRA will have its value appended to the value of the
+OTEL_RESOURCE_ATTRIBUTES environment variable if it exists.
+- The OTEL_RESOURCES_ATTRIBUTES environment variable will typically use Kubernetes environment variable expansion and
+should be last.
 */}}
 {{- define "otel-demo.pod.env" -}}
 {{- $resourceAttributesEnv := dict }}
 {{- $allEnvs := list }}
+
 {{- if .useDefault.env  }}
 {{-   $defaultEnvs := include "otel-demo.envOverriden" (dict "env" .defaultValues.env "envOverrides" .defaultValues.envOverrides) | mustFromJson }}
 {{-   range $defaultEnvs }}
@@ -17,31 +21,45 @@ The OTEL_RESOURCES_ATTRIBUTES environment variable uses Kubernetes environment v
 {{-     end }}
 {{-   end }}
 {{- end }}
+
 {{- if or .env .envOverrides }}
-{{-   $allEnvs = concat $allEnvs ((include "otel-demo.envOverriden" .) | mustFromJson) }}
+{{-   $localEnvs := include "otel-demo.envOverriden" . | mustFromJson }}
+{{-   range $localEnvs }}
+{{-     if eq .name "OTEL_RESOURCE_ATTRIBUTES" }}
+{{-       $resourceAttributesEnv = . }}
+{{-     else if and $resourceAttributesEnv (eq .name "OTEL_RESOURCE_ATTRIBUTES_EXTRA") }}
+{{-       $newValue := (printf "%s,%s" (get $resourceAttributesEnv "value") .value) }}
+{{-       $resourceAttributesEnv = dict "name" "OTEL_RESOURCE_ATTRIBUTES" "value" $newValue }}
+{{-     else }}
+{{-       $allEnvs = append $allEnvs . }}
+{{-     end }}
+{{-   end }}
 {{- end }}
+
 {{- if $resourceAttributesEnv }}
 {{-   $allEnvs = append $allEnvs $resourceAttributesEnv }}
 {{- end }}
+
 {{- tpl (toYaml $allEnvs) . }}
 {{- end }}
+
 
 {{/*
 Get Pod ports
 */}}
 {{- define "otel-demo.pod.ports" -}}
 {{- if .ports }}
-{{- range $port := .ports }}
+{{-   range $port := .ports }}
 - containerPort: {{ $port.value }}
   name: {{ $port.name}}
-{{- end }}
+{{-   end }}
 {{- end }}
 
 {{- if .service }}
-{{- if .service.port }}
+{{-   if .service.port }}
 - containerPort: {{.service.port}}
   name: service
-{{- end }}
+{{-   end }}
 {{- end }}
 
 {{- end }}

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -70,6 +70,7 @@ components:
   ## Environment variables to add to the component's pod
   #   env:
   ## Environment variables that upsert (append + merge) into the `env` specification for this component.
+  ## A variable named OTEL_RESOURCE_ATTRIBUTES_EXTRA will have its value appended to the OTEL_RESOURCE_ATTRIBUTES value.
   #   envOverrides:
   ## Pod Scheduling rules for nodeSelector, affinity, or tolerations.
   #   schedulingRules:


### PR DESCRIPTION
Allows users to completely override the `OTEL_RESOURCE_ATTRIBUTES` environment variable at the component level or append to it using a special `OTEL_RESOURCE_ATTRIBUTES_EXTRA` environment variable.

Users can now specify:
```
components:
  frontendProxy:
    envOverrides:
      - name: OTEL_RESOURCE_ATTRIBUTES_EXTRA
        value: "net.component=proxy"
```

And the resource attributes for the frontendProxy will also contain a `net.component=proxy` attrbribute.