### PR TITLE
[collector] Allow more flexibility around adding environment variables

### DIFF
--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -55,6 +55,9 @@ containers:
       - name: GOMEMLIMIT
         value: {{ include "opentelemetry-collector.gomemlimit" .Values.resources.limits.memory | quote }}
       {{- end }}
+      {{- with .Values.envs }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
       {{- with .Values.extraEnvs }}
       {{- . | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -286,6 +286,12 @@
         "required": ["name"]
       }
     },
+    "envs": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "extraEnvs": {
       "type": "array",
       "items": {

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -228,6 +228,7 @@ topologySpreadConstraints: []
 # Allows for pod scheduler prioritisation
 priorityClassName: ""
 
+envs: []
 extraEnvs: []
 extraEnvsFrom: []
 extraVolumes: []


### PR DESCRIPTION
The changes included here add more flexibilitly to opentelemetry-collector deployments when being consumed as a subchart. Having `envs` field allows the owner of the subchart a space to add pre-defined environment variables. Giving the consumer the freedom to add more under `extraEnvs` fields.