### PR TITLE
[demo] add revisionHistoryLimit parameter

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.32.6
+version: 0.32.7
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -509,6 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -565,7 +567,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -576,6 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -642,7 +645,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -653,6 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -729,7 +733,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -740,6 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -792,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -803,6 +808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -855,7 +861,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -866,6 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -926,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -937,6 +944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -995,7 +1003,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1006,6 +1014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1086,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1097,6 +1106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1179,7 +1189,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1190,6 +1200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1242,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1253,6 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1311,7 +1323,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1322,6 +1334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1390,7 +1403,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1401,6 +1414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1459,7 +1473,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1470,6 +1484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1524,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1535,6 +1550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1591,7 +1607,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1602,6 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1662,7 +1679,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1673,6 +1690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1725,7 +1743,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1736,6 +1754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -509,6 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -565,7 +567,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -576,6 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -642,7 +645,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -653,6 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -729,7 +733,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -740,6 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -792,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -803,6 +808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -855,7 +861,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -866,6 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -926,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -937,6 +944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -995,7 +1003,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1006,6 +1014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1086,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1097,6 +1106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1179,7 +1189,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1190,6 +1200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1242,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1253,6 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1311,7 +1323,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1322,6 +1334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1390,7 +1403,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1401,6 +1414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1459,7 +1473,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1470,6 +1484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1524,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1535,6 +1550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1591,7 +1607,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1602,6 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1662,7 +1679,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1673,6 +1690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1725,7 +1743,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1736,6 +1754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -500,7 +501,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -511,6 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -569,7 +571,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -580,6 +582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -648,7 +651,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -659,6 +662,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -737,7 +741,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -748,6 +752,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -802,7 +807,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -813,6 +818,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -867,7 +873,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -878,6 +884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -938,7 +945,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -949,6 +956,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1009,7 +1017,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1020,6 +1028,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1102,7 +1111,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1113,6 +1122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1195,7 +1205,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1206,6 +1216,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1258,7 +1269,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1269,6 +1280,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1327,7 +1339,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1338,6 +1350,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1408,7 +1421,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1419,6 +1432,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1479,7 +1493,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1490,6 +1504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1546,7 +1561,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1557,6 +1572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1615,7 +1631,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1626,6 +1642,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1688,7 +1705,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1699,6 +1716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1753,7 +1771,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1764,6 +1782,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -509,6 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -565,7 +567,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -576,6 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -642,7 +645,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -653,6 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -729,7 +733,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -740,6 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -792,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -803,6 +808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -855,7 +861,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -866,6 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -926,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -937,6 +944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -995,7 +1003,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1006,6 +1014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1086,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1097,6 +1106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1179,7 +1189,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1190,6 +1200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1242,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1253,6 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1311,7 +1323,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1322,6 +1334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1390,7 +1403,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1401,6 +1414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1459,7 +1473,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1470,6 +1484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1524,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1535,6 +1550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1591,7 +1607,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1602,6 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1662,7 +1679,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1673,6 +1690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1725,7 +1743,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1736,6 +1754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -509,6 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -565,7 +567,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -576,6 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -642,7 +645,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -653,6 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -729,7 +733,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -740,6 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -792,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -803,6 +808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -855,7 +861,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -866,6 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -926,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -937,6 +944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -995,7 +1003,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1006,6 +1014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1086,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1097,6 +1106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1179,7 +1189,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1190,6 +1200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1242,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1253,6 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1311,7 +1323,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1322,6 +1334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1390,7 +1403,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1401,6 +1414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1459,7 +1473,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1470,6 +1484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1524,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1535,6 +1550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1591,7 +1607,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1602,6 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1662,7 +1679,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1673,6 +1690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1725,7 +1743,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1736,6 +1754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -155,7 +155,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -180,7 +180,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -205,7 +205,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -230,7 +230,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -258,7 +258,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -283,7 +283,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -308,7 +308,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -333,7 +333,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -358,7 +358,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -383,7 +383,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -408,7 +408,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -433,7 +433,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -444,6 +444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -498,7 +499,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -509,6 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -565,7 +567,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -576,6 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -642,7 +645,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -653,6 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -729,7 +733,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -740,6 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -792,7 +797,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -803,6 +808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -855,7 +861,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -866,6 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -926,7 +933,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -937,6 +944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -995,7 +1003,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1006,6 +1014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1086,7 +1095,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1097,6 +1106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1179,7 +1189,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1190,6 +1200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1242,7 +1253,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1253,6 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1311,7 +1323,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1322,6 +1334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1390,7 +1403,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1401,6 +1414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1459,7 +1473,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1470,6 +1484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1524,7 +1539,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1535,6 +1550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1591,7 +1607,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1602,6 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1662,7 +1679,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1673,6 +1690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1725,7 +1743,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1736,6 +1754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       
@@ -1786,7 +1805,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.32.6
+    helm.sh/chart: opentelemetry-demo-0.32.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -11,6 +11,7 @@ metadata:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
   replicas: {{ .replicas | default .defaultValues.replicas }}
+  revisionHistoryLimit: {{ .revisionHistoryLimit | default .defaultValues.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "otel-demo.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -144,6 +144,9 @@
         "replicas": {
           "type": "integer"
         },
+        "revisionHistoryLimit": {
+          "type": "integer"
+        },
         "service": {
           "$ref": "#/definitions/Service"
         },
@@ -271,6 +274,9 @@
           }
         },
         "replicas": {
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
           "type": "integer"
         },
         "image": {

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -25,6 +25,8 @@ default:
     pullSecrets: []
   # Default # of replicas for all components
   replicas: 1
+  # default revisionHistoryLimit for all components (number of old ReplicaSets to retain)
+  revisionHistoryLimit: 10
   # Default schedulingRules for all components
   schedulingRules:
     nodeSelector: {}
@@ -143,6 +145,9 @@ components:
   #       command: [list of commands for the init container to run]
   # # Replicas for the component
   #  replicas: 1
+  # # Number of old ReplicaSets to retain
+  #  revisionHistoryLimit: 10
+
   # # Optional pod security context for setting user ID (UID), group ID (GID) and other security policies
   # # This will be applied at pod level, can be applied globally for all pods: .Values.default.podSecurityContext
   # # Or it can be applied to a specific component: .Values.components.<component-name>.podSecurityContext


### PR DESCRIPTION
This adds a new option to the demo chart, allowing to set the revisionHistoryLimit for the Deployments. This parameter already exists in the collector helm chart (if mode=deployment), and it is useful for the demo deployments as well.