### PR TITLE
[docs] Add note for scrape_configs_file to opentelemetry-kube-stack README

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.3.10
+version: 0.3.11
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -45,6 +45,9 @@ bridge.image.tag: 0.103.0
 
 ### scrape_configs_file Details
 
+> [!NOTE]
+> This parameter only works when running the helm chart locally. 
+
 By default, the daemonset collector will load in the daemon_scrape_configs.yaml file which collects prometheus metrics from applications on the same node that have the prometheus.io/scrape=true annotation, kubernetes node metrics, and cadvisor metrics. Users can disable this by settings collectors.daemon.scrape_configs_file: "" OR they can provide their own promethues scrape config file for the daemonset by supplying collectors.daemon.scrape_configs_file: "<your-file>.yaml"
 
 ## Prerequisites

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.10
+              -l helm.sh/chart=opentelemetry-kube-stack-0.3.11

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.10
+    helm.sh/chart: opentelemetry-kube-stack-0.3.11
     app.kubernetes.io/version: "0.107.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.10
+              -l helm.sh/chart=opentelemetry-kube-stack-0.3.11


### PR DESCRIPTION
Added a short note indicating that the `scrape_configs_file` parameter can only be used when running the `opentelemetry-kube-stack` chart locally.