### PR TITLE
Add tempate to cert-manager annotations in opentelemetry-operator helm-chart

### DIFF
--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -3,7 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.admissionWebhooks.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -3,7 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.admissionWebhooks.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -136,9 +136,7 @@ Return the name of cert-manager's Certificate resources for webhooks.
 Return the name of the cert-manager.io/inject-ca-from annotation for webhooks and CRDs.
 */}}
 {{- define "opentelemetry-operator.webhookCertAnnotation" -}}
-{{- if not .Values.admissionWebhooks.certManager.enabled }}
-{{- "none" }}
-{{- else }}
+{{- if .Values.admissionWebhooks.certManager.enabled }}
 {{- printf "%s/%s" .Release.Namespace (include "opentelemetry-operator.webhookCertName" .) }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -3,7 +3,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
+    {{- if .Values.admissionWebhooks.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
+    {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook
@@ -106,7 +108,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
+    {{- if .Values.admissionWebhooks.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
+    {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -134,7 +134,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
+    {{- if .Values.admissionWebhooks.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
+    {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -41,7 +41,7 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: ""
   collectorImage:
-    repository: "otel/opentelemetry-collector-k8s"
+    repository: ""
     tag: 0.99.0
   opampBridgeImage:
     repository: ""
@@ -230,7 +230,7 @@ admissionWebhooks:
   ## TLS Certificate Option 1: Use certManager to generate self-signed certificate.
   ## certManager must be enabled. If enabled, always takes precedence over options 2 and 3.
   certManager:
-    enabled: false
+    enabled: true
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -41,7 +41,7 @@ manager:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     tag: ""
   collectorImage:
-    repository: ""
+    repository: "otel/opentelemetry-collector-k8s"
     tag: 0.99.0
   opampBridgeImage:
     repository: ""
@@ -230,7 +230,7 @@ admissionWebhooks:
   ## TLS Certificate Option 1: Use certManager to generate self-signed certificate.
   ## certManager must be enabled. If enabled, always takes precedence over options 2 and 3.
   certManager:
-    enabled: true
+    enabled: false
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}


### PR DESCRIPTION
This PR is for #1177 


This PR does the following:
- Adds helm "if" templates to add/remove the cert-manager annotations. (if `.Values.admissionWebhooks.certManager.enabled==true`)
- `helpers.tpl`now does not set `cert-manager.io/inject-ca-from` to `none`

> Not to be merged until we think of how to handle CRD templates https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1177#issuecomment-2108857811