### PR TITLE
[collector] resolve YAML formatting issue with `additionalLabels`

### DIFF
--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -119,7 +119,9 @@ Create the name of the clusterRoleBinding to use
 
 {{- define "opentelemetry-collector.additionalLabels" -}}
 {{- if .Values.additionalLabels }}
-{{- tpl (.Values.additionalLabels | toYaml) . }}
+{{- range $key, $value := .Values.additionalLabels }}
+{{ $key }}: {{ $value }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
[This](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1432) change broke the way how [`additionalLabels`](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/11361d78da5495de24c681a016ebc9664bda57dd/charts/opentelemetry-collector/values.yaml#L333-L335) are formatted.

Given the following `values.yaml`:

```yaml
...
  additionalLabels:
    example: "test"
```

The output is:

```yaml
---
# Source: opentelemetry-collector/charts/opentelemetry-collector/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: opentelemetry-collector
  labels:
    helm.sh/chart: opentelemetry-collector-0.110.3
    app.kubernetes.io/name: opentelemetry-collector
    app.kubernetes.io/instance: opentelemetry-collector
    app.kubernetes.io/version: "0.114.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: agent-collectorexample: test             <------ HERE
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: opentelemetry-collector
subjects:
- kind: ServiceAccount
  name: opentelemetry-collector
  namespace: otel
Error: YAML parse error on opentelemetry-collector/charts/opentelemetry-collector/templates/clusterrole.yaml: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
helm.go:86: 2024-12-10 12:25:30.148781 +0100 CET m=+0.148933543 [debug] error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
```

```bash
$ yq '.dependencies[0]' Chart.yaml 
name: opentelemetry-collector
version: 0.110.3
repository: https://open-telemetry.github.io/opentelemetry-helm-charts
```

---

Confirmed the suggested fix works by monkey-patching both the affected (0.110.3) and the latest (0.110.5) version of the chart.