### PR TITLE
Allow `WATCH_NAMESPACE` as `manager.env`

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.52.2
+version: 0.52.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -233,7 +233,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.52.2
+    helm.sh/chart: opentelemetry-operator-0.52.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.96.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -621,6 +621,14 @@
                             "examples": [
                                 "true"
                             ]
+                        },
+                        "WATCH_NAMESPACE": {
+                          "type": "string",
+                          "default": "",
+                          "title": "The WATCH_NAMESPACE namespaces",
+                          "examples": [
+                            "my-namespace-1,my-namespace-2"
+                          ]
                         }
                     },
                     "examples": [{

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -609,22 +609,6 @@
                     "type": "object",
                     "default": {},
                     "title": "The env Schema",
-                    "required": [
-                        "ENABLE_WEBHOOKS"
-                    ],
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "properties": {
-                        "ENABLE_WEBHOOKS": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The ENABLE_WEBHOOKS Schema",
-                            "examples": [
-                                "true"
-                            ]
-                        }
-                    },
                     "examples": [{
                         "ENABLE_WEBHOOKS": "true"
                     }]

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -612,7 +612,9 @@
                     "required": [
                         "ENABLE_WEBHOOKS"
                     ],
-                    "additionalProperties": false,
+                    "additionalProperties": {
+                      "type": "string"
+                    },
                     "properties": {
                         "ENABLE_WEBHOOKS": {
                             "type": "string",
@@ -621,14 +623,6 @@
                             "examples": [
                                 "true"
                             ]
-                        },
-                        "WATCH_NAMESPACE": {
-                          "type": "string",
-                          "default": "",
-                          "title": "The WATCH_NAMESPACE namespaces",
-                          "examples": [
-                            "my-namespace-1,my-namespace-2"
-                          ]
                         }
                     },
                     "examples": [{

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -609,6 +609,9 @@
                     "type": "object",
                     "default": {},
                     "title": "The env Schema",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
                     "examples": [{
                         "ENABLE_WEBHOOKS": "true"
                     }]


### PR DESCRIPTION
This will allow to add extra `WATCH_NAMESPACE` env var to the manager, since it is a known env var https://github.com/open-telemetry/opentelemetry-operator/blob/main/main.go#L225C41-L225C56