### PR TITLE
bump flagd memory limit to 175Mi to avoid OOMs

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -531,7 +531,7 @@ components:
       port: 8013
     resources:
       limits:
-        memory: 20Mi
+        memory: 175Mi
     command:
       - "/flagd-build"
       - "start"


### PR DESCRIPTION
I was seeing flagd fail from OOMs while running the demo. I bumped it to what featureflagservice used before it so its at least no more memory than before, but I can play around with the numbers if you want the bare minimum for the limit.