### PR TITLE
[demo] Replace Redis with Valkey

### DIFF
--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -499,7 +499,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -511,12 +511,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -528,7 +528,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -566,7 +566,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -578,12 +578,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -595,7 +595,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -612,8 +612,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -631,10 +631,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -643,7 +643,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -655,12 +655,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -672,7 +672,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -730,7 +730,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -742,12 +742,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -759,7 +759,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -793,7 +793,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -805,12 +805,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -822,7 +822,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -856,7 +856,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -868,12 +868,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -890,7 +890,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -927,7 +927,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -939,12 +939,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -996,7 +996,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1008,12 +1008,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1025,7 +1025,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1087,7 +1087,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1099,12 +1099,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1116,7 +1116,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1180,7 +1180,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1192,12 +1192,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1209,7 +1209,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1243,7 +1243,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1255,12 +1255,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1272,7 +1272,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1312,7 +1312,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1324,12 +1324,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1341,7 +1341,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1391,7 +1391,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1403,12 +1403,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1420,7 +1420,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1460,7 +1460,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1472,12 +1472,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1489,7 +1489,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1525,7 +1525,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1537,12 +1537,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1554,7 +1554,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1592,7 +1592,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1604,12 +1604,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1621,7 +1621,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1660,14 +1660,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1675,26 +1675,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1724,7 +1724,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1736,12 +1736,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1753,7 +1753,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -499,7 +499,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -511,12 +511,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -528,7 +528,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -566,7 +566,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -578,12 +578,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -595,7 +595,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -612,8 +612,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -631,10 +631,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -643,7 +643,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -655,12 +655,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -672,7 +672,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -730,7 +730,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -742,12 +742,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -759,7 +759,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -793,7 +793,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -805,12 +805,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -822,7 +822,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -856,7 +856,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -868,12 +868,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -890,7 +890,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -927,7 +927,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -939,12 +939,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -996,7 +996,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1008,12 +1008,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1025,7 +1025,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1087,7 +1087,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1099,12 +1099,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1116,7 +1116,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1180,7 +1180,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1192,12 +1192,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1209,7 +1209,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1243,7 +1243,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1255,12 +1255,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1272,7 +1272,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1312,7 +1312,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1324,12 +1324,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1341,7 +1341,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1391,7 +1391,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1403,12 +1403,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1420,7 +1420,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1460,7 +1460,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1472,12 +1472,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1489,7 +1489,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1525,7 +1525,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1537,12 +1537,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1554,7 +1554,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1592,7 +1592,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1604,12 +1604,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1621,7 +1621,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1660,14 +1660,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1675,26 +1675,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1724,7 +1724,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1736,12 +1736,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1753,7 +1753,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.102.1"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     connectors:
@@ -103,7 +103,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: redis-cart:6379
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -501,7 +501,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -513,12 +513,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -530,7 +530,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -570,7 +570,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -582,12 +582,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -599,7 +599,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -616,8 +616,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -637,10 +637,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -649,7 +649,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -661,12 +661,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -678,7 +678,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -738,7 +738,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -750,12 +750,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -767,7 +767,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -803,7 +803,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -815,12 +815,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -832,7 +832,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -868,7 +868,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -880,12 +880,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -902,7 +902,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -939,7 +939,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -951,12 +951,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -1010,7 +1010,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1022,12 +1022,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1039,7 +1039,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1103,7 +1103,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1115,12 +1115,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1132,7 +1132,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1196,7 +1196,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1208,12 +1208,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1225,7 +1225,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1259,7 +1259,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1271,12 +1271,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1288,7 +1288,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1328,7 +1328,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1340,12 +1340,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1357,7 +1357,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1409,7 +1409,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1421,12 +1421,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1438,7 +1438,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1480,7 +1480,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1492,12 +1492,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1509,7 +1509,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1547,7 +1547,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1559,12 +1559,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1576,7 +1576,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1616,7 +1616,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1628,12 +1628,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1645,7 +1645,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1686,14 +1686,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1701,26 +1701,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1750,7 +1750,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1762,12 +1762,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1779,7 +1779,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.102.1"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     connectors:
@@ -110,7 +110,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: redis-cart:6379
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -499,7 +499,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -511,12 +511,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -528,7 +528,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -566,7 +566,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -578,12 +578,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -595,7 +595,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -612,8 +612,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -631,10 +631,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -643,7 +643,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -655,12 +655,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -672,7 +672,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -730,7 +730,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -742,12 +742,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -759,7 +759,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -793,7 +793,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -805,12 +805,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -822,7 +822,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -856,7 +856,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -868,12 +868,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -890,7 +890,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -927,7 +927,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -939,12 +939,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -996,7 +996,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1008,12 +1008,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1025,7 +1025,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1087,7 +1087,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1099,12 +1099,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1116,7 +1116,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1180,7 +1180,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1192,12 +1192,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1209,7 +1209,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1243,7 +1243,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1255,12 +1255,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1272,7 +1272,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1312,7 +1312,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1324,12 +1324,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1341,7 +1341,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1391,7 +1391,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1403,12 +1403,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1420,7 +1420,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1460,7 +1460,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1472,12 +1472,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1489,7 +1489,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1525,7 +1525,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1537,12 +1537,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1554,7 +1554,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1592,7 +1592,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1604,12 +1604,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1621,7 +1621,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1660,14 +1660,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1675,26 +1675,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1724,7 +1724,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1736,12 +1736,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1753,7 +1753,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.102.1"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     connectors:
@@ -101,7 +101,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: redis-cart:6379
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -499,7 +499,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -511,12 +511,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -528,7 +528,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -566,7 +566,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -578,12 +578,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -595,7 +595,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -612,8 +612,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -631,10 +631,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -643,7 +643,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -655,12 +655,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -672,7 +672,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -730,7 +730,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -742,12 +742,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -759,7 +759,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -793,7 +793,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -805,12 +805,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -822,7 +822,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -856,7 +856,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -868,12 +868,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -890,7 +890,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -927,7 +927,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -939,12 +939,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -996,7 +996,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1008,12 +1008,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1025,7 +1025,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1087,7 +1087,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1099,12 +1099,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1116,7 +1116,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1180,7 +1180,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1192,12 +1192,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1209,7 +1209,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1243,7 +1243,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1255,12 +1255,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1272,7 +1272,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1312,7 +1312,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1324,12 +1324,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1341,7 +1341,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1391,7 +1391,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1403,12 +1403,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1420,7 +1420,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1460,7 +1460,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1472,12 +1472,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1489,7 +1489,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1525,7 +1525,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1537,12 +1537,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1554,7 +1554,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1592,7 +1592,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1604,12 +1604,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1621,7 +1621,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1660,14 +1660,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1675,26 +1675,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1724,7 +1724,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1736,12 +1736,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1753,7 +1753,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.102.1"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     connectors:
@@ -236,7 +236,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: redis-cart:6379
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -21,7 +21,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -31,7 +31,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -46,7 +46,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -56,7 +56,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -71,7 +71,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -81,7 +81,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -96,7 +96,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -106,7 +106,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -121,7 +121,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -131,7 +131,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -146,7 +146,7 @@ spec:
       name: tcp-service
       targetPort: 8013
   selector:
