### PR TITLE
fix: Configure feature gates appropriately

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.74.1
+version: 0.74.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -236,7 +236,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -34,7 +34,7 @@ spec:
             - --health-probe-addr=:8081
             - --webhook-port=9443
             - --collector-image=otel/opentelemetry-collector-k8s:0.113.0
-            - --feature-gates="operator.targetallocator.mtls=true"
+            - --feature-gates=operator.targetallocator.mtls
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.74.1
+    helm.sh/chart: opentelemetry-operator-0.74.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.113.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -162,7 +162,7 @@ The image to use for opentelemetry-operator.
         ,
     {{- end -}}
     {{- if $value -}}
-        {{- $key }}={{ $value }}
+        {{- $key }}
     {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -75,9 +75,9 @@ spec:
             - --auto-instrumentation-apache-httpd-image={{ .Values.manager.autoInstrumentationImage.apacheHttpd.repository }}:{{ .Values.manager.autoInstrumentationImage.apacheHttpd.tag }}
             {{- end }}
             {{- if .Values.manager.featureGatesMap }}
-            - --feature-gates={{ include "opentelemetry-operator.featureGatesMap" . | quote }}
+            - --feature-gates={{ include "opentelemetry-operator.featureGatesMap" . }}
             {{- else if ne .Values.manager.featureGates "" }}
-            - --feature-gates={{ .Values.manager.featureGates | quote }}
+            - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}


### PR DESCRIPTION
The operator does not like feature gates being quoted.

Feature gates are also a flag based on presence. If the flag is present, it is understood to be true, absence leaves the default value.