### PR TITLE
Add apache-httpd to schema

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.62.0
+version: 0.63.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.62.0
+    helm.sh/chart: opentelemetry-operator-0.63.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.102.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             {{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag }}
             - --auto-instrumentation-go-image={{ .Values.manager.autoInstrumentationImage.go.repository }}:{{ .Values.manager.autoInstrumentationImage.go.tag }}
             {{- end }}
+            {{- if and .Values.manager.autoInstrumentationImage.apacheHttpd.repository .Values.manager.autoInstrumentationImage.apacheHttpd.tag }}
+            - --auto-instrumentation-apache-httpd-image={{ .Values.manager.autoInstrumentationImage.apacheHttpd.repository }}:{{ .Values.manager.autoInstrumentationImage.apacheHttpd.tag }}
+            {{- end }}
             {{- if .Values.manager.featureGates }}
             - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -285,7 +285,8 @@
                         "nodejs",
                         "python",
                         "dotnet",
-                        "go"
+                        "go",
+                        "apacheHttpd"
                     ],
                     "additionalProperties": false,
                     "properties": {
@@ -448,6 +449,38 @@
                                 "repository": "",
                                 "tag": ""
                             }]
+                        },
+                        "apacheHttpd": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The apache-httpd Schema",
+                            "required": [
+                                "repository",
+                                "tag"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "repository": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The repository Schema",
+                                    "examples": [
+                                        ""
+                                    ]
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The tag Schema",
+                                    "examples": [
+                                        ""
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "repository": "",
+                                "tag": ""
+                            }]
                         }
                     },
                     "examples": [{
@@ -468,6 +501,10 @@
                             "tag": ""
                         },
                         "go": {
+                            "repository": "",
+                            "tag": ""
+                        },
+                        "apacheHttpd": {
                             "repository": "",
                             "tag": ""
                         }
@@ -1042,6 +1079,10 @@
                         "tag": ""
                     },
                     "go": {
+                        "repository": "",
+                        "tag": ""
+                    },
+                    "apacheHttpd": {
                         "repository": "",
                         "tag": ""
                     }
@@ -1803,6 +1844,11 @@
                     "tag": ""
                 },
                 "go": {
+                    "repository": "",
+                    "tag": ""
+                },
+                "apacheHttpd":
+                {
                     "repository": "",
                     "tag": ""
                 }

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -62,6 +62,9 @@ manager:
     dotnet:
       repository: ""
       tag: ""
+    apacheHttpd:
+      repository: ""
+      tag: ""
     # The Go instrumentation support in the operator is disabled by default.
     # To enable it, use the operator.autoinstrumentation.go feature gate.
     go:


### PR DESCRIPTION
Currently `apache-httpd` is missing from schema and not allowing to use the key:
```
Additional property apacheHttpd is not allowed
```