### PR TITLE
feat: Add option to enable --create-rbac-permission on operator

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.53.0
+version: 0.53.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -241,7 +241,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.0
+    helm.sh/chart: opentelemetry-operator-0.53.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -72,6 +72,21 @@ rules:
       - patch
       - update
       - watch
+  {{- if .Values.manager.createRbacPermissions }}
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  {{- end }}
   - apiGroups:
       - batch
     resources:

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             {{- if .Values.manager.featureGates }}
             - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}
+            {{- if .Values.manager.createRbacPermissions }}
+            - --create-rbac-permissions
+            {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -837,6 +837,14 @@
                         "annotations": {}
                     }]
                 },
+                "createRbacPermissions": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Whether the operator should create RBAC permissions for collector deployments",
+                    "examples": [
+                        false
+                    ]
+                },
                 "extraArgs": {
                     "type": "array",
                     "default": [],

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -123,6 +123,8 @@ manager:
     # add annotations on the PrometheusRule
     annotations: {}
 
+  # Whether the operator should create RBAC permissions for collectors
+  createRbacPermissions: false
   ## List of additional cli arguments to configure the manager
   ## for example: --labels, etc.
   extraArgs: []


### PR DESCRIPTION
The `--create-rbac-permissions` argument on the manager requires extra RBAC permissions to actually use. The helm chart should add a flag to make enabling it easy.