### PR TITLE
[demo] update prometheus otlp config

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.33.7
+version: 0.33.8
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
-            - --enable-feature=otlp-write-receiver
+            - --web.enable-otlp-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -574,7 +574,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -654,7 +654,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -744,7 +744,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -810,7 +810,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -876,7 +876,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -991,7 +991,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1063,7 +1063,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1157,7 +1157,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1255,7 +1255,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1319,7 +1319,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1389,7 +1389,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1471,7 +1471,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1543,7 +1543,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1611,7 +1611,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1681,7 +1681,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1755,7 +1755,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1821,7 +1821,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
-            - --enable-feature=otlp-write-receiver
+            - --web.enable-otlp-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
-            - --enable-feature=otlp-write-receiver
+            - --web.enable-otlp-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
-            - --enable-feature=otlp-write-receiver
+            - --web.enable-otlp-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: example-accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-accountingservice
     app.kubernetes.io/instance: example
@@ -502,7 +502,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-adservice
     app.kubernetes.io/instance: example
@@ -570,7 +570,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-cartservice
     app.kubernetes.io/instance: example
@@ -648,7 +648,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-checkoutservice
     app.kubernetes.io/instance: example
@@ -736,7 +736,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-currencyservice
     app.kubernetes.io/instance: example
@@ -800,7 +800,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-emailservice
     app.kubernetes.io/instance: example
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: example-flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-flagd
     app.kubernetes.io/instance: example
@@ -979,7 +979,7 @@ kind: Deployment
 metadata:
   name: example-frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1049,7 +1049,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontend
     app.kubernetes.io/instance: example
@@ -1141,7 +1141,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example
@@ -1239,7 +1239,7 @@ kind: Deployment
 metadata:
   name: example-imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-imageprovider
     app.kubernetes.io/instance: example
@@ -1303,7 +1303,7 @@ kind: Deployment
 metadata:
   name: example-kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-kafka
     app.kubernetes.io/instance: example
@@ -1373,7 +1373,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: example-valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-valkey
     app.kubernetes.io/instance: example
@@ -1855,7 +1855,7 @@ kind: Ingress
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example-frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=exemplar-storage
-            - --enable-feature=otlp-write-receiver
+            - --web.enable-otlp-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.33.7
+    helm.sh/chart: opentelemetry-demo-0.33.8
     
     opentelemetry.io/name: example
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -810,13 +810,35 @@ prometheus:
   server:
     extraFlags:
       - "enable-feature=exemplar-storage"
-      - "enable-feature=otlp-write-receiver"
+      - "web.enable-otlp-receiver"
     global:
       scrape_interval: 5s
       scrape_timeout: 3s
       evaluation_interval: 30s
     tsdb:
       out_of_order_time_window: 30m
+    prometheus.yml:
+      otlp:
+        keep_identifying_resource_attributes: true
+        # Recommended attributes to be promoted to labels.
+        promote_resource_attributes:
+          - service.instance.id
+          - service.name
+          - service.namespace
+          - cloud.availability_zone
+          - cloud.region
+          - container.name
+          - deployment.environment.name
+          - k8s.cluster.name
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.daemonset.name
+          - k8s.deployment.name
+          - k8s.job.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
     persistentVolume:
       enabled: false
     service:


### PR DESCRIPTION
Updates Prometheus config for OTLP based on this [guide](https://prometheus.io/docs/guides/opentelemetry/) provided in Prometheus docs.

Also fixes this [issue](https://github.com/open-telemetry/opentelemetry-demo/issues/1816) in the demo repo.