### PR TITLE
Show the diff in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ check-examples:
 			if diff -r "$${EXAMPLES_DIR}/$${example}/rendered" "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates" > /dev/null; then \
 				echo "Passed $${example}"; \
 			else \
+				diff -r "$${EXAMPLES_DIR}/$${example}/rendered" "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates"; \
 				echo "Failed $${example}. run 'make generate-examples' to re-render the example with the latest $${example}/values.yaml"; \
 				rm -rf ${TMP_DIRECTORY}; \
 				exit 1; \


### PR DESCRIPTION
This will make it easier to understand why the lint command failed without a reviewer needing to fork it locally.

I tested with just manually editing something in the rendered and it found it very quickly:
```

find: ./tmp/default/opentelemetry-operator/charts: No such file or directory
diff -r charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml ./tmp/default/opentelemetry-operator/templates/clusterrolebinding.yaml
7c7
<     helm.sh/chart: opentelemetry-operator-0.64.2
---
>     helm.sh/chart: opentelemetry-operator-0.64.1
12c12
<
---
>
34c34
<
---
>
Failed default. run 'make generate-examples' to re-render the example with the latest default/values.yaml
make: *** [check-examples] Error 1
```