### PR TITLE
bump kube-rbac-proxy v0.18.0 to fix CVE

### DIFF
--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -192,7 +192,7 @@ kubeRBACProxy:
   enabled: true
   image:
     repository: quay.io/brancz/kube-rbac-proxy
-    tag: v0.15.0
+    tag: v0.18.0
   ports:
     proxyPort: 8443
   resources:


### PR DESCRIPTION
As per Issue https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1344, the version of kube-rbac-proxy used in the opentelemetry-operator helm chart is out of date and contains CRITICAL Security vulnerabilities. 

We need to bump the version of  kube-rbac-proxy in opentelemetry-operator.


twistcli images scan --address https://us-east1.cloud.twistlock.com/us-2-158256723  --token $PTOKEN --details quay.io/brancz/kube-rbac-proxy:v0.18.0

Scan results for: image quay.io/brancz/kube-rbac-proxy:v0.18.0 sha256:f11dcab913758ac5cdfdfb4c8209b0d1fd7bf3d22896e8b0e19518bea357de36
Vulnerabilities
+----------------+----------+------+---------------------------------+---------+-----------------+------------+------------+----------------------------------------------------+
|      CVE       | SEVERITY | CVSS |             PACKAGE             | VERSION |     STATUS      | PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
+----------------+----------+------+---------------------------------+---------+-----------------+------------+------------+----------------------------------------------------+
| CVE-2024-28180 | medium   | 0.00 | gopkg.in/square/go-jose.v2      | v2.6.0  | open            | > 6 months | < 1 hour   | Package jose aims to provide an implementation     |
|                |          |      |                                 |         |                 |            |            | of the Javascript Object Signing and Encryption    |
|                |          |      |                                 |         |                 |            |            | set of standards. An attacker could send a JWE     |
|                |          |      |                                 |         |                 |            |            | containi...                                        |
+----------------+----------+------+---------------------------------+---------+-----------------+------------+------------+----------------------------------------------------+
| GO-2024-2978   | low      | 0.00 | google.golang.org/grpc/metadata | v1.64.0 | fixed in 1.64.1 | 64 days    | < 1 hour   | If applications print or log a context containing  |
|                |          |      |                                 |         | 64 days ago     |            |            | gRPC metadata, the output will contain all the     |
|                |          |      |                                 |         |                 |            |            | metadata, which may include private information.   |
|                |          |      |                                 |         |                 |            |            | This...                                            |
+----------------+----------+------+---------------------------------+---------+-----------------+------------+------------+----------------------------------------------------+

Vulnerabilities found for image quay.io/brancz/kube-rbac-proxy:v0.18.0: total - 2, critical - 0, high - 0, medium - 1, low - 1
Vulnerability threshold check results: PASS