### PR TITLE
[collector] support tpl in extraVolumes and extraVolumesMount

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.97.0
+version: 0.97.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1a205b1e0c85ae0efb1186886988dcc5badba36235387da3436270c664b87c96
+        checksum/config: 81589b995dcd384b4fdd1c96a74cdd206a9696cdcb72eba5f89ab039d1d9a279
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf8ede72b9452904010212ed4cbf2fc1e426f915f8a944128776e4eb381528aa
+        checksum/config: 209230bc258db39b7bb7bfcb28a1362d6461cb2eeb280cdf99152f568f577c9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca78f6aafe1134179a662b9bc9fe08a0ab233b3adf5bc844a38656bb527b2f78
+        checksum/config: 5e19f2ed692e4213bd55a87f5dcf356b3af7e62db9e3fd599101299a1407a020
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c570339f50556c635235b465b5ded6a49fd1dce259bb73f0377708f74dc47ee
+        checksum/config: 8e7f63ff3ea1875d90a684391a2b48cdc3e7dcc8202dc641325a2089b127141c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ef080f268aa8a62fbfccd5109fa6eccb7bf3011336c33a758a4d89187c1456dd
+        checksum/config: b89f5c20479bb6ce4cdfb798b5bf8e3f5721a46bbb1256bf31b0f0a5fbd8e791
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ef080f268aa8a62fbfccd5109fa6eccb7bf3011336c33a758a4d89187c1456dd
+        checksum/config: b89f5c20479bb6ce4cdfb798b5bf8e3f5721a46bbb1256bf31b0f0a5fbd8e791
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf8ede72b9452904010212ed4cbf2fc1e426f915f8a944128776e4eb381528aa
+        checksum/config: 209230bc258db39b7bb7bfcb28a1362d6461cb2eeb280cdf99152f568f577c9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 972bc13a37d3ee06f3c3db57555a51f80026b34e62bf41f3f11ee441f4e32760
+        checksum/config: 19e2dbcd2c77b811b37aea7b477483e611cb55a0cee9a66727ccc39c5931d62e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1b9ebdf0c5e14781f5e54455651bfe23bbffeb8b6f16ddce171e917e4e6f9fca
+        checksum/config: 54d26f84ba86027b0b771635a349813f45cd85016d3e9dccf8be6cdf23dc726a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1f876e4b24bae4ab40f113ae66c6e880e19b792247d9a7d5f2278c1959f46ac8
+        checksum/config: bd75ae5ff5fd4bd602a260977d4fdebf5979a36b586735cd22d64e3787b434c1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1f876e4b24bae4ab40f113ae66c6e880e19b792247d9a7d5f2278c1959f46ac8
+        checksum/config: bd75ae5ff5fd4bd602a260977d4fdebf5979a36b586735cd22d64e3787b434c1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf8ede72b9452904010212ed4cbf2fc1e426f915f8a944128776e4eb381528aa
+        checksum/config: 209230bc258db39b7bb7bfcb28a1362d6461cb2eeb280cdf99152f568f577c9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf8ede72b9452904010212ed4cbf2fc1e426f915f8a944128776e4eb381528aa
+        checksum/config: 209230bc258db39b7bb7bfcb28a1362d6461cb2eeb280cdf99152f568f577c9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.104.0"

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -138,7 +138,7 @@ containers:
         mountPropagation: HostToContainer
       {{- end }}
       {{- if .Values.extraVolumeMounts }}
-      {{- toYaml .Values.extraVolumeMounts | nindent 6 }}
+      {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 6 }}
       {{- end }}
 {{- if .Values.extraContainers }}
   {{- tpl (toYaml .Values.extraContainers) . | nindent 2 }}
@@ -179,7 +179,7 @@ volumes:
       path: /
   {{- end }}
   {{- if .Values.extraVolumes }}
-  {{- toYaml .Values.extraVolumes | nindent 2 }}
+  {{- tpl (toYaml .Values.extraVolumes) . | nindent 2 }}
   {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -233,7 +233,10 @@ priorityClassName: ""
 
 extraEnvs: []
 extraEnvsFrom: []
+# This also supports template content, which will eventually be converted to yaml.
 extraVolumes: []
+
+# This also supports template content, which will eventually be converted to yaml.
 extraVolumeMounts: []
 
 # Configuration for ports


### PR DESCRIPTION
the same as https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1139, support tpl in extraVolumes and extraVolumesMount.

e.g.
```yaml
extraVolumes:
  - name: file-{{ .Release.Name }}
    emptyDir: {}

extraVolumeMounts:
  - name: file-{{ .Release.Name }}
    mountPath: /data
```
