### PR TITLE
Remove duplicated service name from frontend proxy

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.33.4
+version: 0.33.5
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -1241,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1305,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1375,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1455,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1525,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1591,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1659,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1731,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1795,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -1241,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1305,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1375,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1455,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1525,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1591,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1659,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1731,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1795,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -574,7 +574,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -654,7 +654,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -744,7 +744,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -810,7 +810,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -876,7 +876,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -991,7 +991,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1063,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1157,7 +1157,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,8 +1237,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
@@ -1257,7 +1255,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1321,7 +1319,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1391,7 +1389,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1473,7 +1471,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1545,7 +1543,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1613,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1683,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1757,7 +1755,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1823,7 +1821,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -1241,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1305,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1375,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1455,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1525,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1591,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1659,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1731,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1795,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -1241,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1305,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1375,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1455,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1525,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1591,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1659,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1731,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1795,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1221,8 +1221,6 @@ spec:
               value: "4317"
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
-            - name: OTEL_SERVICE_NAME
-              value: frontend-proxy
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -1241,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1305,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1375,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1455,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1525,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1591,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1659,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1731,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1795,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1857,7 +1855,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.4
+    helm.sh/chart: opentelemetry-demo-0.33.5
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -401,8 +401,6 @@ components:
         value: "4317"
       - name: OTEL_COLLECTOR_PORT_HTTP
         value: "4318"
-      - name: OTEL_SERVICE_NAME
-        value: frontend-proxy
     resources:
       limits:
         memory: 50Mi


### PR DESCRIPTION
I've wrongly added the env var `SERVICE_NAME` to the `frontendProxy` service in #1422.
The `SERVICE_NAME` is populated via default env var: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml#L5-L9.

This was reported by @lambdanis here: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1438

