### PR TITLE
fix(opentelemetry-operator): remove default resource values

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.79.0
+version: 0.80.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,29 @@
 # Upgrade guidelines
 
+## 0.79.0 to 0.80.0
+
+Prior to 0.80.0, this chart included resource requests and limits for the OpenTelemetry Operator manager pod. These values were set to `100m` and `128Mi` respectively. In 0.78.0, these values have been removed from the chart. If you were relying on these values, you can set them in your `values.yaml` file. For example:
+
+```yaml
+manager:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+kubeRBACProxy:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 5m
+      memory: 64Mi
+```
+
 ## 0.74.0 to 0.74.1
 
 Prior to 0.72.1, feature gates could be enabled via the `manager.featureGates` property. As feature gates may require extra configuration to work properly, e.g. deploying extra permissions on the ClusterRole, the chart has been updated to make use of the `manager.featureGatesMap` property which allows the chart to smartly configure feature gates. If the `manager.featureGatesMap` property is set, the old `manager.featureGates` property will be ignored.

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -61,12 +61,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: 
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 64Mi
+            {}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
@@ -82,13 +77,6 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
       serviceAccountName: opentelemetry-operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -256,7 +256,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -274,7 +274,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -62,12 +62,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: 
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 64Mi
+            {}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
@@ -83,13 +78,6 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
       serviceAccountName: opentelemetry-operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.79.0
+    helm.sh/chart: opentelemetry-operator-0.80.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -8,7 +8,7 @@
 The 'manager.featureGates' value is deprecated. Please migrate to use the 'manager.featureGatesMap' value.
 {{ end }}
 
-{{- if not .Values.resources }}
+{{- if not .Values.manager.resources }}
 [WARNING] No resource limits or requests were set. Consider setter resource requests and limits via the `resources` field.
 {{ end }}
 

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -8,6 +8,10 @@
 The 'manager.featureGates' value is deprecated. Please migrate to use the 'manager.featureGatesMap' value.
 {{ end }}
 
+{{- if not .Values.resources }}
+[WARNING] No resource limits or requests were set. Consider setter resource requests and limits via the `resources` field.
+{{ end }}
+
 {{ $.Chart.Name }} has been installed. Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ $.Release.Name }}"
 

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -90,19 +90,22 @@ manager:
     metricsPort: 8080
     webhookPort: 9443
     healthzPort: 8081
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-      # ephemeral-storage: 50Mi
-    requests:
-      cpu: 100m
-      memory: 64Mi
-      # ephemeral-storage: 50Mi
+  resources: {}
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #     ephemeral-storage: 50Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 64Mi
+  #     ephemeral-storage: 50Mi
+
   ## Adds additional environment variables. This property will be deprecated. Please use extraEnvs instead.
   ## e.g ENV_VAR: env_value
   env:
     ENABLE_WEBHOOKS: "true"
+
 
   # Extra definitions of environment variables.
   extraEnvs: []
@@ -216,13 +219,14 @@ kubeRBACProxy:
     tag: v0.18.1
   ports:
     proxyPort: 8443
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 5m
-      memory: 64Mi
+  resources: {}
+  # resources:
+  #   limits:
+  #     cpu: 500m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 5m
+  #     memory: 64Mi
 
   ## List of additional cli arguments to configure the kube-rbac-proxy
   ## for example: --tls-cipher-suites, --tls-min-version, etc.


### PR DESCRIPTION
Having default values makes it impossible to remove the CPU limits since the default values will always be merged in with anything set by the user. Setting CPU limits are considered an anti pattern ref. https://komodor.com/learn/kubernetes-cpu-limits-throttling/