### PR TITLE
fix(operator): feature gates map allows add empty items

### DIFF
--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -154,15 +154,11 @@ The image to use for opentelemetry-operator.
 {{- end }}
 
 {{- define "opentelemetry-operator.featureGatesMap" -}}
-{{$first := true}}
-{{- range $key, $value := .Values.manager.featureGatesMap -}}
-    {{- if $first -}}
-        {{ $first = false }}
-    {{- else -}}
-        ,
-    {{- end -}}
-    {{- if $value -}}
-        {{- $key }}
-    {{- end -}}
+{{- $list := list -}}
+{{- range $k, $v := .Values.manager.featureGatesMap -}}
+{{- if $v -}}
+{{- $list = append $list (printf "%s=true" $k) -}}
 {{- end -}}
+{{- end -}}
+{{ join "," $list }}
 {{- end }}


### PR DESCRIPTION
When you have a feature flag with the value defined as `false`, the rendered string will contain a empty comma and this triggers a failure in the operator.

```yaml
manager:
  featureGatesMap:
    asdsadsa.adsads1: true
    asdsadsa.adsads2: false
    asdsadsa.adsads3: true
```

```txt
output:
- --feature-gates=asdsadsa.adsads1,,asdsadsa.adsads3
```

[An example in the Helm playground](LQhQFMA8EMFsAcA24BcACA3h4aB0A1aRAV3AGdcBLAF3FjLQB81qB7ATTkSbQDtLeAE3C9qaAExoAvlNCgsOYQDMB4NACJW8EbWSxw1AE4BPYFvCHobQ7iXgrxQ).
