### PR TITLE
[opentelemetry-operator] Update kube-rbac-proxy image to 0.18.1 to remediate vulnerabilities

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.71.1
+version: 0.71.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -76,7 +76,6 @@ spec:
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
             - --v=0
           image: "quay.io/brancz/kube-rbac-proxy:v0.18.1"
           name: kube-rbac-proxy

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -78,7 +78,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.18.1"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.71.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -134,7 +134,6 @@ spec:
         - args:
             - --secure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.ports.proxyPort }}
             - --upstream=http://127.0.0.1:{{ .Values.manager.ports.metricsPort }}/
-            - --logtostderr=true
             - --v=0
             {{-  if .Values.kubeRBACProxy.extraArgs  }}
             {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -192,7 +192,7 @@ kubeRBACProxy:
   enabled: true
   image:
     repository: quay.io/brancz/kube-rbac-proxy
-    tag: v0.15.0
+    tag: v0.18.1
   ports:
     proxyPort: 8443
   resources:


### PR DESCRIPTION
To close #1344 as the earlier PR #1345 didn't go through. Increasing the version to `0.18.1` which is the latest and fixes CVE-2024-28180 and GHSA-xr7q-jx4m-x55m as per their [release](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.18.1) on top of those fixed in the original proposed version of `0.18.0`.  