### PR TITLE
docs: docs: adjust a description error in NOTES.txt file

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.71.2
+version: 0.71.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.2
+    helm.sh/chart: opentelemetry-operator-0.71.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -3,6 +3,6 @@
 {{ end }}
 
 {{ $.Chart.Name }} has been installed. Check its status by running:
-  kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ $.Release.Name }}"
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ $.Release.Name }}"
 
 Visit https://github.com/open-telemetry/opentelemetry-operator for instructions on how to create & configure OpenTelemetryCollector and Instrumentation custom resources by using the Operator.


### PR DESCRIPTION
previous：
```bash
kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ $.Release.Name }}"
```
now:
```bash
kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ $.Release.Name }}"
```
this will correctly list pods like blew：
```bash
$ kubectl --namespace opentelemetry-operator-system get pods -l "app.kubernetes.io/name=opentelemetry-operator"
NAME                                     READY   STATUS    RESTARTS   AGE
opentelemetry-operator-556cf4f79-8bqwd   2/2     Running   0          8m47s
```