### PR TITLE
Remove required container resources

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.68.0
+version: 0.68.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.68.0
+    helm.sh/chart: opentelemetry-operator-0.68.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -131,7 +131,6 @@
                 "autoInstrumentationImage",
                 "featureGates",
                 "ports",
-                "resources",
                 "env",
                 "serviceAccount",
                 "serviceMonitor",
@@ -564,10 +563,7 @@
                     "type": "object",
                     "default": {},
                     "title": "The resources Schema",
-                    "required": [
-                        "limits",
-                        "requests"
-                    ],
+                    "required": [],
                     "additionalProperties": false,
                     "properties": {
                         "limits": {
@@ -611,10 +607,7 @@
                             "type": "object",
                             "default": {},
                             "title": "The requests Schema",
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
+                            "required": [],
                             "additionalProperties": false,
                             "properties": {
                                 "cpu": {
@@ -1198,7 +1191,6 @@
                 "enabled",
                 "image",
                 "ports",
-                "resources",
                 "extraArgs",
                 "securityContext"
             ],
@@ -1270,10 +1262,7 @@
                     "type": "object",
                     "default": {},
                     "title": "The resources Schema",
-                    "required": [
-                        "limits",
-                        "requests"
-                    ],
+                    "required": [],
                     "additionalProperties": false,
                     "properties": {
                         "limits": {
@@ -1309,10 +1298,7 @@
                             "type": "object",
                             "default": {},
                             "title": "The requests Schema",
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
+                            "required": [],
                             "additionalProperties": false,
                             "properties": {
                                 "cpu": {

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -571,7 +571,7 @@
                             "default": {},
                             "title": "The limits Schema",
                             "required": [],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -608,7 +608,7 @@
                             "default": {},
                             "title": "The requests Schema",
                             "required": [],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -1270,7 +1270,7 @@
                             "default": {},
                             "title": "The limits Schema",
                             "required": [],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cpu": {
                                     "type": "string",
@@ -1299,7 +1299,7 @@
                             "default": {},
                             "title": "The requests Schema",
                             "required": [],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "cpu": {
                                     "type": "string",


### PR DESCRIPTION
It's currently impossible to deploy the operator chart without requests and/or limits. CPU limits are of particular concern; they are essentially considered harmful at this point.

Additionally, the schema is incomplete by not allowing for [(as seen on this page)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container):
1. `spec.containers[].resources.requests.hugepages-<size>`
2. `spec.containers[].resources.limits.hugepages-<size>`

So I also set `additionalProperties` to true for the respective limits/requests to support arbitrary hugepage sizes.

This PR allows the user to freely enable, disable or set any value in limits or requests to whatever they want including, most importantly, removing them entirely:
```yaml
manager:
  resources:
    requests: null
    limits: null
kubeRBACProxy:
  resources:
    requests: null
    limits: null
```