### PR TITLE
[opentelemetry-operator] fix `fullnameOverride`

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.52.0
+version: 0.52.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.52.1
+version: 0.52.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -233,7 +233,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -213,7 +213,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -231,7 +231,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.1
+    helm.sh/chart: opentelemetry-operator-0.52.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.0
+    helm.sh/chart: opentelemetry-operator-0.52.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -49,6 +49,14 @@
                 ""
             ]
         },
+        "fullnameOverride": {
+            "type": "string",
+            "default": "",
+            "title": "The fullnameOverride Schema",
+            "examples": [
+                ""
+            ]
+        },
         "imagePullSecrets": {
             "type": "array",
             "default": [],

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -4,9 +4,13 @@
 
 replicaCount: 1
 
-## Provide a name in place of opentelemetry-operator.
+## Provide a name in place of opentelemetry-operator (includes the chart's release name).
 ##
 nameOverride: ""
+
+## Fully override the name (excludes the chart's release name).
+##
+fullnameOverride: ""
 
 ## Reference one or more secrets to be used when pulling images from authenticated repositories.
 imagePullSecrets: []


### PR DESCRIPTION
This fixes #1095 

I also added the property to the `values.yaml` to make it more clear that this is available.

```bash
$ helm template my-otel-operator . --set fullnameOverride="fullnameoverride-otel-operator" -s templates/deployment.yaml| yq '.metadata.name'
fullnameoverride-otel-operator
```