### PR TITLE
Add permissions to operator's ClusterRole that it tries to grant to some collectors

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.55.0
+version: 0.55.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.53.2
+version: 0.53.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.54.0
+version: 0.54.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -60,6 +60,7 @@ rules:
       - watch
   - apiGroups:
       - apps
+      - extensions
     resources:
       - replicasets
     verbs:
@@ -222,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -241,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.54.0
+    helm.sh/chart: opentelemetry-operator-0.54.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.0
+    helm.sh/chart: opentelemetry-operator-0.55.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.53.2
+    helm.sh/chart: opentelemetry-operator-0.53.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.97.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -54,6 +54,7 @@ rules:
       - watch
   - apiGroups:
       - apps
+      - extensions
     resources:
       - replicasets
     verbs:
@@ -85,6 +86,15 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - namespaces
+    verbs:
+      - get
+      - list
       - watch
   {{- end }}
   - apiGroups:


### PR DESCRIPTION
Fixes [opentelemetry-operator/issues/2824](https://github.com/open-telemetry/opentelemetry-operator/issues/2824).

Since introduction of `--create-rbac-permissions` Operator is required to have permissions it tries to grant ro Collectors. Example [code](https://github.com/open-telemetry/opentelemetry-operator/blob/c65629b3b9fcb722e770eb58b73ea4f5cc8bc63f/internal/manifests/collector/parser/processor/processor_k8sattributes.go#L78-L102).

This PR adds `extensions/replicasets` permissions unconditionally to mirror `apps/replicasets` and `nodes + namespaces` permissions only when `--create-rbac-permissions` is enabled.