### PR TITLE
Remove image setting when not needed

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.2.0
+version: 0.2.1
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -23,7 +23,7 @@ spec:
     ReportsRemoteConfig: true
     ReportsStatus: true
   replicas: 1
-  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.103.0"
+  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.107.0"
   upgradeStrategy: automatic
   securityContext:
     runAsNonRoot: true

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -132,7 +132,6 @@ spec:
           receivers:
           - k8s_cluster
   replicas: 1
-  image: "otel/opentelemetry-collector-k8s:0.103.1"
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   hostNetwork: false
@@ -586,7 +585,6 @@ spec:
           - batch
           receivers:
           - otlp
-  image: "otel/opentelemetry-collector-k8s:0.103.1"
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   hostNetwork: false

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm        
     opentelemetry.io/opamp-reporting: "true"
@@ -188,7 +188,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm        
     opentelemetry.io/opamp-reporting: "true"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.0
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.1

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -290,7 +290,6 @@ spec:
           - batch
           receivers:
           - otlp
-  image: "otel/opentelemetry-collector-k8s:0.103.1"
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   hostNetwork: false

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.0
+    helm.sh/chart: opentelemetry-kube-stack-0.2.1
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.0
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.1

--- a/charts/opentelemetry-kube-stack/templates/collector.yaml
+++ b/charts/opentelemetry-kube-stack/templates/collector.yaml
@@ -30,8 +30,8 @@ spec:
   {{- end }}
   {{- if $collector.image.digest }}
   image: "{{ $collector.image.repository }}@{{ $collector.image.digest }}"
-  {{- else }}
-  image: "{{ $collector.image.repository }}:{{ $collector.image.tag | default $.Chart.AppVersion }}"
+  {{- else if $collector.image.tag }}
+  image: "{{ $collector.image.repository }}:{{ $collector.image.tag }}"
   {{- end }}
   imagePullPolicy: {{ $collector.image.pullPolicy }}
   upgradeStrategy: {{ $collector.upgradeStrategy }}

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -90,7 +90,7 @@ defaultCRConfig:
     # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
     repository: otel/opentelemetry-collector-k8s
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # By default, the version set for the collector will match the version of the operator being run.
     tag: ""
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
@@ -818,7 +818,7 @@ opAMPBridge:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # By default, the version set for the bridge will match the version of the operator being run.
     tag: ""
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -91,7 +91,7 @@ defaultCRConfig:
     repository: otel/opentelemetry-collector-k8s
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.103.1"
+    tag: ""
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
 
@@ -819,7 +819,7 @@ opAMPBridge:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.103.0"
+    tag: ""
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
 


### PR DESCRIPTION
Remove setting the image version from the collector as that is handled by the operator's functionality. Also fixes the bridge's image which was hardcoded.