### PR TITLE
fix: Update pdb.yaml to use pdb in statfulset mode

### DIFF
--- a/charts/opentelemetry-collector/templates/pdb.yaml
+++ b/charts/opentelemetry-collector/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podDisruptionBudget.enabled (eq .Values.mode "deployment") }}
+{{- if and .Values.podDisruptionBudget.enabled (or (eq .Values.mode "deployment") (eq .Values.mode "statefulset")) }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
This enables to use pod  disruption budget, if collector configured as statefulset