### PR TITLE
[opentelemetry-operator] fix references to old variables

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.55.1
+version: 0.55.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -19,7 +19,7 @@ certificate that the API server is configured to trust. There are a few differen
   - You can provide your own Issuer by configuring the `admissionWebhooks.certManager.issuerRef` value. You will need
     to specify the `kind` (Issuer or ClusterIssuer) and the `name`. Note that this method also requires the installation of cert-manager.
   - You can use an automatically generated self-signed certificate by setting `admissionWebhooks.certManager.enabled` to `false` and `admissionWebhooks.autoGenerateCert.enabled` to `true`. Helm will create a self-signed cert and a secret for you.
-  - You can use your own generated self-signed certificate by setting both `admissionWebhooks.certManager.enabled` and `admissionWebhooks.autoGenerateCert.enabled` to `false`. You should provide the necessary values to `admissionWebhooks.cert_file`, `admissionWebhooks.key_file`, and `admissionWebhooks.ca_file`.
+  - You can use your own generated self-signed certificate by setting both `admissionWebhooks.certManager.enabled` and `admissionWebhooks.autoGenerateCert.enabled` to `false`. You should provide the necessary values to `admissionWebhooks.certFile`, `admissionWebhooks.keyFile`, and `admissionWebhooks.caFile`.
   - You can sideload custom webhooks and certificate by disabling `.Values.admissionWebhooks.create` and `admissionWebhooks.certManager.enabled` while setting your custom cert secret name in `admissionWebhooks.secretName`
   - You can disable webhooks altogether by disabling `.Values.admissionWebhooks.create` and setting env var to `ENABLE_WEBHOOKS: "false"`
 

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,6 +1,9 @@
 # Upgrade guidelines
 
-## <0.54.0 to 0.54.0
+## <0.54.0 to 0.55.2
+
+> **_NOTE:_**  Versions 0.54.0 to 0.55.1 of the opentelemetry-operator helm chart should be avoided if providing user-managed certificates as file paths.
+
 [Changes to functionality, and variable names used for providing user-managed webhook certificates](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1121)
 
 Below variables have been renamed to be consistent with the chart's naming format. v0.54.0 also has a bug fix which makes the chart now read the contents of the file paths provided by these variables, instead of just using the value of the variables.

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.1
+    helm.sh/chart: opentelemetry-operator-0.55.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -117,9 +117,9 @@ a cert is loaded from an existing secret or is provided via `.Values`
 {{- $caCertEnc = b64enc $ca.Cert }}
 {{- end }}
 {{- else }}
-{{- $certCrtEnc = .Files.Get .Values.admissionWebhooks.cert_file | b64enc }}
-{{- $certKeyEnc = .Files.Get .Values.admissionWebhooks.key_file | b64enc }}
-{{- $caCertEnc = .Files.Get .Values.admissionWebhooks.ca_file | b64enc }}
+{{- $certCrtEnc = .Files.Get .Values.admissionWebhooks.certFile | b64enc }}
+{{- $certKeyEnc = .Files.Get .Values.admissionWebhooks.keyFile | b64enc }}
+{{- $caCertEnc = .Files.Get .Values.admissionWebhooks.caFile | b64enc }}
 {{- end }}
 {{- $result := dict "crt" $certCrtEnc "key" $certKeyEnc "ca" $caCertEnc }}
 {{- $result | toYaml }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1545,9 +1545,9 @@
                     "enabled": true,
                     "recreate": true
                 },
-                "cert_file": "",
-                "key_file": "",
-                "ca_file": "",
+                "certFile": "",
+                "keyFile": "",
+                "caFile": "",
                 "secretAnnotations": {},
                 "secretLabels": {}
             }]
@@ -1862,9 +1862,9 @@
                 "enabled": true,
                 "recreate": true
             },
-            "cert_file": "",
-            "key_file": "",
-            "ca_file": "",
+            "certFile": "",
+            "keyFile": "",
+            "caFile": "",
             "secretAnnotations": {},
             "secretLabels": {}
         },


### PR DESCRIPTION
Fixes issue #1142 

Update references to removed variables when providing user managed certificates for the operator webhook.

Tested locally by generating the templates

![Screenshot 2024-04-16 at 1 06 51 PM](https://github.com/open-telemetry/opentelemetry-helm-charts/assets/22205748/5fe5cb9d-aa52-46e6-9fbf-6fa365026abb)
