### PR TITLE
[operator] Allow PrometheusRule duration set

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.74.2
+version: 0.74.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -236,7 +236,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.2
+    helm.sh/chart: opentelemetry-operator-0.74.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-operator/templates/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
     rules:
     - alert: ReconcileErrors
       expr: rate(controller_runtime_reconcile_total{controller="opentelemetrycollector",result="error"}[5m]) > 0
-      for: 5m
+      for: {{ .Values.manager.prometheusRule.defaultRules.duration }}
       labels:
         severity: warning
         {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleLabels }}
@@ -38,7 +38,7 @@ spec:
         {{- end }}
     - alert: WorkqueueDepth
       expr: workqueue_depth{name="opentelemetrycollector"} > 0
-      for: 5m
+      for: {{ .Values.manager.prometheusRule.defaultRules.duration }}
       labels:
         severity: warning
         {{- with .Values.manager.prometheusRule.defaultRules.additionalRuleLabels }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -953,6 +953,14 @@
                                     "required": [],
                                     "properties": {},
                                     "examples": [{}]
+                                },
+                                "duration": {
+                                    "type": "string",
+                                    "default": {},
+                                    "title": "The prometheusRule duration to be considered firing",
+                                    "required": [],
+                                    "properties": {},
+                                    "examples": [{}]
                                 }
                             },
                             "examples": [{

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -142,6 +142,8 @@ manager:
       additionalRuleLabels: {}
       ## Additional annotations for PrometheusRule alerts
       additionalRuleAnnotations: {}
+      ## Alerts are considered firing once they have been returned for this long.
+      duration: 5m
     # additional labels on the PrometheusRule object
     extraLabels: {}
     # add annotations on the PrometheusRule object


### PR DESCRIPTION
Adding the `manager.prometheusRule.defaulRules.duration` value to allow change of the default `5m` default alerts duration.