### PR TITLE
docs: one too many jacobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 Approvers ([@open-telemetry/helm-approvers](https://github.com/orgs/open-telemetry/teams/helm-approvers)):
 
 - [Alex Birca](https://github.com/Allex1), Adobe
-- [Jacob Aronoff](https://github.com/jaronoff97), ServiceNow
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 - [Povilas](https://github.com/povilasv), Coralogix


### PR DESCRIPTION
Looks like the name wasn't moved from approver to maintainer but rather added and is now in two places 😅