-    
+
     opentelemetry.io/name: example-flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -156,7 +156,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -171,7 +171,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -181,7 +181,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -196,7 +196,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -206,7 +206,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -221,7 +221,7 @@ spec:
       name: tcp-service
       targetPort: 8081
   selector:
-    
+
     opentelemetry.io/name: example-imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -231,7 +231,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -249,7 +249,7 @@ spec:
       name: controller
       targetPort: 9093
   selector:
-    
+
     opentelemetry.io/name: example-kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -259,7 +259,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -274,7 +274,7 @@ spec:
       name: tcp-service
       targetPort: 8089
   selector:
-    
+
     opentelemetry.io/name: example-loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -284,7 +284,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -299,7 +299,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -309,7 +309,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -324,7 +324,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -334,7 +334,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -349,7 +349,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -359,7 +359,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -374,21 +374,21 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -396,11 +396,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: redis
+      name: valkey
       targetPort: 6379
   selector:
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
@@ -409,7 +409,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -424,7 +424,7 @@ spec:
       name: tcp-service
       targetPort: 8080
   selector:
-    
+
     opentelemetry.io/name: example-shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
@@ -434,7 +434,7 @@ metadata:
   name: example-accountingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
@@ -446,12 +446,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-accountingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
@@ -499,7 +499,7 @@ metadata:
   name: example-adservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -511,12 +511,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-adservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
