### PR TITLE
Bump operator to 0.95.0

### DIFF
--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -46,7 +46,7 @@ jobs:
           git clone -b v"$appVersion" --single-branch https://github.com/open-telemetry/opentelemetry-operator.git ./opentelemetry-operator
 
       - name: Install chainsaw
-        uses: kyverno/action-install-chainsaw@v0.1.6
+        uses: kyverno/action-install-chainsaw@v0.1.7
 
       - name: Install metrics-server
         run: |

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.48.0
+version: 0.49.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.94.0
+appVersion: 0.95.0

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -16,6 +16,11 @@ rules:
       - ""
     resources:
       - configmaps
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - serviceaccounts
+      - services
     verbs:
       - create
       - delete
@@ -39,45 +44,11 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - apps
     resources:
       - daemonsets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
       - deployments
+      - statefulsets
     verbs:
       - create
       - delete
@@ -95,18 +66,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - apps
-    resources:
-      - statefulsets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - autoscaling
     resources:
       - horizontalpodautoscalers
@@ -117,6 +76,15 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -130,8 +98,8 @@ rules:
   - apiGroups:
       - monitoring.coreos.com
     resources:
-      - servicemonitors
       - podmonitors
+      - servicemonitors
     verbs:
       - create
       - delete
@@ -165,6 +133,32 @@ rules:
   - apiGroups:
       - opentelemetry.io
     resources:
+      - opampbridges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
       - opentelemetrycollectors
     verbs:
       - get
@@ -189,56 +183,22 @@ rules:
       - patch
       - update
   - apiGroups:
-      - opentelemetry.io
+      - policy
     resources:
-      - opampbridges
+      - poddisruptionbudgets
     verbs:
+      - create
+      - delete
       - get
       - list
       - patch
       - update
       - watch
   - apiGroups:
-      - opentelemetry.io
+      - route.openshift.io
     resources:
-      - opampbridges/finalizers
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - opentelemetry.io
-    resources:
-      - opampbridges/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-    - route.openshift.io
-    resources:
-    - routes
-    - routes/custom-host
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - discovery.k8s.io
-    resources:
-    - endpointslices
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
+      - routes
+      - routes/custom-host
     verbs:
       - create
       - delete

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -253,9 +253,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -271,9 +271,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -33,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.94.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.95.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.94.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.95.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.48.0
+    helm.sh/chart: opentelemetry-operator-0.49.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.94.0"
+    app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -11,6 +11,11 @@ rules:
       - ""
     resources:
       - configmaps
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - serviceaccounts
+      - services
     verbs:
       - create
       - delete
@@ -34,45 +39,11 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - apps
     resources:
       - daemonsets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
       - deployments
+      - statefulsets
     verbs:
       - create
       - delete
@@ -90,18 +61,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - apps
-    resources:
-      - statefulsets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - autoscaling
     resources:
       - horizontalpodautoscalers
@@ -112,6 +71,15 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -125,8 +93,8 @@ rules:
   - apiGroups:
       - monitoring.coreos.com
     resources:
-      - servicemonitors
       - podmonitors
+      - servicemonitors
     verbs:
       - create
       - delete
@@ -160,6 +128,32 @@ rules:
   - apiGroups:
       - opentelemetry.io
     resources:
+      - opampbridges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
       - opentelemetrycollectors
     verbs:
       - get
@@ -184,56 +178,22 @@ rules:
       - patch
       - update
   - apiGroups:
-      - opentelemetry.io
+      - policy
     resources:
-      - opampbridges
+      - poddisruptionbudgets
     verbs:
+      - create
+      - delete
       - get
       - list
       - patch
       - update
       - watch
   - apiGroups:
-      - opentelemetry.io
+      - route.openshift.io
     resources:
-      - opampbridges/finalizers
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - opentelemetry.io
-    resources:
-      - opampbridges/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-    - route.openshift.io
-    resources:
-    - routes
-    - routes/custom-host
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - discovery.k8s.io
-    resources:
-    - endpointslices
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
+      - routes
+      - routes/custom-host
     verbs:
       - create
       - delete

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -32,7 +32,7 @@ manager:
     tag: ""
   collectorImage:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.94.0
+    tag: 0.95.0
   opampBridgeImage:
     repository: ""
     tag: ""


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-operator/issues/2656

I had to add new permissions to the operator ClusterRole due to https://github.com/open-telemetry/opentelemetry-operator/pull/2575. I ended up copying the rules from the operator's kustomize manifest, resulting in a smaller ClusterRole at the end of it.