### PR TITLE
[opentelemetry-kube-stack]: Fix missing "release" label to opentelemetry-kube-stack.labels

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.2.1
+version: 0.2.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,9 +5,10 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
-    app.kubernetes.io/managed-by: Helm    
+    app.kubernetes.io/managed-by: Helm
+    release: "example"    
 spec:
   endpoint: http://opamp-server:8080
   capabilities:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,9 +6,10 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
-    app.kubernetes.io/managed-by: Helm        
+    app.kubernetes.io/managed-by: Helm
+    release: "example"        
     opentelemetry.io/opamp-reporting: "true"
 spec:
   managementState: managed
@@ -188,9 +189,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
-    app.kubernetes.io/managed-by: Helm        
+    app.kubernetes.io/managed-by: Helm
+    release: "example"        
     opentelemetry.io/opamp-reporting: "true"
 spec:
   managementState: managed

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.2

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,9 +5,10 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
-    app.kubernetes.io/managed-by: Helm    
+    app.kubernetes.io/managed-by: Helm
+    release: "example"    
 spec:
   exporter:
     endpoint: http://${OTEL_K8S_NODE_NAME}:4317

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,9 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
-    app.kubernetes.io/managed-by: Helm        
+    app.kubernetes.io/managed-by: Helm
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   
   endpoints:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,9 +7,10 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
   namespace: kube-system
 spec:
   clusterIP: None

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   jobLabel: jobLabel
   

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,9 +7,10 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
   namespace: kube-system
 spec:
   clusterIP: None

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   jobLabel: jobLabel
   

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,9 +7,10 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
   namespace: kube-system
 spec:
   clusterIP: None

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   jobLabel: jobLabel
     

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,9 +7,10 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
   namespace: kube-system
 spec:
   clusterIP: None

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   jobLabel: jobLabel
   

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,9 +7,10 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
   namespace: kube-system
 spec:
   clusterIP: None

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.1
+    helm.sh/chart: opentelemetry-kube-stack-0.2.2
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
+    release: "example"
 spec:
   jobLabel: jobLabel
   

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.2

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -121,6 +121,7 @@ helm.sh/chart: {{ include "opentelemetry-kube-stack.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+release: {{ .Release.Name | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The labels in some `ServiceMonitor` selectors doesn't match the ones in the `Service` objects, specifically the label `release` is missing from some of them.

This PR attempts to solve the problem described above. I realized the `opentelemetry-kube-stack.labels` variable used to populate the labels in most `Service` objects was missing the `release` label. So the fix is as easy to add this label to this variable.

Thanks!

Fixes #1362