@@ -528,7 +528,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-adservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -566,7 +566,7 @@ metadata:
   name: example-cartservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -578,12 +578,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-cartservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
@@ -595,7 +595,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-cartservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -612,8 +612,8 @@ spec:
             value: "8080"
           - name: ASPNETCORE_URLS
             value: http://*:$(CART_SERVICE_PORT)
-          - name: REDIS_ADDR
-            value: 'example-redis:6379'
+          - name: VALKEY_ADDR
+            value: 'example-valkey:6379'
           - name: FLAGD_HOST
             value: 'example-flagd'
           - name: FLAGD_PORT
@@ -631,10 +631,10 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-redis 6379; do echo waiting
-            for redis; sleep 2; done;
+          - until nc -z -v -w30 example-valkey 6379; do echo waiting
+            for valkey; sleep 2; done;
           image: busybox:latest
-          name: wait-for-redis
+          name: wait-for-valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -643,7 +643,7 @@ metadata:
   name: example-checkoutservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -655,12 +655,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-checkoutservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
@@ -672,7 +672,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-checkoutservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -730,7 +730,7 @@ metadata:
   name: example-currencyservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -742,12 +742,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-currencyservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
@@ -759,7 +759,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-currencyservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -793,7 +793,7 @@ metadata:
   name: example-emailservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -805,12 +805,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-emailservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
@@ -822,7 +822,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-emailservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -856,7 +856,7 @@ metadata:
   name: example-flagd
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
@@ -868,12 +868,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-flagd
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
@@ -890,7 +890,7 @@ spec:
           - --uri
           - file:./etc/flagd/demo.flagd.json
           ports:
-          
+
           - containerPort: 8013
             name: service
           env:
@@ -927,7 +927,7 @@ metadata:
   name: example-frauddetectionservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
@@ -939,12 +939,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frauddetectionservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
@@ -996,7 +996,7 @@ metadata:
   name: example-frontend
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -1008,12 +1008,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontend
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
@@ -1025,7 +1025,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1087,7 +1087,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1099,12 +1099,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-frontendproxy
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
@@ -1116,7 +1116,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-frontendproxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1180,7 +1180,7 @@ metadata:
   name: example-imageprovider
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
@@ -1192,12 +1192,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-imageprovider
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
@@ -1209,7 +1209,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-imageprovider'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8081
             name: service
           env:
@@ -1243,7 +1243,7 @@ metadata:
   name: example-kafka
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
@@ -1255,12 +1255,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-kafka
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
@@ -1272,7 +1272,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 9092
             name: plaintext
           - containerPort: 9093
@@ -1312,7 +1312,7 @@ metadata:
   name: example-loadgenerator
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1324,12 +1324,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-loadgenerator
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
@@ -1341,7 +1341,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-loadgenerator'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8089
             name: service
           env:
@@ -1391,7 +1391,7 @@ metadata:
   name: example-paymentservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1403,12 +1403,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-paymentservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
@@ -1420,7 +1420,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-paymentservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1460,7 +1460,7 @@ metadata:
   name: example-productcatalogservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1472,12 +1472,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-productcatalogservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
@@ -1489,7 +1489,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-productcatalogservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1525,7 +1525,7 @@ metadata:
   name: example-quoteservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1537,12 +1537,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-quoteservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
@@ -1554,7 +1554,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-quoteservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1592,7 +1592,7 @@ metadata:
   name: example-recommendationservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1604,12 +1604,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-recommendationservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
@@ -1621,7 +1621,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-recommendationservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1660,14 +1660,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-redis
+  name: example-valkey
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
-    opentelemetry.io/name: example-redis
+
+    opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: example-redis
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: example-valkey
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1675,26 +1675,26 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
-      opentelemetry.io/name: example-redis
+
+      opentelemetry.io/name: example-valkey
   template:
     metadata:
       labels:
