### PR TITLE
[operator] Reject invalid/unknown properties using `additionalProperties`

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.49.1
+version: 0.50.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,10 @@
 # Upgrade guidelines
 
+## <0.50.0 to 0.50.0
+
+Additional properties are not allowed anymore, so care must be taken that no old or misspelled ones are present anymore.
+`helm show values open-telemetry/opentelemetry-operator --version 0.50.0` can be used to list the allowed values.
+
 ## <0.42.3 to 0.42.3
 
 A type of flag `autoGenerateCert` has been changed, now it is an object with two attributes `enabled` and `recreate`.

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -213,7 +213,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -231,7 +231,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.49.1
+    helm.sh/chart: opentelemetry-operator-0.50.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.95.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -23,6 +23,7 @@
         "securityContext",
         "testFramework"
     ],
+    "additionalProperties": false,
     "properties": {
         "replicaCount": {
             "type": "integer",
@@ -58,6 +59,7 @@
                 "minAvailable",
                 "maxUnavailable"
             ],
+            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -119,6 +121,7 @@
                 "rolling",
                 "securityContext"
             ],
+            "additionalProperties": false,
             "properties": {
                 "image": {
                     "type": "object",
@@ -128,6 +131,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
@@ -159,6 +163,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
@@ -190,6 +195,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
@@ -221,6 +227,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
@@ -255,6 +262,7 @@
                         "dotnet",
                         "go"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "java": {
                             "type": "object",
@@ -264,6 +272,7 @@
                                 "repository",
                                 "tag"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "repository": {
                                     "type": "string",
@@ -295,6 +304,7 @@
                                 "repository",
                                 "tag"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "repository": {
                                     "type": "string",
@@ -326,6 +336,7 @@
                                 "repository",
                                 "tag"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "repository": {
                                     "type": "string",
@@ -357,6 +368,7 @@
                                 "repository",
                                 "tag"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "repository": {
                                     "type": "string",
@@ -388,6 +400,7 @@
                                 "repository",
                                 "tag"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "repository": {
                                     "type": "string",
@@ -452,6 +465,7 @@
                         "webhookPort",
                         "healthzPort"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "metricsPort": {
                             "type": "integer",
@@ -492,12 +506,14 @@
                         "limits",
                         "requests"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "limits": {
                             "type": "object",
                             "default": {},
                             "title": "The limits Schema",
                             "required": [],
+                            "additionalProperties": false,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -529,6 +545,7 @@
                                 "cpu",
                                 "memory"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -571,6 +588,7 @@
                     "required": [
                         "ENABLE_WEBHOOKS"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "ENABLE_WEBHOOKS": {
                             "type": "string",
@@ -593,6 +611,7 @@
                         "create",
                         "annotations"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "create": {
                             "type": "boolean",
@@ -626,6 +645,7 @@
                         "annotations",
                         "metricsEndpoints"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -662,6 +682,7 @@
                                 "required": [
                                     "port"
                                 ],
+                                "additionalProperties": false,
                                 "properties": {
                                     "port": {
                                         "type": "string",
@@ -719,6 +740,7 @@
                         "extraLabels",
                         "annotations"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -744,6 +766,7 @@
                             "required": [
                                 "enabled"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "enabled": {
                                     "type": "boolean",
@@ -801,6 +824,7 @@
                     "required": [
                         "enabled"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -826,6 +850,7 @@
                         "minAllowed",
                         "updatePolicy"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -1031,6 +1056,7 @@
                 "extraArgs",
                 "securityContext"
             ],
+            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -1048,6 +1074,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
@@ -1078,6 +1105,7 @@
                     "required": [
                         "proxyPort"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "proxyPort": {
                             "type": "integer",
@@ -1100,12 +1128,14 @@
                         "limits",
                         "requests"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "limits": {
                             "type": "object",
                             "default": {},
                             "title": "The limits Schema",
                             "required": [],
+                            "additionalProperties": false,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -1137,6 +1167,7 @@
                                 "cpu",
                                 "memory"
                             ],
+                            "additionalProperties": false,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -1234,6 +1265,7 @@
                 "secretAnnotations",
                 "secretLabels"
             ],
+            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -1274,6 +1306,7 @@
                     "required": [
                         "failurePolicy"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "failurePolicy": {
                             "type": "string",
@@ -1330,6 +1363,7 @@
                         "certificateAnnotations",
                         "issuerAnnotations"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -1379,6 +1413,7 @@
                         "enabled",
                         "recreate"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",
@@ -1478,6 +1513,7 @@
             "required": [
                 "create"
             ],
+            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -1499,6 +1535,7 @@
             "required": [
                 "create"
             ],
+            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -1573,6 +1610,7 @@
                 "runAsUser",
                 "fsGroup"
             ],
+            "additionalProperties": false,
             "properties": {
                 "runAsGroup": {
                     "type": "integer",
@@ -1621,6 +1659,7 @@
             "required": [
                 "image"
             ],
+            "additionalProperties": false,
             "properties": {
                 "image": {
                     "type": "object",
@@ -1630,6 +1669,7 @@
                         "repository",
                         "tag"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",


### PR DESCRIPTION
This can catch misspellings like the one below, which I encountered when
using this Helm chart myself (but the previous validation did not catch it):

    Error: values don't meet the specifications of the schema(s) in the following chart(s):
    opentelemetry-operator:
    - (root): Additional property kubeRBACPRoxy is not allowed

I was not entirely sure about the version, so I bumped the minor version
as this change may reject charts that worked previously (if they contain
unknown or unspecified fields).

The three other charts already use `additionalProperties: false` in many
places, this adds similar validation to the `opentelemetry-operator` chart
as well: https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-helm-charts+additionalProperties&type=code