### PR TITLE
[kube-stack] Bump operator chart dependency version

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.lock
+++ b/charts/opentelemetry-kube-stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.71.0
+  version: 0.71.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.21.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.37.3
-digest: sha256:5a8307f7678a5dc41fa8624008409ff5bfd1e44029405175abc7101ceba097ac
-generated: "2024-10-14T11:29:46.485429354+02:00"
+digest: sha256:ff56967acb909bc46ee586a1034ab7f8969dec606a43c48989a5bad7e4791424
+generated: "2024-10-21T15:34:58.29871407+02:00"

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.3.2
+version: 0.3.3
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -23,7 +23,7 @@ dependencies:
     condition: crds.install
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.71.0
+    version: 0.71.1
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "5.21.*"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -189,7 +189,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.2
+              -l helm.sh/chart=opentelemetry-kube-stack-0.3.3

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -16,9 +16,9 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 10252
+      port: 10257
       protocol: TCP
-      targetPort: 10252
+      targetPort: 10257
   selector:
     component: kube-controller-manager
   type: ClusterIP

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
@@ -16,9 +16,9 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 10257
+      port: 10252
       protocol: TCP
-      targetPort: 10257
+      targetPort: 10252
   selector:
     component: kube-controller-manager
   type: ClusterIP

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -24,3 +24,7 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecureSkipVerify: true

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
@@ -24,7 +24,3 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    scheme: https
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -16,9 +16,9 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 10251
+      port: 10259
       protocol: TCP
-      targetPort: 10251
+      targetPort: 10259
   selector:
     component: kube-scheduler
   type: ClusterIP

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
@@ -16,9 +16,9 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 10259
+      port: 10251
       protocol: TCP
-      targetPort: 10259
+      targetPort: 10251
   selector:
     component: kube-scheduler
   type: ClusterIP

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -24,3 +24,7 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecureSkipVerify: true

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.2
+    helm.sh/chart: opentelemetry-kube-stack-0.3.3
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
@@ -24,7 +24,3 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    scheme: https
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.2
+              -l helm.sh/chart=opentelemetry-kube-stack-0.3.3

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.0
+    helm.sh/chart: opentelemetry-operator-0.71.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Bumps Operator's chart version released in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1391