### PR TITLE
Update the documentation to import a subset of k8s logs

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -5,11 +5,11 @@ description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
 sources:
-- https://github.com/open-telemetry/opentelemetry-collector
-- https://github.com/open-telemetry/opentelemetry-collector-contrib
+ - https://github.com/open-telemetry/opentelemetry-collector
+ - https://github.com/open-telemetry/opentelemetry-collector-contrib
 maintainers:
-- name: dmitryax
-- name: jaronoff97
-- name: TylerHelmuth
+ - name: dmitryax
+ - name: jaronoff97
+ - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 0.108.0

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -5,11 +5,11 @@ description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
 sources:
- - https://github.com/open-telemetry/opentelemetry-collector
- - https://github.com/open-telemetry/opentelemetry-collector-contrib
+  - https://github.com/open-telemetry/opentelemetry-collector
+  - https://github.com/open-telemetry/opentelemetry-collector-contrib
 maintainers:
- - name: dmitryax
- - name: jaronoff97
- - name: TylerHelmuth
+  - name: dmitryax
+  - name: jaronoff97
+  - name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 0.108.0

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.104.0
+version: 0.105.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
 sources:
-  - https://github.com/open-telemetry/opentelemetry-collector
-  - https://github.com/open-telemetry/opentelemetry-collector-contrib
+- https://github.com/open-telemetry/opentelemetry-collector
+- https://github.com/open-telemetry/opentelemetry-collector-contrib
 maintainers:
-  - name: dmitryax
-  - name: jaronoff97
-  - name: TylerHelmuth
+- name: dmitryax
+- name: jaronoff97
+- name: TylerHelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 0.108.0

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.105.0
+version: 0.105.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -104,6 +104,29 @@ presets:
 The way this feature works is it adds a `filelog` receiver on the `logs` pipeline. This receiver is preconfigured
 to read the files where Kubernetes container runtime writes all containers' console output to.
 
+#### Log collection for a subset of pods or containers
+
+The `logsCollection` preset will by default ingest the logs of all kubernetes containers.
+This is achieved by using an include path of `/var/log/pods/*/*/*.log` for the `filelog`receiver.
+
+To limit the import to a certain subset of pods or containers, the `filelog`
+receivers `include` list can be overwritten by supplying explicit configuration.
+
+E.g. The following configuration would only import logs for pods within namespace `example-namespace`:
+
+```yaml
+mode: daemonset
+
+presets:
+  logsCollection:
+    enabled: true
+config:
+  receivers:
+    filelog:
+      include:
+        - /var/log/pods/example-namespace_*/*/*.log
+```
+
 #### :warning: Warning: Risk of looping the exported logs back into the receiver, causing "log explosion"
 
 The container logs pipeline uses the `debug` exporter by default.
@@ -113,7 +136,7 @@ it is easy to accidentally feed the exported logs back into the receiver.
 Also note that using the `--verbosity=detailed` option for the `debug` exporter causes it to output
 multiple lines per single received log, which when looped, would amplify the logs exponentially.
 
-To prevent the looping, the default configuration of the receiver excludes logs from the collector's containers.
+To prevent the looping, the default configuration of the receiver excludes logs from the collector's containers by setting `presets.logsCollection.includeCollectorLogs` to `false`.
 
 If you want to include the collector's logs, make sure to replace the `debug` exporter
 with an exporter that does not send logs to collector's standard output.

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -136,7 +136,7 @@ it is easy to accidentally feed the exported logs back into the receiver.
 Also note that using the `--verbosity=detailed` option for the `debug` exporter causes it to output
 multiple lines per single received log, which when looped, would amplify the logs exponentially.
 
-To prevent the looping, the default configuration of the receiver excludes logs from the collector's containers by setting `presets.logsCollection.includeCollectorLogs` to `false`.
+To prevent the looping, the default configuration of the receiver excludes logs from the collector's containers.
 
 If you want to include the collector's logs, make sure to replace the `debug` exporter
 with an exporter that does not send logs to collector's standard output.


### PR DESCRIPTION
Updated the doc to import a subset of k8s logs

Details:
Updated documentation for Log collection for a subset of pods or containers

File modified:
charts/opentelemetry-collector/README.md