### PR TITLE
[opentelemetry-kube-stack]: Fix "Additional property selector is not allowed" error while adding selector label to service

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.2.2
+version: 0.2.3
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -189,7 +189,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.2
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.3

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.2.2
+    helm.sh/chart: opentelemetry-kube-stack-0.2.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.2.2
+              -l helm.sh/chart=opentelemetry-kube-stack-0.2.3

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -3444,6 +3444,16 @@
         "enabled": {
           "type": "boolean"
         },
+        "selector": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9-]+$": {
+              "type": "string",
+              "description": "Selector labels used to match the service to pods."
+            }
+          },
+          "description": "Labels to select pods for the service."
+        },
         "port": {
           "anyOf": [
             {


### PR DESCRIPTION
 This is to fix the following error and details are documented in this [issue](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1360)

```
\Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
opentelemetry-kube-stack:
- kubeScheduler.service: Additional property selector is not allowed

```