### PR TITLE
Updated image repository to download using ghcr.io instead of docker.io

### DIFF
--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -24,14 +24,14 @@ spec:
     metadata:
       annotations:
         checksum/config: ca3642ba8e030091c887974ba82caf54e7ef306c351fa5c1d98d75931d7a796f
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -42,10 +42,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 00ff9eccf97275d88a6ec37d489186f7119fb0f836d257ca14d4d8f2c6c5c957
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -24,14 +24,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 6f216172f1a02f25a88defb616776c68ab671f6e5664940d13eccac2cc5aff25
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -42,10 +42,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -24,14 +24,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 4238a48562ef423922b8bd7997e0fc1dc884a8e06cec1c02cad9eb143ebedba6
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -42,10 +42,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -24,14 +24,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 672bdde9ba480a0d903fb8d681eb80b1a4e72d84eab9f100842a27897268dc88
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -42,10 +42,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -24,14 +24,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 672bdde9ba480a0d903fb8d681eb80b1a4e72d84eab9f100842a27897268dc88
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -42,10 +42,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 3
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 00ff9eccf97275d88a6ec37d489186f7119fb0f836d257ca14d4d8f2c6c5c957
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 2e4e78999bb026ad7ca185224cee7c907cc2f5a75c0b2241dba1df98a69cd65f
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: otlp
               containerPort: 4317
               protocol: TCP

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/config.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: ef27f7354f2ec1335cf0a2ccaccbc5c7d9861efe8bcf83653a205f261ac62087
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   serviceName: example-opentelemetry-collector
   podManagementPolicy: Parallel
@@ -27,14 +27,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 596396aea9bcb58f160997cf237a27276e9467f4477de0076f8f18b1f09d72bc
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: statefulset-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -45,10 +45,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   serviceName: example-opentelemetry-collector
   podManagementPolicy: Parallel
@@ -30,14 +30,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 596396aea9bcb58f160997cf237a27276e9467f4477de0076f8f18b1f09d72bc
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: statefulset-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -48,10 +48,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -26,14 +26,14 @@ spec:
     metadata:
       annotations:
         checksum/config: 00ff9eccf97275d88a6ec37d489186f7119fb0f836d257ca14d4d8f2c6c5c957
-        
+
       labels:
         app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-opentelemetry-collector
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -161,7 +161,7 @@ config:
 
 image:
   # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
-  repository: otel/opentelemetry-collector-contrib
+  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -31,9 +31,9 @@ spec:
         app.kubernetes.io/name: otelcol
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-otelcol
       securityContext:
         {}
@@ -44,10 +44,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.93.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -33,9 +33,9 @@ spec:
         app.kubernetes.io/name: otelcol
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-otelcol
       securityContext:
         {}
@@ -46,10 +46,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.93.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -33,9 +33,9 @@ spec:
         app.kubernetes.io/name: otelcol
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-otelcol
       securityContext:
         {}
@@ -46,10 +46,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.93.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   selector:
     matchLabels:
@@ -31,9 +31,9 @@ spec:
         app.kubernetes.io/name: otelcol
         app.kubernetes.io/instance: example
         component: agent-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-otelcol
       securityContext:
         {}
@@ -45,10 +45,10 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          image: "otel/opentelemetry-collector-contrib:0.93.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.93.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -33,9 +33,9 @@ spec:
         app.kubernetes.io/name: otelcol
         app.kubernetes.io/instance: example
         component: standalone-collector
-        
+
     spec:
-      
+
       serviceAccountName: example-otelcol
       securityContext:
         {}
@@ -46,10 +46,10 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.93.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.93.0"
           imagePullPolicy: IfNotPresent
           ports:
-            
+
             - name: jaeger-compact
               containerPort: 6831
               protocol: UDP

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -45,7 +45,7 @@ defaultCRConfig:
   # Image details for the collector
   image:
     # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
-    repository: otel/opentelemetry-collector-contrib
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -34,7 +34,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.97.0
+            - --collector-image=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.97.0
           command:
             - /manager
           env:
@@ -61,7 +61,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources: 
+          resources:
             limits:
               cpu: 100m
               memory: 128Mi
@@ -72,7 +72,7 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-        
+
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -84,7 +84,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
+          resources:
             limits:
               cpu: 500m
               memory: 128Mi

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -194,7 +194,7 @@
                             "default": "",
                             "title": "The repository Schema",
                             "examples": [
-                                "otel/opentelemetry-collector-contrib"
+                                "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
                             ]
                         },
                         "tag": {
@@ -207,7 +207,7 @@
                         }
                     },
                     "examples": [{
-                        "repository": "otel/opentelemetry-collector-contrib",
+                        "repository": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib",
                         "tag": "0.93.0"
                     }]
                 },
@@ -980,7 +980,7 @@
                     "tag": "v0.93.0"
                 },
                 "collectorImage": {
-                    "repository": "otel/opentelemetry-collector-contrib",
+                    "repository": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib",
                     "tag": "0.93.0"
                 },
                 "opampBridgeImage": {
@@ -1719,7 +1719,7 @@
                 "tag": "v0.93.0"
             },
             "collectorImage": {
-                "repository": "otel/opentelemetry-collector-contrib",
+                "repository": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib",
                 "tag": "0.93.0"
             },
             "opampBridgeImage": {

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -41,7 +41,7 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: ""
   collectorImage:
-    repository: otel/opentelemetry-collector-contrib
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
     tag: 0.97.0
   opampBridgeImage:
     repository: ""


### PR DESCRIPTION
Updated to image repository to download using ghcr.io instead of docker.io

Due to Docker Hub Rate Limit
https://www.docker.com/increase-rate-limits/