### PR TITLE
feat(opentelemetry-operator): Adding extraEnv

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.77.0
+version: 0.78.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -256,7 +256,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -274,7 +274,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.77.0
+    helm.sh/chart: opentelemetry-operator-0.78.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -84,13 +84,13 @@ spec:
             {{-  end  }}
           command:
             - /manager
-          {{- if or .Values.manager.env .Values.manager.extraEnv .Values.manager.createRbacPermissions }}
+          {{- if or .Values.manager.env .Values.manager.extraEnvs .Values.manager.createRbacPermissions }}
           env:
             {{- range $name, $value := .Values.manager.env }}
             - name: {{ $name }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- with .Values.manager.extraEnv }}
+            {{- with .Values.manager.extraEnvs }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
             {{- if .Values.manager.createRbacPermissions }}

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -84,13 +84,14 @@ spec:
             {{-  end  }}
           command:
             - /manager
-          {{- if or .Values.manager.env .Values.manager.createRbacPermissions }}
+          {{- if or .Values.manager.env .Values.manager.extraEnv .Values.manager.createRbacPermissions }}
           env:
-            {{- if .Values.manager.env }}
             {{- range $name, $value := .Values.manager.env }}
             - name: {{ $name }}
-              value: {{ $value | quote -}}
+              value: {{ $value | quote }}
             {{- end }}
+            {{- with .Values.manager.extraEnv }}
+              {{- . | toYaml | nindent 12 }}
             {{- end }}
             {{- if .Values.manager.createRbacPermissions }}
             - name: SERVICE_ACCOUNT_NAME

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -132,6 +132,7 @@
                 "featureGates",
                 "ports",
                 "env",
+                "extraEnv",
                 "serviceAccount",
                 "serviceMonitor",
                 "deploymentAnnotations",
@@ -718,6 +719,20 @@
                     },
                     "examples": [{
                         "ENABLE_WEBHOOKS": "true"
+                    }]
+                },
+                "extraEnv": {
+                    "type": "array",
+                    "default": [],
+                    "title": "Extra definitions of environment variables",
+                    "examples": [{
+                      "name": "GOMEMLIMIT",
+                      "valueFrom": {
+                        "resourceFieldRef": {
+                          "containerName": "manager",
+                          "resource": "limits.memory"
+                        }
+                      }
                     }]
                 },
                 "serviceAccount": {

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -132,7 +132,7 @@
                 "featureGates",
                 "ports",
                 "env",
-                "extraEnv",
+                "extraEnvs",
                 "serviceAccount",
                 "serviceMonitor",
                 "deploymentAnnotations",
@@ -721,7 +721,7 @@
                         "ENABLE_WEBHOOKS": "true"
                     }]
                 },
-                "extraEnv": {
+                "extraEnvs": {
                     "type": "array",
                     "default": [],
                     "title": "Extra definitions of environment variables",

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -104,6 +104,14 @@ manager:
   env:
     ENABLE_WEBHOOKS: "true"
 
+  # Extra definitions of environment variables.
+  extraEnv: []
+    # - name: GOMEMLIMIT
+    #   valueFrom:
+    #     resourceFieldRef:
+    #       containerName: manager
+    #       resource: limits.memory
+
   # -- Create the manager ServiceAccount
   serviceAccount:
     create: true

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -105,7 +105,7 @@ manager:
     ENABLE_WEBHOOKS: "true"
 
   # Extra definitions of environment variables.
-  extraEnv: []
+  extraEnvs: []
     # - name: GOMEMLIMIT
     #   valueFrom:
     #     resourceFieldRef:

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -99,7 +99,7 @@ manager:
       cpu: 100m
       memory: 64Mi
       # ephemeral-storage: 50Mi
-  ## Adds additional environment variables
+  ## Adds additional environment variables. This property will be deprecated. Please use extraEnvs instead.
   ## e.g ENV_VAR: env_value
   env:
     ENABLE_WEBHOOKS: "true"


### PR DESCRIPTION
This PR is adding the possibility to specify extra environment variable definitions that are not simple name/value pairs, for example when `valueFrom` should be used.