### PR TITLE
Release operator 0.115.0

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.75.1
+version: 0.76.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -12,4 +12,4 @@ maintainers:
   - name: jaronoff97
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.114.1
+appVersion: 0.115.0

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -7914,6 +7914,58 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      probeSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      scrapeConfigSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       scrapeInterval:
                         default: 30s
                         format: duration

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -90,9 +90,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
@@ -9679,6 +9679,58 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      probeSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      scrapeConfigSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       scrapeInterval:
                         default: 30s
                         format: duration

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -222,9 +222,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -240,9 +240,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -33,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.114.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.115.1
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.114.1"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.115.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -90,9 +90,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
@@ -9679,6 +9679,58 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      probeSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      scrapeConfigSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       scrapeInterval:
                         default: 30s
                         format: duration

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook
@@ -29,9 +29,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -256,9 +256,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -274,9 +274,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -25,9 +25,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -33,14 +33,14 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.114.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.115.1
             - --feature-gates=operator.targetallocator.mtls
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.114.1"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.115.0"
           name: manager
           ports:
             - containerPort: 8080

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -31,9 +31,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -43,9 +43,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.75.1
+    helm.sh/chart: opentelemetry-operator-0.76.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.114.1"
+    app.kubernetes.io/version: "0.115.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -42,7 +42,7 @@ manager:
     tag: ""
   collectorImage:
     repository: ""
-    tag: 0.114.0
+    tag: 0.115.1
   opampBridgeImage:
     repository: ""
     tag: ""


### PR DESCRIPTION
We're behind on operator releases. 0.116.0 is out, and the helm chart is still at 0.114.1. Updating to 0.115.0 first, will follow up with 0.116.0.