### PR TITLE
fix: add missing resource to clusterrole.yaml

### DIFF
--- a/charts/opentelemetry-collector/templates/clusterrole.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
   {{- end}}
   {{- if .Values.presets.kubeletMetrics.enabled}}
   - apiGroups: [""]
-    resources: ["nodes/stats"]
+    resources: ["nodes/stats", "nodes/proxy"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if .Values.presets.kubernetesEvents.enabled }}


### PR DESCRIPTION
With `kubeletMetrics` enabled I get 
```
2024-03-08T11:50:01.933Z        error   kubeletstatsreceiver@v0.95.0/scraper.go:86      call to /pods endpoint failed   {"kind": "receiver", "name": "kubeletstats", "data_type": "metrics", "error": "kubelet request GET https://10.240.90.199:10250/pods failed - \"403 Forbidden\", response: \"Forbidden (user=system:serviceaccount:opentelemetry-collector:opentelemetry-collector, verb=get, resource=nodes, subresource=proxy)\""}
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver.(*kubletScraper).scrape
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver@v0.95.0/scraper.go:86
go.opentelemetry.io/collector/receiver/scraperhelper.ScrapeFunc.Scrape
        go.opentelemetry.io/collector/receiver@v0.95.0/scraperhelper/scraper.go:20
go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).scrapeMetricsAndReport
        go.opentelemetry.io/collector/receiver@v0.95.0/scraperhelper/scrapercontroller.go:197
go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).startScraping.func1
        go.opentelemetry.io/collector/receiver@v0.95.0/scraperhelper/scrapercontroller.go:176
```
        
Unless I also add `nodes/proxy` to the clusterrole