### PR TITLE
fix(opentelemetry-operator): ensure valid version label

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.78.0
+version: 0.78.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -256,7 +256,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -274,7 +274,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.78.0
+    helm.sh/chart: opentelemetry-operator-0.78.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.116.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -38,12 +38,20 @@ Create Operator version.
 {{- end }}
 
 {{/*
+Enforce valid label value.
+See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+*/}}
+{{- define "opentelemetry-operator.validLabelValue" -}}
+{{- (regexReplaceAllLiteral "[^a-zA-Z0-9._-]" . "-") | trunc 63 | trimSuffix "-" | trimSuffix "_" | trimSuffix "." }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "opentelemetry-operator.labels" -}}
 helm.sh/chart: {{ include "opentelemetry-operator.chart" . }}
 {{ include "opentelemetry-operator.selectorLabels" . }}
-app.kubernetes.io/version: {{ include "opentelemetry-operator.appVersion" . | quote }}
+app.kubernetes.io/version: {{ include "opentelemetry-operator.validLabelValue" (include "opentelemetry-operator.appVersion" .) | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.additionalLabels }}


### PR DESCRIPTION
To test:

```sh
helm template my-release charts/opentelemetry-operator/ \
  --set manager.collectorImage.repository=otel/opentelemetry-collector-contrib \
  --set manager.image.tag=v0.116.0@sha256:11edfad24ead5f48140eb12aea642a2716ca0cd9e63eae3851f39c4477f3c2c2 \
  | grep app.kubernetes.io/version
```

Bug introduced by https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1461.
See https://github.com/grafana/loki/pull/8260 for a similar fix.