### PR TITLE
[operator] Align to `create-rbac-permission` flag deprecation

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.63.0
+version: 0.63.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -108,6 +108,18 @@ $ helm show values open-telemetry/opentelemetry-operator
 
 When using this chart as a subchart, you may want to unset certain default values. Since Helm v3.13 values handling is improved and null can now consistently be used to remove values (e.g. to remove the default CPU limits).
 
+### Role-based Access Control (RBAC) Configuration
+
+The OpenTelemetry Collector requires specific RBAC permissions to function correctly, especially when using the `k8sattributesprocessor`. Depending on your deployment's scope, you may need to configure Cluster-scoped or Namespace-scoped RBAC permissions.
+
+- **Cluster-scoped RBAC**: Necessary if the collector is to receive telemetry from across multiple namespaces. This setup requires `get`, `watch`, and `list` permissions on `pods`, `namespaces`, and `nodes`, plus `replicasets` if using deployment-related attributes.
+
+- **Namespace-scoped RBAC**: Suitable for collecting telemetry within a specific namespace. This requires setting up a `Role` and `RoleBinding` to grant access to `pods` and `replicasets` within the target namespace. This setup limits the collector's access to resources within the specified namespace only.
+
+**Important**: The `manager.createRbacPermissions` flag in the Helm chart values should be set to `false` if you are manually configuring RBAC permissions for the collector. Manual configuration allows for more granular control over the permissions granted to the OpenTelemetry Collector, ensuring it has exactly the access it needs based on your specific deployment requirements. Conversely, setting `manager.createRbacPermissions` to `true` will allow the operator to automatically configure RBAC for your collectors.
+
+For detailed instructions and examples on configuring RBAC permissions, please refer to the [official documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md).
+
 ## Install OpenTelemetry Collector
 
 _See [OpenTelemetry website](https://opentelemetry.io/docs/collector/) for more details about the Collector_

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.63.0
+    helm.sh/chart: opentelemetry-operator-0.63.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -77,19 +77,24 @@ spec:
             {{- if .Values.manager.featureGates }}
             - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}
-            {{- if .Values.manager.createRbacPermissions }}
-            - --create-rbac-permissions
-            {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}
           command:
             - /manager
-          {{- if .Values.manager.env }}
+          {{- if or .Values.manager.env .Values.manager.createRbacPermissions }}
           env:
+            {{- if .Values.manager.env }}
             {{- range $name, $value := .Values.manager.env }}
             - name: {{ $name }}
               value: {{ $value | quote -}}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.manager.createRbacPermissions }}
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             {{- end }}
           {{- end }}
           image: {{ include "opentelemetry-operator.image" . | quote }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -129,7 +129,7 @@ manager:
     # add annotations on the PrometheusRule
     annotations: {}
 
-  # Whether the operator should create RBAC permissions for collectors
+  # Whether the operator should create RBAC permissions for collectors. See README.md for more information.
   createRbacPermissions: false
   ## List of additional cli arguments to configure the manager
   ## for example: --labels, etc.


### PR DESCRIPTION
Ensure SERVICE_ACCOUNT_NAME env variable is set in pods to align with the deprecation of the `create-rbac-permission flag`

Addressing functionality issues with k8sattributes.

Closes: #1224