### PR TITLE
[demo] fix flagdui otlp endpoint

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.109.0
+  version: 0.110.3
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 3.3.2
+  version: 3.3.3
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 25.30.1
+  version: 26.0.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 8.6.0
+  version: 8.6.4
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.27.0
-digest: sha256:67a465bbc85a180538a0acbf52d1e3e7f4ee2007bf487ff469595185f37d3a99
-generated: "2024-11-21T21:41:54.532988-05:00"
+  version: 2.27.1
+digest: sha256:2e2e8f2ccffb71336fe3ed52ed58577d3ea28ee13a0ca3dab44f27d311d559f5
+generated: "2024-12-04T09:22:35.686227+01:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.33.6
+version: 0.33.7
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -15,22 +15,22 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: "1.12.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.109.0
+    version: 0.110.3
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 3.3.2
+    version: 3.3.3
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 25.30.1
+    version: 26.0.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 8.6.0
+    version: 8.6.4
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: opensearch
-    version: 2.27.0
+    version: 2.27.1
     repository: https://opensearch-project.github.io/helm-charts
     condition: opensearch.enabled

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -945,7 +945,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -945,7 +945,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
     name: example-grafana

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,8 +22,10 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: grafana-8.6.4
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "11.3.1"
       annotations:
         checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -41,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.3.0"
+          image: "docker.io/grafana/grafana:11.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 data:
   relay: |
     connectors:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 spec:
   selector:
     matchLabels:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c785938d4e96434953505eb11fa7093a94e83a47f46c30d9ff98c9733498d4ab
+        checksum/config: b51c2bb1b47e24cdb0e7b7c4a480740892aacac3ec8fbff71f85eb0e3ac33861
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.113.0"
+          image: "otel/opentelemetry-collector-contrib:0.114.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
@@ -29,8 +29,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.55.1
-        helm.sh/chart: prometheus-25.30.1
+        app.kubernetes.io/version: v3.0.0
+        helm.sh/chart: prometheus-26.0.0
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.0.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -574,7 +574,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -654,7 +654,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -744,7 +744,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -810,7 +810,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -876,7 +876,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -957,7 +957,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
@@ -991,7 +991,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1063,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1157,7 +1157,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1255,7 +1255,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1319,7 +1319,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1389,7 +1389,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1471,7 +1471,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1543,7 +1543,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1611,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1681,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1755,7 +1755,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1821,7 +1821,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
     name: example-grafana

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,8 +22,10 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: grafana-8.6.4
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "11.3.1"
       annotations:
         checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -41,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.3.0"
+          image: "docker.io/grafana/grafana:11.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 data:
   relay: |
     connectors:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be50574d6269a13993685eacd8ea89c70541e50c581ad068de4220c68b707130
+        checksum/config: 3aee62980696aac5c68642d151740e3b06b0419b048c5c86f7b909ae633bcb55
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.113.0"
+          image: "otel/opentelemetry-collector-contrib:0.114.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
     component: standalone-collector
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
@@ -29,8 +29,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.55.1
-        helm.sh/chart: prometheus-25.30.1
+        app.kubernetes.io/version: v3.0.0
+        helm.sh/chart: prometheus-26.0.0
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.0.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -945,7 +945,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
     name: example-grafana

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,8 +22,10 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: grafana-8.6.4
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "11.3.1"
       annotations:
         checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -41,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.3.0"
+          image: "docker.io/grafana/grafana:11.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 data:
   relay: |
     connectors:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7bbac6c4b232e93365cd58d993c05e7111fb881c7813f0513b7c92be229a1bce
+        checksum/config: 62adfeddd71a96dc4b733857c6c6b1ca5ba8c9aae0e8464666dd8fce27f595cc
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.113.0"
+          image: "otel/opentelemetry-collector-contrib:0.114.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
     component: standalone-collector
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
@@ -29,8 +29,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.55.1
-        helm.sh/chart: prometheus-25.30.1
+        app.kubernetes.io/version: v3.0.0
+        helm.sh/chart: prometheus-26.0.0
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.0.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -945,7 +945,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
     name: example-grafana

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,8 +22,10 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: grafana-8.6.4
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "11.3.1"
       annotations:
         checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -41,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.3.0"
+          image: "docker.io/grafana/grafana:11.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 data:
   relay: |
     connectors:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: agent-collector
 spec:
   selector:
     matchLabels:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8e1daf8f7331bb092914be12680f624c980332b6f050cf12675b43b0063ccdf7
+        checksum/config: 0ff346b3f43d037338a5a4af050b6a5c80971391325d2ffd35e5db5769639621
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -44,7 +44,7 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          image: "otel/opentelemetry-collector-contrib:0.113.0"
+          image: "otel/opentelemetry-collector-contrib:0.114.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
@@ -29,8 +29,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.55.1
-        helm.sh/chart: prometheus-25.30.1
+        app.kubernetes.io/version: v3.0.0
+        helm.sh/chart: prometheus-26.0.0
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.0.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -945,7 +945,7 @@ spec:
             - name: FLAGD_METRICS_EXPORTER
               value: otel
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://$(OTEL_COLLECTOR_NAME):4317
+              value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1855,7 +1855,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
     name: example-grafana

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,8 +22,10 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: grafana-8.6.4
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "11.3.1"
       annotations:
         checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -41,7 +43,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.3.0"
