### PR TITLE
[collector] Allow more flexibility around adding volumes/volumeMounts

### DIFF
--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -131,6 +131,9 @@ containers:
         readOnly: true
         mountPropagation: HostToContainer
       {{- end }}
+      {{- if .Values.volumeMounts }}
+      {{- toYaml .Values.volumeMounts | nindent 6 }}
+      {{- end }}
       {{- if .Values.extraVolumeMounts }}
       {{- toYaml .Values.extraVolumeMounts | nindent 6 }}
       {{- end }}
@@ -171,6 +174,9 @@ volumes:
   - name: hostfs
     hostPath:
       path: /
+  {{- end }}
+  {{- if .Values.volumes }}
+  {{- toYaml .Values.volumes | nindent 2 }}
   {{- end }}
   {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 2 }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -298,7 +298,19 @@
         "type": "object"
       }
     },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
       "type": "array",
       "items": {
         "type": "object"

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -230,7 +230,9 @@ priorityClassName: ""
 
 extraEnvs: []
 extraEnvsFrom: []
+volumes: []
 extraVolumes: []
+volumeMounts: []
 extraVolumeMounts: []
 
 # Configuration for ports


### PR DESCRIPTION
The changes included here add more flexibilitly to opentelemetry-collector deployments when being consumed as a subchart. Having both `volumes/volumeMounts` and `extraVolumes/extraVolumeMounts` allows the owner of the subchart a space to add pre-defined volumes/volumeMounts. Giving the consumer the freedom to add more volumes/volumeMounts under extraVolumes/extraVolumeMounts fields.