### PR TITLE
Add support for setting additional annotations on the CRDs

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.72.0
+version: 0.72.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
     controller-gen.kubebuilder.io/version: v0.16.1
+    {{- range $key, $value := .Values.crds.additionalAnnotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
     controller-gen.kubebuilder.io/version: v0.16.1
+    {{- range $key, $value := .Values.crds.additionalAnnotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
+    {{- range $key, $value := .Values.crds.additionalAnnotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: "keep"
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -1772,6 +1773,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: "keep"
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
@@ -11011,6 +11013,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: "keep"
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.72.0
+    helm.sh/chart: opentelemetry-operator-0.72.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/values.yaml
+++ b/charts/opentelemetry-operator/examples/default/values.yaml
@@ -1,3 +1,7 @@
 manager:
   collectorImage:
     repository: "otel/opentelemetry-collector-k8s"
+
+crds:
+  additionalAnnotations:
+    helm.sh/resource-policy: keep

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1694,6 +1694,14 @@
                     "examples": [
                         true
                     ]
+                },
+                "additionalAnnotations": {
+                  "type": "object",
+                  "default": {},
+                  "title": "The serviceAnnotations Schema",
+                  "required": [],
+                  "properties": {},
+                  "examples": [{}]
                 }
             },
             "examples": [{

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -295,6 +295,8 @@ admissionWebhooks:
 ## See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0560-to-0570 for more details.
 crds:
   create: true
+  # Add annotations to the CRDs
+  additionalAnnotations: {}
 
 ## Create the provided Roles and RoleBindings
 ##


### PR DESCRIPTION
This is especially useful since CRDs are now installed through templates. Because of this change that was introduced in 0.57.0, now running `helm uninstall` of the operator chart will delete the CRDs as well, which is a destructive operation.

The workaround is to leverage the special helm.sh/resource-policy=keep annotation, see https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource

One currently open issue though, is that the annotation needs to be set by Helm itself, see https://github.com/helm/helm/issues/10890 So running kubectl annotate on the CRDs as a post-install step doesn't work.