### PR TITLE
[operator] Add extra labels/annotations on default alerts

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.64.0
+version: 0.64.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.64.0
+    helm.sh/chart: opentelemetry-operator-0.64.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.103.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-operator/templates/prometheusrule.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
   annotations:
-    {{- range $key, $value := .Values.manager.serviceMonitor.annotations }}
+    {{- range $key, $value := .Values.manager.prometheusRule.annotations }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
 spec:
@@ -27,16 +27,28 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         description: '{{`Reconciliation errors for {{ $labels.controller }} is increasing and has now reached {{ humanize $value }} `}}'
         runbook_url: 'Check manager logs for reasons why this might happen'
+        {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: WorkqueueDepth
       expr: workqueue_depth{name="opentelemetrycollector"} > 0
       for: 5m
       labels:
         severity: warning
+        {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         description: '{{`Queue depth for {{ $labels.name }} has reached {{ $value }} `}}'
         runbook_url: 'Check manager logs for reasons why this might happen'
+        {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -855,9 +855,10 @@
                             "default": {},
                             "title": "The defaultRules Schema",
                             "required": [
-                                "enabled"
+                                "enabled",
+                                "additionalRuleLabels",
+                                "additionalRuleAnnotations"
                             ],
-                            "additionalProperties": false,
                             "properties": {
                                 "enabled": {
                                     "type": "boolean",
@@ -866,10 +867,28 @@
                                     "examples": [
                                         false
                                     ]
+                                },
+                                "additionalRuleLabels": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The additionalRuleLabels Schema",
+                                    "required": [],
+                                    "properties": {},
+                                    "examples": [{}]
+                                },
+                                "additionalRuleAnnotations": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The additionalRuleAnnotations Schema",
+                                    "required": [],
+                                    "properties": {},
+                                    "examples": [{}]
                                 }
                             },
                             "examples": [{
-                                "enabled": false
+                                "enabled": false,
+                                "additionalRuleLabels": {},
+                                "additionalRuleAnnotations": {}
                             }]
                         },
                         "extraLabels": {
@@ -893,7 +912,9 @@
                         "enabled": false,
                         "groups": [],
                         "defaultRules": {
-                            "enabled": false
+                            "enabled": false,
+                            "additionalRuleLabels": {},
+                            "additionalRuleAnnotations": {}
                         },
                         "extraLabels": {},
                         "annotations": {}
@@ -1124,7 +1145,9 @@
                     "enabled": false,
                     "groups": [],
                     "defaultRules": {
-                        "enabled": false
+                        "enabled": false,
+                        "additionalRuleLabels": {},
+                        "additionalRuleAnnotations": {}
                     },
                     "extraLabels": {},
                     "annotations": {}
@@ -1904,7 +1927,9 @@
                 "enabled": false,
                 "groups": [],
                 "defaultRules": {
-                    "enabled": false
+                    "enabled": false,
+                    "additionalRuleLabels": {},
+                    "additionalRuleAnnotations": {}
                 },
                 "extraLabels": {},
                 "annotations": {}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -124,9 +124,13 @@ manager:
     # Create default rules for monitoring the manager
     defaultRules:
       enabled: false
-    # additional labels on the PrometheusRule
+      ## Additional labels for PrometheusRule alerts
+      additionalRuleLabels: {}
+      ## Additional annotations for PrometheusRule alerts
+      additionalRuleAnnotations: {}
+    # additional labels on the PrometheusRule object
     extraLabels: {}
-    # add annotations on the PrometheusRule
+    # add annotations on the PrometheusRule object
     annotations: {}
 
   # Whether the operator should create RBAC permissions for collectors. See README.md for more information.


### PR DESCRIPTION
This is needed for routing alerts to 3rd party systems via labels and using custom annotations for alertmanager templates.