### PR TITLE
[operator] fix: move 'relabelings' and 'metricRelabelings' configs under endpoints in serviceMonitor spec

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.65.0
+version: 0.65.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.65.0
+    helm.sh/chart: opentelemetry-operator-0.65.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-operator/templates/servicemonitor.yaml
@@ -24,12 +24,12 @@ spec:
   endpoints:
   {{- toYaml .Values.manager.serviceMonitor.metricsEndpoints | nindent 2 }}
   {{- with .Values.manager.serviceMonitor.relabelings }}
-  relabelings:
-  {{- toYaml . | nindent 4 }}
+    relabelings:
+  {{- toYaml . | nindent 6 }}
   {{- end }}
   {{- with .Values.manager.serviceMonitor.metricRelabelings }}
-  metricRelabelings:
-  {{- toYaml . | nindent 4 }}
+    metricRelabelings:
+  {{- toYaml . | nindent 6 }}
   {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/opentelemetry-operator/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-operator/templates/servicemonitor.yaml
@@ -22,15 +22,15 @@ spec:
       {{- include "opentelemetry-operator.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: controller-manager
   endpoints:
-  {{- toYaml .Values.manager.serviceMonitor.metricsEndpoints | nindent 2 }}
-    {{- with .Values.manager.serviceMonitor.relabelings }}
-    relabelings:
-    {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.manager.serviceMonitor.metricRelabelings }}
-    metricRelabelings:
-    {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- toYaml .Values.manager.serviceMonitor.metricsEndpoints | nindent 4 }}
+      {{- with .Values.manager.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/opentelemetry-operator/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-operator/templates/servicemonitor.yaml
@@ -23,14 +23,14 @@ spec:
       app.kubernetes.io/component: controller-manager
   endpoints:
   {{- toYaml .Values.manager.serviceMonitor.metricsEndpoints | nindent 2 }}
-  {{- with .Values.manager.serviceMonitor.relabelings }}
+    {{- with .Values.manager.serviceMonitor.relabelings }}
     relabelings:
-  {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.manager.serviceMonitor.metricRelabelings }}
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.manager.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-  {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Fixes indentation issues causing an invalid ServiceMonitor spec when using relabeling/metricRelabeling configs  https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1287