### PR TITLE
[operator] Require collector image be set

### DIFF
--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install opentelemetry-operator chart
         run: |
-          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator --set "manager.featureGates=operator.autoinstrumentation.go"
+          helm install --namespace=opentelemetry-operator-system --create-namespace my-opentelemetry-operator ./charts/opentelemetry-operator --set "manager.featureGates=operator.autoinstrumentation.go" --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s"
           kubectl wait --timeout=5m --for=condition=available deployment my-opentelemetry-operator -n opentelemetry-operator-system
 
       - name: Run e2e tests

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.55.3
+version: 0.56.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -35,22 +35,25 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-$ helm install \
-  opentelemetry-operator open-telemetry/opentelemetry-operator
+$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
+--set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s"
 ```
 
 If you created a custom namespace, like in the TLS Certificate Requirement section above, you will need to specify the namespace with the `--namespace` helm option:
 
 ```console
-$ helm install --namespace opentelemetry-operator-system \
-  opentelemetry-operator open-telemetry/opentelemetry-operator
+$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
+--namespace opentelemetry-operator-system \
+--set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s"
 ```
 
 If you wish for helm to create an automatically generated self-signed certificate, make sure to set the appropriate values when installing the chart:
 
 ```console
-$ helm install  --set admissionWebhooks.certManager.enabled=false --set admissionWebhooks.autoGenerateCert.enabled=true \
-  opentelemetry-operator open-telemetry/opentelemetry-operator
+$ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
+--set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
+--set admissionWebhooks.certManager.enabled=false \
+--set admissionWebhooks.autoGenerateCert.enabled=true
 ```
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -3,9 +3,7 @@
 ## 0.55.3 to 0.56.0
 
 > [!WARNING]  
-> Critical content demanding immediate user attention due to potential risks.
-
-As part of working towards using the [OpenTelemetry Collector Kubernetes Distro](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s) by default, the chart now requires users to explicitly set a collector image repository. If you are already explicitly setting a collector image repository this breaking change does not affect you.
+> As part of working towards using the [OpenTelemetry Collector Kubernetes Distro](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s) by default, the chart now requires users to explicitly set a collector image repository. If you are already explicitly setting a collector image repository this breaking change does not affect you.
 
 If you are using a OpenTelemetry Community distribution of the Collector we recommend you use `otel/opentelemetry-collector-k8s`, but carefully review the [components included in this distribution](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-k8s/manifest.yaml) to make sure it includes all the components you use in your configuration. In the future this distribution will become the default image used for the chart.
 

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,32 @@
 # Upgrade guidelines
 
+## 0.55.3 to 0.56.0
+
+> [!WARNING]  
+> Critical content demanding immediate user attention due to potential risks.
+
+As part of working towards using the [OpenTelemetry Collector Kubernetes Distro](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s) by default, the chart now requires users to explicitly set a collector image repository. If you are already explicitly setting a collector image repository this breaking change does not affect you.
+
+If you are using a OpenTelemetry Community distribution of the Collector we recommend you use `otel/opentelemetry-collector-k8s`, but carefully review the [components included in this distribution](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-k8s/manifest.yaml) to make sure it includes all the components you use in your configuration. In the future this distribution will become the default image used for the chart.
+
+You can use the OpenTelemetry Collector Kubernetes Distro by adding these lines to your values.yaml:
+
+```yaml
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"
+```
+
+If you want to stick with using the Contrib distribution, add these lines to your values.yaml:
+
+```yaml
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-contrib"
+```
+
+For more details see [#1153](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1153).
+
 ## <0.54.0 to 0.55.2
 
 > **_NOTE:_**  Versions 0.54.0 to 0.55.1 of the opentelemetry-operator helm chart should be avoided if providing user-managed certificates as file paths.

--- a/charts/opentelemetry-operator/ci/cert-manager-disable-nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-disable-nameoverride-values.yaml
@@ -3,3 +3,7 @@ nameOverride: no-cert-manager
 admissionWebhooks:
   certManager:
     enabled: false
+
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/ci/cert-manager-disable-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-disable-values.yaml
@@ -1,3 +1,7 @@
 admissionWebhooks:
   certManager:
     enabled: false
+
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/ci/nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/nameoverride-values.yaml
@@ -1,1 +1,5 @@
 nameOverride: foobar
+
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/ci/secret-name-nameoverride-values.yaml
+++ b/charts/opentelemetry-operator/ci/secret-name-nameoverride-values.yaml
@@ -2,3 +2,7 @@ nameOverride: secret-name
 
 admissionWebhooks:
   secretName: random-name
+
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/ci/secret-name-values.yaml
+++ b/charts/opentelemetry-operator/ci/secret-name-values.yaml
@@ -1,2 +1,6 @@
 admissionWebhooks:
   secretName: random-name
+
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -34,7 +34,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.98.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.98.0
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.55.3
+    helm.sh/chart: opentelemetry-operator-0.56.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.98.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/values.yaml
+++ b/charts/opentelemetry-operator/examples/default/values.yaml
@@ -1,1 +1,3 @@
-
+manager:
+  collectorImage:
+    repository: "otel/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -1,3 +1,7 @@
+{{- if not .Values.manager.collectorImage.repository }}
+{{ fail "[ERROR] 'manager.collectorImage.repository' must be set. See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md for instructions." }}
+{{ end }}
+
 {{ $.Chart.Name }} has been installed. Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ $.Release.Name }}"
 

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -41,7 +41,7 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: ""
   collectorImage:
-    repository: otel/opentelemetry-collector-contrib
+    repository: ""
     tag: 0.98.0
   opampBridgeImage:
     repository: ""


### PR DESCRIPTION
Works towards https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1153

This PR removes the default `manager.collectorImage.repository` from the operator chart so that installs/upgrades fail for users depending on the previously set `contrib` image.

Adds a new section to UPGRADING.md to guide users through this failure.