### PR TITLE
[opentelemetry-ebpf] adding option to specify security context for kernel collector

### DIFF
--- a/charts/opentelemetry-ebpf/Chart.yaml
+++ b/charts/opentelemetry-ebpf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-ebpf
-version: 0.1.4
+version: 0.1.5
 description: OpenTelemetry eBPF Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf/ci/security-context-values.yaml
+++ b/charts/opentelemetry-ebpf/ci/security-context-values.yaml
@@ -1,0 +1,32 @@
+kernelCollector:
+  securityContext:
+    allowPrivilegeEscalation: true
+    capabilities:
+      add:
+      - AUDIT_CONTROL
+      - BLOCK_SUSPEND
+      - DAC_READ_SEARCH
+      - IPC_LOCK
+      - IPC_OWNER
+      - LEASE
+      - LINUX_IMMUTABLE
+      - MAC_ADMIN
+      - MAC_OVERRIDE
+      - NET_ADMIN
+      - NET_BROADCAST
+      - SYSLOG
+      - SYS_ADMIN
+      - SYS_BOOT
+      - SYS_MODULE
+      - SYS_NICE
+      - SYS_PACCT
+      - SYS_PTRACE
+      - SYS_RAWIO
+      - SYS_RESOURCE
+      - SYS_TIME
+      - SYS_TTY_CONFIG
+      - WAKE_ALARM
+    seccompProfile:
+      type: Unconfined
+    seLinuxOptions:
+      type: super_t

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/cloud-collector-deployment.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/cloud-collector-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-ebpf-cloud-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/cloud-collector-serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/cloud-collector-serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-ebpf-cloud-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-opentelemetry-ebpf-config
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-clusterrole.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-k8s-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-k8s-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-deployment.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-deployment.yaml
@@ -10,7 +10,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-ebpf-k8s-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"
@@ -30,7 +30,7 @@ spec:
       annotations:
         # This is here to allow us to do "zero-downtime" updates without an image change.
         rollingUpdateVersion: "1"
-        charts.flowmill.com/version: 0.1.4
+        charts.flowmill.com/version: 0.1.5
       labels:
         app.kubernetes.io/name: example-opentelemetry-ebpf-k8s-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/k8s-collector-serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-ebpf-k8s-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-clusterrole.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-kernel-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-kernel-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-daemonset.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-daemonset.yaml
@@ -9,7 +9,7 @@ kind: DaemonSet
 metadata:
   name: example-opentelemetry-ebpf-kernel-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        charts.flowmill.com/version: 0.1.4
+        charts.flowmill.com/version: 0.1.5
       labels:
         app.kubernetes.io/name: example-opentelemetry-ebpf-kernel-collector
         app.kubernetes.io/instance: example

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/kernel-collector-serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-ebpf-kernel-collector
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/reducer-deployment.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/reducer-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-opentelemetry-ebpf-reducer
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/reducer-service.yaml
+++ b/charts/opentelemetry-ebpf/examples/cloud-collector/rendered/reducer-service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-opentelemetry-ebpf-reducer
   labels:
-    helm.sh/chart: opentelemetry-ebpf-0.1.4
+    helm.sh/chart: opentelemetry-ebpf-0.1.5
     app.kubernetes.io/name: opentelemetry-ebpf
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.2"

--- a/charts/opentelemetry-ebpf/templates/kernel-collector-daemonset.yaml
+++ b/charts/opentelemetry-ebpf/templates/kernel-collector-daemonset.yaml
@@ -123,7 +123,11 @@ spec:
 {{ toYaml .Values.kernelCollector.resources | indent 12 }}
 {{- end }}
           securityContext:
+{{- if .Values.kernelCollector.securityContext }}
+{{ toYaml .Values.kernelCollector.securityContext | indent 12 }}
+{{- else }}
             privileged: true
+{{- end }}
           volumeMounts:
           - mountPath: /hostfs/
             name: host-root

--- a/charts/opentelemetry-ebpf/values.yaml
+++ b/charts/opentelemetry-ebpf/values.yaml
@@ -51,6 +51,7 @@ kernelCollector:
 
   affinity: {}
   resources: {}
+  securityContext: {}
 
   # uncomment the line below to disable automatic kernel headers fetching
   # fetchKernelHeaders: false


### PR DESCRIPTION
This allows for the kernel collector's default behavior to be overridden by someone who, hopefully, knows what they are doing with the security context.

Fixes #1365 