### PR TITLE
chore: Bump operator version to v0.97.1

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.53.1
+version: 0.53.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ maintainers:
   - name: dmitryax
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.97.0
+appVersion: 0.97.1

--- a/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
@@ -2236,7 +2236,7 @@ spec:
                     type: integer
                 type: object
               config:
-                description: Config is the raw JSON to be used as the collector's
+                description: Config is the raw YAML to be used as the collector's
                   configuration. Refer to the OpenTelemetry Collector documentation
                   for details.
                 type: string

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -222,9 +222,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -241,9 +241,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -40,7 +40,7 @@ spec:
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.97.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.97.1"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     
@@ -44,9 +44,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.1
+    helm.sh/chart: opentelemetry-operator-0.53.2
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.97.0"
+    app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     


### PR DESCRIPTION
I would normally wait until https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1119 gets merged, but this version of the operator completely breaks for me. I need this ASAP so I figured I'd make the clean ups that are needed on the other PR.