### PR TITLE
fix(collector): actually enable the deployment of PrometheusRule when using PodMonitor

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.109.0
+version: 0.109.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-collector/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheusRule.enabled .Values.serviceMonitor.enabled  }}
+{{- if and .Values.prometheusRule.enabled (or .Values.serviceMonitor.enabled .Values.podMonitor.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/opentelemetry-collector/templates/prometheusrule.yaml
+++ b/charts/opentelemetry-collector/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheusRule.enabled (or .Values.serviceMonitor.enabled .Values.podMonitor.enabled) }}
+{{- if and .Values.prometheusRule.enabled (eq (include "opentelemetry-collector.serviceEnabled" .) "true") (or .Values.serviceMonitor.enabled .Values.podMonitor.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
PrometheusRule was not being deployed because this logic was not in place. Tested a couple of iterations. Works well when PodMonitor is used with Deployment or Daemonset. Works well when ServiceMonitor is used with Deployment.

When you use ServiceMonitor with Daemonset you don't get a ServiceMonitor unless you specify `Values.service.enabled` == `true` (this is expected behavior, see https://github.com/crutonjohn/opentelemetry-helm-charts/blob/f7704926b88c97e4adbf4e9966d95a74f08facd2/charts/opentelemetry-collector/templates/_helpers.tpl#L131-L141) , but you will get the PrometheusRule regardless.

I implemented a fix for the regression i introduced, so that if you want to run a Daemonset and use a ServiceMonitor you will have to specify `Values.service.enabled` == `true` to get the ServiceMonitor and the PrometheusRule.

#1379