### PR TITLE
[kube-stack] Bump opentelemetry-operator from 0.71.1 to 0.79.0

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.lock
+++ b/charts/opentelemetry-kube-stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.71.1
+  version: 0.79.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.21.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.37.3
-digest: sha256:ff56967acb909bc46ee586a1034ab7f8969dec606a43c48989a5bad7e4791424
-generated: "2024-10-21T15:34:58.29871407+02:00"
+digest: sha256:e366f5ae17e63842b0e12e654c637fd6d68c7950f2e97ef5a6b23c007c70ae72
+generated: "2025-02-10T13:34:02.606198673+01:00"

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.3.12
+version: 0.4.0
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -16,14 +16,14 @@ maintainers:
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 # the appVersion stays aligned with the operator's latest version. If the collector has a patch
 # release, the collector's latest patch will be manually overridden.
-appVersion: 0.107.0
+appVersion: 0.117.0
 dependencies:
   - name: crds
     version: "0.0.0"
     condition: crds.install
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.71.1
+    version: 0.79.0
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "5.21.*"

--- a/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_instrumentations.yaml
+++ b/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_instrumentations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: instrumentations.opentelemetry.io
 spec:
   group: opentelemetry.io
@@ -215,6 +215,118 @@ spec:
                     type: object
                   version:
                     type: string
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
                   volumeLimitSize:
                     anyOf:
                     - type: integer
@@ -330,6 +442,118 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
                   volumeLimitSize:
                     anyOf:
                     - type: integer
@@ -409,13 +633,13 @@ spec:
                     type: string
                   tls:
                     properties:
-                      ca:
+                      ca_file:
                         type: string
-                      cert:
+                      cert_file:
                         type: string
                       configMapName:
                         type: string
-                      key:
+                      key_file:
                         type: string
                       secretName:
                         type: string
@@ -523,6 +747,118 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         type: object
+                    type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
                     type: object
                   volumeLimitSize:
                     anyOf:
@@ -645,6 +981,118 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         type: object
+                    type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
                     type: object
                   volumeLimitSize:
                     anyOf:
@@ -824,6 +1272,118 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
                   volumeLimitSize:
                     anyOf:
                     - type: integer
@@ -933,6 +1493,118 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         type: object
+                    type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
                     type: object
                   volumeLimitSize:
                     anyOf:
@@ -1056,6 +1728,118 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         type: object
+                    type: object
+                  volumeClaimTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    required:
+                    - spec
                     type: object
                   volumeLimitSize:
                     anyOf:

--- a/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_opampbridges.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: opampbridges.opentelemetry.io
 spec:
   group: opentelemetry.io

--- a/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/charts/opentelemetry-kube-stack/charts/crds/crds/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: opentelemetrycollectors.opentelemetry.io
 spec:
   group: opentelemetry.io
@@ -6949,6 +6949,13 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              persistentVolumeClaimRetentionPolicy:
+                properties:
+                  whenDeleted:
+                    type: string
+                  whenScaled:
+                    type: string
+                type: object
               podAnnotations:
                 additionalProperties:
                   type: string
@@ -7863,6 +7870,58 @@ spec:
                       enabled:
                         type: boolean
                       podMonitorSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      probeSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      scrapeConfigSelector:
                         properties:
                           matchExpressions:
                             items:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:
@@ -24,7 +24,7 @@ spec:
     ReportsRemoteConfig: true
     ReportsStatus: true
   replicas: 1
-  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.107.0"
+  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.117.0"
   upgradeStrategy: automatic
   securityContext:
     runAsNonRoot: true

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/clusterrole.yaml
@@ -24,6 +24,8 @@ rules:
   resources:
   - servicemonitors
   - podmonitors
+  - scrapeconfigs
+  - probes
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
     opentelemetry.io/opamp-reporting: "true"
@@ -188,7 +188,7 @@ metadata:
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
     opentelemetry.io/opamp-reporting: "true"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.12
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.0

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-mutation
 webhooks:
@@ -93,10 +92,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-validation
 webhooks:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-serving-cert
   namespace: default
@@ -32,10 +31,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-selfsigned-issuer
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 rules:
@@ -225,10 +224,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-metrics
 rules:
@@ -244,10 +242,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 rules:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 roleRef:
@@ -28,10 +27,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 roleRef:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -34,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.110.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.117.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.110.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.117.0"
           name: manager
           ports:
             - containerPort: 8080
@@ -76,9 +75,8 @@ spec:
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.18.1"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -34,10 +33,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-webhook
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -8,8 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test
@@ -46,10 +45,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/clusterrole.yaml
@@ -24,6 +24,8 @@ rules:
   resources:
   - servicemonitors
   - podmonitors
+  - scrapeconfigs
+  - probes
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
     otel-collector-type: daemonset-example    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-apiserver
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     helm.sh/chart: opentelemetry-kube-stack-0.3.12
-    app.kubernetes.io/version: "0.107.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.3.12
+    helm.sh/chart: opentelemetry-kube-stack-0.4.0
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.3.12
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.0

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-mutation
 webhooks:
@@ -93,10 +92,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-validation
 webhooks:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-serving-cert
   namespace: default
@@ -32,10 +31,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   name: example-opentelemetry-operator-selfsigned-issuer
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -223,7 +223,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -242,7 +242,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 rules:
@@ -225,10 +224,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-metrics
 rules:
@@ -244,10 +242,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 rules:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-manager
 roleRef:
@@ -28,10 +27,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-proxy
 roleRef:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -34,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.110.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.117.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.110.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.117.0"
           name: manager
           ports:
             - containerPort: 8080
@@ -76,9 +75,8 @@ spec:
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.18.1"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-leader-election
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator
   namespace: default
@@ -34,10 +33,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   name: example-opentelemetry-operator-webhook
   namespace: default

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -8,8 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: webhook
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.71.1
+    helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.110.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -8,10 +8,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test
@@ -46,10 +45,9 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.79.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: example
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test

--- a/charts/opentelemetry-kube-stack/templates/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/templates/clusterrole.yaml
@@ -24,6 +24,8 @@ rules:
   resources:
   - servicemonitors
   - podmonitors
+  - scrapeconfigs
+  - probes
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions


### PR DESCRIPTION
Updating the now very outdated operator 0.71.1 to 0.79.0, and bumping the kube-stack chart from 0.3.13 to 0.4.0 as a result.

Can somebody sanity check my CRD updates? Is there a breaking change requiring a larger version bump because of the instrumentations CRD?