### PR TITLE
[Operator] Allow setting of manager service account name, default value if not used

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.55.1
+version: 0.55.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.55.2
+version: 0.55.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.2
+    helm.sh/chart: opentelemetry-operator-0.55.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -644,7 +644,7 @@
                         },
                         "name": {
                             "type": "string",
-                            "default": "opentelemetry-operator",
+                            "default": "",
                             "title": "The name of the service account",
                             "examples": [
                                 "opentelemetry-operator"

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -641,6 +641,14 @@
                             "required": [],
                             "properties": {},
                             "examples": [{}]
+                        },
+                        "name": {
+                            "type": "string",
+                            "default": "opentelemetry-operator",
+                            "title": "The name of the service account",
+                            "examples": [
+                                "opentelemetry-operator"
+                            ]
                         }
                     },
                     "examples": [{

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -92,7 +92,8 @@ manager:
   serviceAccount:
     create: true
     annotations: {}
-    # name: nameOverride
+    ## Provide a name in place of value set in nameOverride or its default
+    name: ""
 
   ## Enable ServiceMonitor for Prometheus metrics scrape
   serviceMonitor:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -92,7 +92,7 @@ manager:
   serviceAccount:
     create: true
     annotations: {}
-    ## Provide a name in place of value set in nameOverride or its default
+    ## Override the default name of the serviceaccount (the name of your installation)
     name: ""
 
   ## Enable ServiceMonitor for Prometheus metrics scrape


### PR DESCRIPTION
We should be able to set the name of the service account used. If no service account name is set it defaults to `opentelemetry-operator`.

This also helps with confusion when seeing the values that are in `values.yaml`, specifically this part:
```yaml
  # -- Create the manager ServiceAccount
  serviceAccount:
    create: true
    annotations: {}
    # name: nameOverride
```
Using existing schema uncommenting `# name:` will break the chart

Resolves #1144 