-        
-        opentelemetry.io/name: example-redis
+
+        opentelemetry.io/name: example-valkey
         app.kubernetes.io/instance: example
-        app.kubernetes.io/component: redis
-        app.kubernetes.io/name: example-redis
+        app.kubernetes.io/component: valkey
+        app.kubernetes.io/name: example-valkey
     spec:
       serviceAccountName: example
       containers:
-        - name: redis
-          image: 'redis:7.2-alpine'
+        - name: valkey
+          image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 6379
-            name: redis
+            name: valkey
           env:
           - name: OTEL_SERVICE_NAME
             valueFrom:
@@ -1724,7 +1724,7 @@ metadata:
   name: example-shippingservice
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -1736,12 +1736,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      
+
       opentelemetry.io/name: example-shippingservice
   template:
     metadata:
       labels:
-        
+
         opentelemetry.io/name: example-shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
@@ -1753,7 +1753,7 @@ spec:
           image: 'ghcr.io/open-telemetry/demo:1.10.0-shippingservice'
           imagePullPolicy: IfNotPresent
           ports:
-          
+
           - containerPort: 8080
             name: service
           env:
@@ -1787,7 +1787,7 @@ metadata:
   name: example-frontendproxy
   labels:
     helm.sh/chart: opentelemetry-demo-0.31.0
-    
+
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.102.1"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     connectors:
@@ -101,7 +101,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: redis-cart:6379
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -112,7 +112,7 @@
         "kafka": {
           "$ref": "#/definitions/Component"
         },
-        "redis": {
+        "valkey": {
           "$ref": "#/definitions/Component"
         }
       },

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -200,8 +200,8 @@ components:
         value: "8080"
       - name: ASPNETCORE_URLS
         value: http://*:$(CART_SERVICE_PORT)
-      - name: REDIS_ADDR
-        value: '{{ include "otel-demo.name" . }}-redis:6379'
+      - name: VALKEY_ADDR
+        value: '{{ include "otel-demo.name" . }}-valkey:6379'
       - name: FLAGD_HOST
         value: '{{ include "otel-demo.name" . }}-flagd'
       - name: FLAGD_PORT
@@ -212,9 +212,9 @@ components:
       limits:
         memory: 160Mi
     initContainers:
-      - name: wait-for-redis
+      - name: wait-for-valkey
         image: busybox:latest
-        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-redis 6379; do echo waiting for redis; sleep 2; done;']
+        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-valkey 6379; do echo waiting for valkey; sleep 2; done;']
 
   checkoutService:
     enabled: true
@@ -608,22 +608,22 @@ components:
       runAsGroup: 1000
       runAsNonRoot: true
 
-  redis:
+  valkey:
     enabled: true
     useDefault:
       env: true
     imageOverride:
-      repository: "redis"
+      repository: "valkey/valkey"
       tag: "7.2-alpine"
     replicas: 1
     ports:
-      - name: redis
+      - name: valkey
         value: 6379
     resources:
       limits:
         memory: 20Mi
     securityContext:
-      runAsUser: 999  # redis
+      runAsUser: 999  # valkey
       runAsGroup: 1000
       runAsNonRoot: true
 
@@ -668,7 +668,7 @@ opentelemetry-collector:
         targets:
           - endpoint: 'http://{{ include "otel-demo.name" . }}-frontendproxy:8080'
       redis:
-        endpoint: "redis-cart:6379"
+        endpoint: "valkey-cart:6379"
         collection_interval: 10s
 
     exporters:


### PR DESCRIPTION
The OpenTelemetry demo replaced the Redis usage in favor of Valkey: https://github.com/open-telemetry/opentelemetry-demo/pull/1619

The current helm chart needs to be updated before next OpenTelemetry demo release. If used demo's nightly image for the deployment, the following error arised for the cartservice pod:

```
Defaulted container "cartservice" out of: cartservice, wait-for-redis (init)
VALKEY_ADDR environment variable is required.
```

**Formatting**: My editor autoremoves any leading/trailing spaces, I see most changes are related to than. If not desired, I can move that in another PR.