### PR TITLE
Promote jaronoff97 to Approver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 
 * @open-telemetry/helm-approvers
 
-charts/opentelemetry-collector/ @open-telemetry/helm-approvers @dmitryax @TylerHelmuth @povilasv
-charts/opentelemetry-operator/  @open-telemetry/helm-approvers @Allex1
-charts/opentelemetry-demo/      @open-telemetry/helm-approvers @puckpuck
+charts/opentelemetry-collector/  @open-telemetry/helm-approvers @dmitryax @TylerHelmuth @povilasv
+charts/opentelemetry-operator/   @open-telemetry/helm-approvers @Allex1
+charts/opentelemetry-demo/       @open-telemetry/helm-approvers @puckpuck
+charts/opentelemetry-kube-stack/ @open-telemetry/helm-approvers @jaronoff97

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 Approvers ([@open-telemetry/helm-approvers](https://github.com/orgs/open-telemetry/teams/helm-approvers)):
 
 - [Alex Birca](https://github.com/Allex1), Adobe
-- [Jacob Aronoff](https://github.com/jaronoff97), Service Now
+- [Jacob Aronoff](https://github.com/jaronoff97), ServiceNow
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 - [Povilas](https://github.com/povilasv), Coralogix

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 Approvers ([@open-telemetry/helm-approvers](https://github.com/orgs/open-telemetry/teams/helm-approvers)):
 
 - [Alex Birca](https://github.com/Allex1), Adobe
+- [Jacob Aronoff](https://github.com/jaronoff97), Service Now
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 - [Povilas](https://github.com/povilasv), Coralogix


### PR DESCRIPTION
@jaronoff97 has been a big help with all the helm chart, reviewing PRs and contributing improvements. I specifically want to call out this work on the the long-standing issue of installing the operator and CRs at the same time - the new opentelemetry-kube-stack chart will level-up our new user experience in Kubernetes.