### PR TITLE
[collector] Only use internalTrafficPolicy: if on Kubernetes vesrion 1.26 or later

### DIFF
--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -35,7 +35,9 @@ spec:
   selector:
     {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
     {{- include "opentelemetry-collector.component" . | nindent 4 }}
+  {{- if semverCompare ">=1.26-0" .Capabilities.KubeVersion.Version }}
   internalTrafficPolicy: {{ include "opentelemetry-collector.serviceInternalTrafficPolicy" . }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.externalTrafficPolicy) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}


### PR DESCRIPTION
following this [PR](https://github.com/grafana/alloy/pull/1213/files), we have to make limits based on k8s version. 

Otherwise we will fail to install collector when k8s version is low