### PR TITLE
Adding automountServiceAccountToken default to collector deployment

### DIFF
--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
+  automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -317,6 +317,9 @@ dnsConfig: {}
 replicaCount: 1
 
 # only used with deployment mode
+automountServiceAccountToken: true
+
+# only used with deployment mode
 revisionHistoryLimit: 10
 
 annotations: {}


### PR DESCRIPTION
Adding this to hopefully help with others issues with kyverno-scan errors/warnings.
Noticed after attempting to add and receiving warning.

`policy restrict-automount-sa-token/autogen-validate-automountServiceAccountToken fail: validation error: Auto-mounting of Service Account tokens is not allowed. rule autogen-validate-automountServiceAccountToken failed at path /spec/template/spec/automountServiceAccountToken/`