### PR TITLE
fix: remove null creationTimestamp from CRDs to pass schema validation

### DIFF
--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opampbridges.opentelemetry.io

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opentelemetrycollectors.opentelemetry.io

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: instrumentations.opentelemetry.io

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opampbridges.opentelemetry.io
@@ -1772,7 +1771,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opentelemetrycollectors.opentelemetry.io
@@ -11070,7 +11068,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: instrumentations.opentelemetry.io

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opampbridges.opentelemetry.io
@@ -1772,7 +1771,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: opentelemetrycollectors.opentelemetry.io
@@ -11070,7 +11068,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: opentelemetry-operator
   name: instrumentations.opentelemetry.io


### PR DESCRIPTION
`creationTimestamp` would be generated. Setting null does not seem to provide any benefit. It does fail schema validation using tools like https://github.com/yannh/kubeconform. So, remove the field.