### PR TITLE
Add uninstall hook for the kube-stack chart

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.1.2
+version: 0.1.3
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm        
     opentelemetry.io/opamp-reporting: "true"
@@ -189,7 +189,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm        
     opentelemetry.io/opamp-reporting: "true"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -1,0 +1,59 @@
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: delete-resources-role
+rules:
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opampbridges
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - delete
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: delete-resources-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: delete-resources-role
+subjects:
+  - kind: ServiceAccount
+    name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opentelemetry-kube-stack-pre-delete-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: delete-resources-sa
+      containers:
+      - name: delete-resources
+        image: bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
+              -l helm.sh/chart=opentelemetry-kube-stack-0.1.3

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/values.yaml
@@ -1,6 +1,4 @@
 clusterName: demo
-opentelemetry-operator:
-  enabled: true
 collectors:
   daemon:
     ports:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.1.2
+    helm.sh/chart: opentelemetry-kube-stack-0.1.3
     app.kubernetes.io/version: "0.105.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -1,0 +1,59 @@
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: delete-resources-role
+rules:
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opampbridges
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - delete
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: delete-resources-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: delete-resources-role
+subjects:
+  - kind: ServiceAccount
+    name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opentelemetry-kube-stack-pre-delete-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: delete-resources-sa
+      containers:
+      - name: delete-resources
+        image: bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
+              -l helm.sh/chart=opentelemetry-kube-stack-0.1.3

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
@@ -1,6 +1,4 @@
 clusterName: demo
-opentelemetry-operator:
-  enabled: true
 collectors:
   daemon:
     enabled: true

--- a/charts/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/templates/hooks.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.cleanupJob.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-resources-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: delete-resources-role
+rules:
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opampbridges
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: delete-resources-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: delete-resources-role
+subjects:
+  - kind: ServiceAccount
+    name: delete-resources-sa
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "opentelemetry-kube-stack.name" . }}-pre-delete-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: delete-resources-sa
+      containers:
+      - name: delete-resources
+        image: bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
+              -l helm.sh/chart={{ include "opentelemetry-kube-stack.chart" . }}
+{{- end }}

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -3827,6 +3827,14 @@
     }
   },
   "properties": {
+    "cleanupJob": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "crds": {
       "type": "object",
       "properties": {

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -21,8 +21,7 @@ crds:
 # Top level field related to the OpenTelemetry Operator
 opentelemetry-operator:
   # Field indicating whether the operator is enabled or not
-  # This is disabled for now while the chart is under development
-  enabled: false
+  enabled: true
   manager:
     collectorImage:
       repository: otel/opentelemetry-collector-k8s

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -9,6 +9,10 @@ clusterName: ""
 # Extra environment variables to add to each collector, bridge and instrumentation
 extraEnvs: []
 
+# Enables a cleanup job to make sure the CRs are uninstalled before the operator
+cleanupJob:
+  enabled: true
+
 # Should the CRDs be installed by this chart.
 crds:
   # Should the CRDs be installed


### PR DESCRIPTION
This adds an uninstall hook which makes sure that we get rid of the CRs before we uninstall the operator