### PR TITLE
[opentelemetry-operator] read cert contents

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.53.3
+version: 0.54.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.53.2
+version: 0.53.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,15 @@
 # Upgrade guidelines
 
+## <0.53.3 to 0.53.3
+[Changes to functionality, and variable names used for providing self-signed certificates](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1121)
+
+Below variables have been renamed to be consistent with the chart's naming format. v0.53.2 also has a bug fix which makes the chart now read the contents of the file paths provided by these variables, instead of just using the value of the variables.
+```
+admissionWebhooks.ca_file -> admissionWebhooks.caFile
+admissionWebhooks.cert_file -> admissionWebhooks.certFile
+admissionWebhooks.key_file -> admissionWebhooks.keyFile
+```
+
 ## <0.50.0 to 0.50.0
 
 Additional properties are not allowed anymore, so care must be taken that no old or misspelled ones are present anymore.
@@ -24,7 +34,7 @@ Some CI/CD tools might create duplicate resources when upgrading from an older v
 `fullnameOverride` can be used to keep `deployment` resource consistent with the same name during an upgrade.
 
 ## 0.16.0 to 0.17.0
- 
+
 The v0.17.0 helm chart version changes OpenTelemetry Collector image to the contrib version. If you want to use the core version, set `manager.collectorImage.repository` to `otel/opentelemetry-collector`.
 
 ## 0.15.0 to 0.16.0

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,9 +1,9 @@
 # Upgrade guidelines
 
-## <0.53.3 to 0.53.3
-[Changes to functionality, and variable names used for providing self-signed certificates](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1121)
+## <0.54.0 to 0.54.0
+[Changes to functionality, and variable names used for providing user-managed webhook certificates](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1121)
 