+          image: "docker.io/grafana/grafana:11.3.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.6.0
+    helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.3.0"
+    app.kubernetes.io/version: "11.3.1"
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: jaeger-3.3.2
+    helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: otel-demo-opensearch-config
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -24,42 +24,42 @@ data:
     
     # Start OpenSearch Security Demo Configuration
     # WARNING: revise all the lines below before you go into production
-    plugins:
-      security:
-        ssl:
-          transport:
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-            enforce_hostname_verification: false
-          http:
-            enabled: true
-            pemcert_filepath: esnode.pem
-            pemkey_filepath: esnode-key.pem
-            pemtrustedcas_filepath: root-ca.pem
-        allow_unsafe_democertificates: true
-        allow_default_init_securityindex: true
-        authcz:
-          admin_dn:
-            - CN=kirk,OU=client,O=client,L=test,C=de
-        audit.type: internal_opensearch
-        enable_snapshot_restore_privilege: true
-        check_snapshot_restore_write_privileges: true
-        restapi:
-          roles_enabled: ["all_access", "security_rest_api_access"]
-        system_indices:
-          enabled: true
-          indices:
-            [
-              ".opendistro-alerting-config",
-              ".opendistro-alerting-alert*",
-              ".opendistro-anomaly-results*",
-              ".opendistro-anomaly-detector*",
-              ".opendistro-anomaly-checkpoints",
-              ".opendistro-anomaly-detection-state",
-              ".opendistro-reports-*",
-              ".opendistro-notifications-*",
-              ".opendistro-notebooks",
-              ".opendistro-asynchronous-search-response*",
-            ]
+    # plugins:
+    #   security:
+    #     ssl:
+    #       transport:
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #         enforce_hostname_verification: false
+    #       http:
+    #         enabled: true
+    #         pemcert_filepath: esnode.pem
+    #         pemkey_filepath: esnode-key.pem
+    #         pemtrustedcas_filepath: root-ca.pem
+    #     allow_unsafe_democertificates: true
+    #     allow_default_init_securityindex: true
+    #     authcz:
+    #       admin_dn:
+    #         - CN=kirk,OU=client,O=client,L=test,C=de
+    #     audit.type: internal_opensearch
+    #     enable_snapshot_restore_privilege: true
+    #     check_snapshot_restore_write_privileges: true
+    #     restapi:
+    #       roles_enabled: ["all_access", "security_rest_api_access"]
+    #     system_indices:
+    #       enabled: true
+    #       indices:
+    #         [
+    #           ".opendistro-alerting-config",
+    #           ".opendistro-alerting-alert*",
+    #           ".opendistro-anomaly-results*",
+    #           ".opendistro-anomaly-detector*",
+    #           ".opendistro-anomaly-checkpoints",
+    #           ".opendistro-anomaly-detection-state",
+    #           ".opendistro-reports-*",
+    #           ".opendistro-notifications-*",
+    #           ".opendistro-notebooks",
+    #           ".opendistro-asynchronous-search-response*",
+    #         ]
     ######## End OpenSearch Security Demo Configuration ########

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "otel-demo-opensearch-pdb"
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -35,7 +35,7 @@ apiVersion: v1
 metadata:
   name: otel-demo-opensearch-headless
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
   name: otel-demo-opensearch
   labels:
-    helm.sh/chart: opensearch-2.27.0
+    helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
@@ -27,14 +27,14 @@ spec:
     metadata:
       name: "otel-demo-opensearch"
       labels:
-        helm.sh/chart: opensearch-2.27.0
+        helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: otel-demo-opensearch
       annotations:
-        configchecksum: f0dfd912d048bdc1d51a184176aca84581d7706dce6e33250e13f38169ec49f
+        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
     spec:
       securityContext:
         fsGroup: 1000

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,12 +5,12 @@ kind: ClusterRole
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,12 +5,12 @@ kind: ClusterRoleBinding
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 data:
   relay: |
     connectors:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7bbac6c4b232e93365cd58d993c05e7111fb881c7813f0513b7c92be229a1bce
+        checksum/config: 62adfeddd71a96dc4b733857c6c6b1ca5ba8c9aae0e8464666dd8fce27f595cc
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.113.0"
+          image: "otel/opentelemetry-collector-contrib:0.114.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
     component: standalone-collector
 spec:
   rules:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -6,12 +6,12 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
-    
+    app.kubernetes.io/component: standalone-collector
     component: standalone-collector
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   name: example-otelcol
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.109.0
+    helm.sh/chart: opentelemetry-collector-0.110.3
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default
@@ -29,8 +29,8 @@ spec:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v2.55.1
-        helm.sh/chart: prometheus-25.30.1
+        app.kubernetes.io/version: v3.0.0
+        helm.sh/chart: prometheus-26.0.0
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v2.55.1"
+          image: "quay.io/prometheus/prometheus:v3.0.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: prometheus-25.30.1
+    app.kubernetes.io/version: v3.0.0
+    helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.6
+    helm.sh/chart: opentelemetry-demo-0.33.7
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -601,7 +601,7 @@ components:
           - name: FLAGD_METRICS_EXPORTER
             value: otel
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
+            value: http://$(OTEL_COLLECTOR_NAME):4318
         resources:
           limits:
             memory: 75Mi


### PR DESCRIPTION
Hello all, sorry about another PR fixing the endpoint, I should've seen it together with yesterday's PR 😓 

To avoid sending another one tomorrow I also bumped the dependencies in this one.

So this PR:

- Bumps charts dependencies versions
- Update the `OTEL_EXPORTER_OTLP_ENDPOINT` in `flagdui` service to `http://$(OTEL_COLLECTOR_NAME):4318`.