### PR TITLE
[demo] Remove duplicate envvar on frontendproxy

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.33.4
+version: 0.33.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -574,7 +574,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -654,7 +654,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -744,7 +744,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -810,7 +810,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -876,7 +876,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -991,7 +991,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1063,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1157,7 +1157,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1255,7 +1255,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1319,7 +1319,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1389,7 +1389,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1471,7 +1471,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1543,7 +1543,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1611,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1681,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1755,7 +1755,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1821,7 +1821,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1237,8 +1237,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1855,7 +1855,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -401,8 +401,6 @@ components:
         value: "4317"
       - name: OTEL_COLLECTOR_PORT_HTTP
         value: "4318"
-      - name: OTEL_SERVICE_NAME
-        value: frontend-proxy
     resources:
       limits:
         memory: 50Mi


### PR DESCRIPTION
OTEL_SERVICE_NAME envvar is set on all components as one of envvars listed in default.env, to the value of app.kubernetes.io/component label. Recently 51993de76504 ("Bump dependencies and fix grafana dashboards") duplicated OTEL_SERVICE_NAME on the frontendproxy deployment by setting it explicitly to frontend-proxy. A duplicated envvar causes an error when upgrading the opentelemetry-demo chart:

     Deployment.apps "opentelemetry-demo-frontendproxy" is invalid:
     spec.template.spec.containers[0].env[0].valueFrom: Invalid value: "": may
     not be specified when `value` is not empty

My understanding is that the duplicated envvar was introduced in #1422 as a follow-up to open-telemetry/opentelemetry-demo#1768 that introduced it in docker-compose setup of opentelemetry-demo? But I don't have context on why it was needed there.

cc @julianocosta89 @puckpuck as authors of the PRs.