### PR TITLE
[charts/opentelemetry-demo] Use helm namespace for service.namespace in default helm values

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -12,7 +12,7 @@ default:
     - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
       value: cumulative
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: 'service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version={{ .Chart.AppVersion }}'
+      value: 'service.name=$(OTEL_SERVICE_NAME),service.namespace={{ .Release.Namespace }},service.version={{ .Chart.AppVersion }}'
   # Allows overriding and additions to .Values.default.env
   envOverrides: []
   #  - name: OTEL_K8S_NODE_NAME


### PR DESCRIPTION
Currently, service.namespace always gets set to opentelemetry-demo.

This results in confusing metric labels when deploying the chart into a namespace that is not opentelemetry-demo. With this change, service.namespace will be set to the namespace the chart is deployed in.

Should I also bump the chart patch or minor version here? 