### PR TITLE
feat[opentelemetry-collector]: add support for multiline recombine from container parser

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.107.0
+version: 0.108.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
-    
+
 data:
   relay: |
     exporters:
@@ -36,6 +36,12 @@ data:
         - id: container-parser
           max_log_size: 102400
           type: container
+        - combine_field: body
+          id: recombine-multiline
+          is_first_entry: body matches "^[^\\s]"
+          max_log_size: 102400
+          source_identifier: attributes["log.file.path"]
+          type: recombine
         retry_on_failure:
           enabled: true
         start_at: end

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -179,6 +179,13 @@ receivers:
       - type: container
         id: container-parser
         max_log_size: {{ $.Values.presets.logsCollection.maxRecombineLogSize }}
+      # combine multiline logs (e.g. stack traces)
+      - id: recombine-multiline
+        type: recombine
+        combine_field: body
+        is_first_entry: body matches "^[^\\s]"
+        source_identifier: attributes["log.file.path"]
+        max_log_size: {{ $.Values.presets.logsCollection.maxRecombineLogSize }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesAttributesConfig" -}}


### PR DESCRIPTION
The current `container` operator cannot handle multiline messages like Java stack traces.

This PR adds the needed recombine operator to make it work. Probably in the future, this makes sense to be moved into the container operator itself. 

```
2024-10-02 13:23:27.062 ERROR a.b.c.SolrConnection.dummyFunction ZURL:zookeeper:2181   Exception deleting users for team[123456789] org.apache.solr.common.SolrException: Could not find a healthy node to handle the request.
	at org.apache.solr.client.solrj.impl.CloudSolrClient.sendRequest(CloudSolrClient.java:1085)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:871)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:954)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:954)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:954)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:954)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:954)
	at org.apache.solr.client.solrj.impl.CloudSolrClient.request(CloudSolrClient.java:807)
	at org.apache.solr.client.solrj.SolrRequest.process(SolrRequest.java:150)
	at org.apache.solr.client.solrj.SolrRequest.process(SolrRequest.java:167)
...
```