-Below variables have been renamed to be consistent with the chart's naming format. v0.53.2 also has a bug fix which makes the chart now read the contents of the file paths provided by these variables, instead of just using the value of the variables.
+Below variables have been renamed to be consistent with the chart's naming format. v0.54.0 also has a bug fix which makes the chart now read the contents of the file paths provided by these variables, instead of just using the value of the variables.
 ```
 admissionWebhooks.ca_file -> admissionWebhooks.caFile
 admissionWebhooks.cert_file -> admissionWebhooks.certFile

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-mutation
 webhooks:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-validation
 webhooks:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,12 +6,11 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-mutation
 webhooks:
@@ -91,12 +90,20 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
+<<<<<<< HEAD
 
+=======
+
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-validation
 webhooks:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
+    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-mutation
 webhooks:
@@ -90,20 +91,12 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-<<<<<<< HEAD
-
-=======
-
->>>>>>> c65dde8e (fix examples, rebase)
+    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-validation
 webhooks:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-serving-cert
   namespace: default
@@ -30,16 +30,12 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-selfsigned-issuer
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,12 +4,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-serving-cert
   namespace: default
@@ -30,12 +30,16 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-selfsigned-issuer
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -241,7 +241,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,12 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 rules:
@@ -222,12 +222,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-metrics
 rules:
@@ -241,12 +245,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 rules:

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 rules:
@@ -222,16 +222,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-metrics
 rules:
@@ -245,16 +241,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 rules:

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 roleRef:
@@ -26,16 +26,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 roleRef:

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,12 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 roleRef:
@@ -26,12 +26,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 roleRef:

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -61,7 +61,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources:
+          resources: 
             limits:
               cpu: 100m
               memory: 128Mi
@@ -72,7 +72,7 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-
+        
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -84,7 +84,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources:
+          resources: 
             limits:
               cpu: 500m
               memory: 128Mi

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,12 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -61,7 +61,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources: 
+          resources:
             limits:
               cpu: 100m
               memory: 128Mi
@@ -72,7 +72,7 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-        
+
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -84,7 +84,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
+          resources:
             limits:
               cpu: 500m
               memory: 128Mi

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,12 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,12 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,12 +4,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -32,12 +32,16 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-webhook
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -32,16 +32,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-webhook
   namespace: default

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,12 +6,12 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: webhook
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: webhook
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.3
+    helm.sh/chart: opentelemetry-operator-0.54.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test
@@ -44,16 +44,12 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: opentelemetry-operator-0.53.2
-=======
     helm.sh/chart: opentelemetry-operator-0.53.3
->>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-
+    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,12 +6,12 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test
@@ -44,12 +44,16 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
+<<<<<<< HEAD
     helm.sh/chart: opentelemetry-operator-0.53.2
+=======
+    helm.sh/chart: opentelemetry-operator-0.53.3
+>>>>>>> c65dde8e (fix examples, rebase)
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
+
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -117,9 +117,9 @@ a cert is loaded from an existing secret or is provided via `.Values`
 {{- $caCertEnc = b64enc $ca.Cert }}
 {{- end }}
 {{- else }}
-{{- $certCrtEnc = b64enc .Values.admissionWebhooks.cert_file }}
-{{- $certKeyEnc = b64enc .Values.admissionWebhooks.key_file }}
-{{- $caCertEnc = b64enc .Values.admissionWebhooks.ca_file }}
+{{- $certCrtEnc = .Files.Get .Values.admissionWebhooks.cert_file | b64enc }}
+{{- $certKeyEnc = .Files.Get .Values.admissionWebhooks.key_file | b64enc }}
+{{- $caCertEnc = .Files.Get .Values.admissionWebhooks.ca_file | b64enc }}
 {{- end }}
 {{- $result := dict "crt" $certCrtEnc "key" $certKeyEnc "ca" $caCertEnc }}
 {{- $result | toYaml }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1296,9 +1296,9 @@
                 "objectSelector",
                 "certManager",
                 "autoGenerateCert",
-                "cert_file",
-                "key_file",
-                "ca_file",
+                "certFile",
+                "keyFile",
+                "caFile",
                 "serviceAnnotations",
                 "secretAnnotations",
                 "secretLabels"

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1475,26 +1475,26 @@
                         "recreate": true
                     }]
                 },
-                "cert_file": {
+                "certFile": {
                     "type": "string",
                     "default": "",
-                    "title": "The cert_file Schema",
+                    "title": "File path to self-managed TLS certificate.",
                     "examples": [
                         ""
                     ]
                 },
-                "key_file": {
+                "keyFile": {
                     "type": "string",
                     "default": "",
-                    "title": "The key_file Schema",
+                    "title": "File path to self-managed TLS key.",
                     "examples": [
                         ""
                     ]
                 },
-                "ca_file": {
+                "caFile": {
                     "type": "string",
                     "default": "",
-                    "title": "The ca_file Schema",
+                    "title": "File path to self-managed CA bundle.",
                     "examples": [
                         ""
                     ]

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -244,13 +244,16 @@ admissionWebhooks:
     recreate: true
 
   ## TLS Certificate Option 3: Use your own self-signed certificate.
-  ## certManager and autoGenerateCert must be disabled and cert_file, key_file, and ca_file must be set.
+  ## certManager and autoGenerateCert must be disabled and certFile, keyFile, and caFile must be set.
+  ## The chart reads the contents of the file paths with the helm .Files.Get function.
+  ## Refer to this doc https://helm.sh/docs/chart_template_guide/accessing_files/ to understand
+  ## limitations of file paths accessible to the chart.
   ## Path to your own PEM-encoded certificate.
-  cert_file: ""
+  certFile: ""
   ## Path to your own PEM-encoded private key.
-  key_file: ""
+  keyFile: ""
   ## Path to the CA cert.
-  ca_file: ""
+  caFile: ""
 
   # Adds additional annotations to the admissionWebhook Service
   serviceAnnotations: {}


### PR DESCRIPTION
[Issue Link](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1120)

The operator chart has been updated to read contents of the file path provided in below variables.
```
  ## TLS Certificate Option 3: Use your own self-signed certificate.
  ## certManager and autoGenerateCert must be disabled and cert_file, key_file, and ca_file must be set.
  ## Path to your own PEM-encoded certificate.
  cert_file: ""
  ## Path to your own PEM-encoded private key.
  key_file: ""
  ## Path to the CA cert.
  ca_file: ""
```

Screenshot to verify that the contents are read and added to secret correctly.

![Screenshot 2024-04-05 at 1 44 11 PM](https://github.com/open-telemetry/opentelemetry-helm-charts/assets/22205748/13bcf8ed-4e74-4f84-b053-37a7f9072c0f)
