### PR TITLE
[demo] remove release name prefix

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.34.1
+version: 0.35.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/UPGRADING.md
+++ b/charts/opentelemetry-demo/UPGRADING.md
@@ -5,6 +5,12 @@
 > another. If you need to upgrade the chart, you must first delete the existing
 > release and then install the new version.
 
+## To 0.35
+
+The Helm chart release name prefix has been removed from all resources. If you
+have any custom configuration that depend on the release name, you will need to
+update it accordingly.
+
 ## To 0.33
 
 The Helm prerequisite version has been updated to Helm 3.14+. Please upgrade your

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -477,7 +477,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -490,8 +490,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -500,14 +499,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -517,15 +516,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -549,7 +548,7 @@ spec:
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -568,14 +567,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -585,15 +584,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -619,9 +618,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -636,8 +635,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -646,14 +644,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -663,15 +661,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -695,21 +693,21 @@ spec:
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -724,8 +722,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -734,14 +731,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -751,15 +748,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -798,14 +795,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -815,15 +812,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -862,14 +859,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -879,15 +876,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -897,6 +894,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -921,7 +920,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -950,7 +949,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -970,21 +969,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -994,15 +993,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1020,9 +1019,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1037,8 +1036,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1047,14 +1045,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1064,15 +1062,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1098,21 +1096,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1139,14 +1137,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1156,15 +1154,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1188,31 +1186,31 @@ spec:
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1237,14 +1235,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1254,15 +1252,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1301,14 +1299,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1318,15 +1316,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1350,7 +1348,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1371,14 +1369,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1388,15 +1386,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1426,7 +1424,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1436,7 +1434,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1453,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1470,15 +1468,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1502,7 +1500,7 @@ spec:
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1523,14 +1521,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1540,15 +1538,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1572,7 +1570,7 @@ spec:
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1589,14 +1587,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1606,15 +1604,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1657,14 +1655,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1674,15 +1672,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1706,13 +1704,13 @@ spec:
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1729,14 +1727,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1746,15 +1744,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1778,7 +1776,7 @@ spec:
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1793,14 +1791,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1810,15 +1808,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1223,7 +1223,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -477,7 +477,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -490,8 +490,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -500,14 +499,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -517,15 +516,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -549,7 +548,7 @@ spec:
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -568,14 +567,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -585,15 +584,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -619,9 +618,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -636,8 +635,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -646,14 +644,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -663,15 +661,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -695,21 +693,21 @@ spec:
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -724,8 +722,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -734,14 +731,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -751,15 +748,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -798,14 +795,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -815,15 +812,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -862,14 +859,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -879,15 +876,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -897,6 +894,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -921,7 +920,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -950,7 +949,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -970,21 +969,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -994,15 +993,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1020,9 +1019,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1037,8 +1036,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1047,14 +1045,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1064,15 +1062,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1098,21 +1096,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1139,14 +1137,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1156,15 +1154,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1188,31 +1186,31 @@ spec:
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1237,14 +1235,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1254,15 +1252,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1301,14 +1299,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1318,15 +1316,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1350,7 +1348,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1371,14 +1369,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1388,15 +1386,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1426,7 +1424,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1436,7 +1434,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1453,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1470,15 +1468,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1502,7 +1500,7 @@ spec:
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1523,14 +1521,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1540,15 +1538,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1572,7 +1570,7 @@ spec:
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1589,14 +1587,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1606,15 +1604,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1657,14 +1655,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1674,15 +1672,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1706,13 +1704,13 @@ spec:
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1729,14 +1727,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1746,15 +1744,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1778,7 +1776,7 @@ spec:
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1793,14 +1791,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1810,15 +1808,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -1223,7 +1223,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana-dashboards
+  name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: example-grafana-clusterrolebinding
+  name: grafana-clusterrolebinding
   labels:
     helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
-    name: example-grafana
+    name: grafana
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -50,13 +50,13 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://example-prometheus-server:9090
+      url: http://prometheus-server:9090
     - editable: true
       isDefault: false
       name: Jaeger
       type: jaeger
       uid: webstore-traces
-      url: http://example-jaeger-query:16686/jaeger/ui
+      url: http://jaeger-query:16686/jaeger/ui
     - access: proxy
       editable: true
       isDefault: false
@@ -70,7 +70,7 @@ data:
         version: 2.18.0
       name: OpenSearch
       type: grafana-opensearch-datasource
-      url: http://otel-demo-opensearch:9200/
+      url: http://opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -27,13 +27,13 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
+        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
-      serviceAccountName: example-grafana
+      serviceAccountName: grafana
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
@@ -84,17 +84,17 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               valueFrom:
                 configMapKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
@@ -121,9 +121,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: example-grafana
+            name: grafana
         - name: dashboards-default
           configMap:
-            name: example-grafana-dashboards
+            name: grafana-dashboards
         - name: storage
           emptyDir: {}

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -13,8 +13,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-grafana
+  name: grafana
 subjects:
 - kind: ServiceAccount
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-agent
+  name: jaeger-agent
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-collector
+  name: jaeger-collector
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:
@@ -108,5 +108,5 @@ spec:
         fsGroup: 10001
         runAsGroup: 10001
         runAsUser: 10001
-      serviceAccountName: example-jaeger
+      serviceAccountName: jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-query
+  name: jaeger-query
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -14,8 +14,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-otelcol
+  name: otelcol
 subjects:
 - kind: ServiceAccount
-  name: example-otelcol
+  name: otelcol
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-otelcol-agent
+  name: otelcol-agent
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -20,16 +20,16 @@ data:
       debug: {}
       opensearch:
         http:
-          endpoint: http://otel-demo-opensearch:9200
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
         logs_index: otel
       otlp:
-        endpoint: 'example-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -81,7 +81,7 @@ data:
     receivers:
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+        - endpoint: http://frontendproxy:8080
       jaeger:
         protocols:
           grpc:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: example-otelcol-agent
+  name: otelcol-agent
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -15,7 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: example
       component: agent-collector
   updateStrategy:
@@ -23,18 +23,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b51c2bb1b47e24cdb0e7b7c4a480740892aacac3ec8fbff71f85eb0e3ac33861
+        checksum/config: 49145188d1b6b8656a00b28386fbf83d0db15e2b946864db5c71bb90c03414d5
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
         
     spec:
       
-      serviceAccountName: example-otelcol
+      serviceAccountName: otelcol
       securityContext:
         {}
       containers:
@@ -106,7 +106,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: example-otelcol-agent
+            name: otelcol-agent
             items:
               - key: relay
                 path: relay.yaml

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 subjects:
   - kind: ServiceAccount
-    name: example-prometheus-server
+    name: prometheus
     namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-prometheus-server
+  name: prometheus

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 data:
   allow-snippet-annotations: "false"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   selector:
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
-      serviceAccountName: example-prometheus-server
+      serviceAccountName: prometheus
       containers:
 
         - name: prometheus-server
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: example-prometheus-server
+            name: prometheus
         - name: storage-volume
           emptyDir:
             {}

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   ports:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
   annotations:
     {}

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1239,7 +1239,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -473,11 +473,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: TEAM_NAME
@@ -492,8 +492,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -502,14 +501,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -519,15 +518,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -545,13 +544,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -572,14 +571,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -589,15 +588,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -615,7 +614,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CART_SERVICE_PORT
@@ -623,9 +622,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -642,8 +641,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -652,14 +650,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -669,15 +667,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -695,27 +693,27 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -732,8 +730,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -742,14 +739,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -759,15 +756,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -785,7 +782,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CURRENCY_SERVICE_PORT
@@ -808,14 +805,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -825,15 +822,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -851,7 +848,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: EMAIL_SERVICE_PORT
@@ -874,14 +871,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -891,15 +888,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -909,6 +906,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -922,7 +921,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -933,7 +932,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -951,7 +950,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -962,7 +961,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME)
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -982,21 +981,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1006,15 +1005,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1028,13 +1027,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1051,8 +1050,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1061,14 +1059,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1078,15 +1076,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1104,7 +1102,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FRONTEND_PORT
@@ -1112,21 +1110,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1155,14 +1153,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1172,15 +1170,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1198,37 +1196,37 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1253,14 +1251,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1270,15 +1268,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1296,7 +1294,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: IMAGE_PROVIDER_PORT
@@ -1317,14 +1315,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1334,15 +1332,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1362,11 +1360,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1387,14 +1385,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1404,15 +1402,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1430,7 +1428,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: LOCUST_WEB_HOST
@@ -1442,7 +1440,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1452,7 +1450,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1471,14 +1469,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1488,15 +1486,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1514,13 +1512,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1543,14 +1541,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1560,15 +1558,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1586,13 +1584,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1611,14 +1609,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1628,15 +1626,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1654,7 +1652,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: QUOTE_SERVICE_PORT
@@ -1681,14 +1679,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1698,15 +1696,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1724,19 +1722,19 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1755,14 +1753,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1772,15 +1770,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1798,13 +1796,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: TEAM_NAME
@@ -1821,14 +1819,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1838,15 +1836,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:
@@ -1864,7 +1862,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana-dashboards
+  name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: example-grafana-clusterrolebinding
+  name: grafana-clusterrolebinding
   labels:
     helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
-    name: example-grafana
+    name: grafana
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -50,13 +50,13 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://example-prometheus-server:9090
+      url: http://prometheus-server:9090
     - editable: true
       isDefault: false
       name: Jaeger
       type: jaeger
       uid: webstore-traces
-      url: http://example-jaeger-query:16686/jaeger/ui
+      url: http://jaeger-query:16686/jaeger/ui
     - access: proxy
       editable: true
       isDefault: false
@@ -70,7 +70,7 @@ data:
         version: 2.18.0
       name: OpenSearch
       type: grafana-opensearch-datasource
-      url: http://otel-demo-opensearch:9200/
+      url: http://opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -27,13 +27,13 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
+        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
-      serviceAccountName: example-grafana
+      serviceAccountName: grafana
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
@@ -84,17 +84,17 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               valueFrom:
                 configMapKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
@@ -121,9 +121,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: example-grafana
+            name: grafana
         - name: dashboards-default
           configMap:
-            name: example-grafana-dashboards
+            name: grafana-dashboards
         - name: storage
           emptyDir: {}

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -13,8 +13,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-grafana
+  name: grafana
 subjects:
 - kind: ServiceAccount
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-agent
+  name: jaeger-agent
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-collector
+  name: jaeger-collector
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:
@@ -108,5 +108,5 @@ spec:
         fsGroup: 10001
         runAsGroup: 10001
         runAsUser: 10001
-      serviceAccountName: example-jaeger
+      serviceAccountName: jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-query
+  name: jaeger-query
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -14,8 +14,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-otelcol
+  name: otelcol
 subjects:
 - kind: ServiceAccount
-  name: example-otelcol
+  name: otelcol
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -20,16 +20,16 @@ data:
       debug: {}
       opensearch:
         http:
-          endpoint: http://otel-demo-opensearch:9200
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
         logs_index: otel
       otlp:
-        endpoint: 'example-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -88,7 +88,7 @@ data:
     receivers:
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+        - endpoint: http://frontendproxy:8080
       jaeger:
         protocols:
           grpc:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -17,7 +17,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: example
       component: standalone-collector
   strategy:
@@ -25,18 +25,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3aee62980696aac5c68642d151740e3b06b0419b048c5c86f7b909ae633bcb55
+        checksum/config: bbf9d60e3fb78dc8144e43eb3c9839dd67b68b2e377b8989c71e8f29e9a6c449
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
         
     spec:
       
-      serviceAccountName: example-otelcol
+      serviceAccountName: otelcol
       securityContext:
         {}
       containers:
@@ -98,7 +98,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: example-otelcol
+            name: otelcol
             items:
               - key: relay
                 path: relay.yaml

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -51,7 +51,7 @@ spec:
       targetPort: 9411
       protocol: TCP
   selector:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     component: standalone-collector
   internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 subjects:
   - kind: ServiceAccount
-    name: example-prometheus-server
+    name: prometheus
     namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-prometheus-server
+  name: prometheus

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 data:
   allow-snippet-annotations: "false"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   selector:
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
-      serviceAccountName: example-prometheus-server
+      serviceAccountName: prometheus
       containers:
 
         - name: prometheus-server
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: example-prometheus-server
+            name: prometheus
         - name: storage-volume
           emptyDir:
             {}

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   ports:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
   annotations:
     {}

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1223,7 +1223,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -473,11 +473,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -490,8 +490,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -500,14 +499,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -517,15 +516,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -543,13 +542,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -568,14 +567,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -585,15 +584,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -611,7 +610,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CART_SERVICE_PORT
@@ -619,9 +618,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -636,8 +635,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -646,14 +644,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -663,15 +661,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -689,27 +687,27 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -724,8 +722,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -734,14 +731,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -751,15 +748,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -777,7 +774,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CURRENCY_SERVICE_PORT
@@ -798,14 +795,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -815,15 +812,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -841,7 +838,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: EMAIL_SERVICE_PORT
@@ -862,14 +859,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -879,15 +876,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -897,6 +894,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -910,7 +909,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -921,7 +920,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -939,7 +938,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -950,7 +949,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -970,21 +969,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -994,15 +993,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1016,13 +1015,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1037,8 +1036,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1047,14 +1045,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1064,15 +1062,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1090,7 +1088,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FRONTEND_PORT
@@ -1098,21 +1096,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1139,14 +1137,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1156,15 +1154,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1182,37 +1180,37 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1237,14 +1235,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1254,15 +1252,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1280,7 +1278,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: IMAGE_PROVIDER_PORT
@@ -1301,14 +1299,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1318,15 +1316,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1346,11 +1344,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1371,14 +1369,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1388,15 +1386,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1414,7 +1412,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: LOCUST_WEB_HOST
@@ -1426,7 +1424,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1436,7 +1434,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1453,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1470,15 +1468,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1496,13 +1494,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1523,14 +1521,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1540,15 +1538,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1566,13 +1564,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1589,14 +1587,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1606,15 +1604,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1632,7 +1630,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: QUOTE_SERVICE_PORT
@@ -1657,14 +1655,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1674,15 +1672,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1700,19 +1698,19 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1729,14 +1727,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1746,15 +1744,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1772,13 +1770,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1793,14 +1791,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1810,15 +1808,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:
@@ -1836,7 +1834,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana-dashboards
+  name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: example-grafana-clusterrolebinding
+  name: grafana-clusterrolebinding
   labels:
     helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
-    name: example-grafana
+    name: grafana
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -50,13 +50,13 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://example-prometheus-server:9090
+      url: http://prometheus-server:9090
     - editable: true
       isDefault: false
       name: Jaeger
       type: jaeger
       uid: webstore-traces
-      url: http://example-jaeger-query:16686/jaeger/ui
+      url: http://jaeger-query:16686/jaeger/ui
     - access: proxy
       editable: true
       isDefault: false
@@ -70,7 +70,7 @@ data:
         version: 2.18.0
       name: OpenSearch
       type: grafana-opensearch-datasource
-      url: http://otel-demo-opensearch:9200/
+      url: http://opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -27,13 +27,13 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
+        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
-      serviceAccountName: example-grafana
+      serviceAccountName: grafana
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
@@ -84,17 +84,17 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               valueFrom:
                 configMapKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
@@ -121,9 +121,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: example-grafana
+            name: grafana
         - name: dashboards-default
           configMap:
-            name: example-grafana-dashboards
+            name: grafana-dashboards
         - name: storage
           emptyDir: {}

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -13,8 +13,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-grafana
+  name: grafana
 subjects:
 - kind: ServiceAccount
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-agent
+  name: jaeger-agent
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-collector
+  name: jaeger-collector
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:
@@ -108,5 +108,5 @@ spec:
         fsGroup: 10001
         runAsGroup: 10001
         runAsUser: 10001
-      serviceAccountName: example-jaeger
+      serviceAccountName: jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-query
+  name: jaeger-query
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -14,8 +14,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-otelcol
+  name: otelcol
 subjects:
 - kind: ServiceAccount
-  name: example-otelcol
+  name: otelcol
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -20,16 +20,16 @@ data:
       debug: {}
       opensearch:
         http:
-          endpoint: http://otel-demo-opensearch:9200
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
         logs_index: otel
       otlp:
-        endpoint: 'example-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -79,7 +79,7 @@ data:
     receivers:
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+        - endpoint: http://frontendproxy:8080
       jaeger:
         protocols:
           grpc:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -17,7 +17,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: example
       component: standalone-collector
   strategy:
@@ -25,18 +25,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 62adfeddd71a96dc4b733857c6c6b1ca5ba8c9aae0e8464666dd8fce27f595cc
+        checksum/config: 8d7f3109987e88eb44c7bd9e8f30ca3254e1267ea2d95031ecd8c8fd3bff21a0
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
         
     spec:
       
-      serviceAccountName: example-otelcol
+      serviceAccountName: otelcol
       securityContext:
         {}
       containers:
@@ -98,7 +98,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: example-otelcol
+            name: otelcol
             items:
               - key: relay
                 path: relay.yaml

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -51,7 +51,7 @@ spec:
       targetPort: 9411
       protocol: TCP
   selector:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     component: standalone-collector
   internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 subjects:
   - kind: ServiceAccount
-    name: example-prometheus-server
+    name: prometheus
     namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-prometheus-server
+  name: prometheus

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 data:
   allow-snippet-annotations: "false"

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   selector:
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
-      serviceAccountName: example-prometheus-server
+      serviceAccountName: prometheus
       containers:
 
         - name: prometheus-server
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: example-prometheus-server
+            name: prometheus
         - name: storage-volume
           emptyDir:
             {}

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   ports:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
   annotations:
     {}

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -1223,7 +1223,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -473,11 +473,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -490,8 +490,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -500,14 +499,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -517,15 +516,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -543,13 +542,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -568,14 +567,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -585,15 +584,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -611,7 +610,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CART_SERVICE_PORT
@@ -619,9 +618,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -636,8 +635,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -646,14 +644,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -663,15 +661,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -689,27 +687,27 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -724,8 +722,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -734,14 +731,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -751,15 +748,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -777,7 +774,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CURRENCY_SERVICE_PORT
@@ -798,14 +795,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -815,15 +812,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -841,7 +838,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: EMAIL_SERVICE_PORT
@@ -862,14 +859,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -879,15 +876,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -897,6 +894,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -910,7 +909,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -921,7 +920,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -939,7 +938,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -950,7 +949,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -970,21 +969,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -994,15 +993,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1016,13 +1015,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1037,8 +1036,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1047,14 +1045,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1064,15 +1062,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1090,7 +1088,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FRONTEND_PORT
@@ -1098,21 +1096,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1139,14 +1137,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1156,15 +1154,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1182,37 +1180,37 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1237,14 +1235,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1254,15 +1252,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1280,7 +1278,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: IMAGE_PROVIDER_PORT
@@ -1301,14 +1299,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1318,15 +1316,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1346,11 +1344,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1371,14 +1369,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1388,15 +1386,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1414,7 +1412,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: LOCUST_WEB_HOST
@@ -1426,7 +1424,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1436,7 +1434,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1453,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1470,15 +1468,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1496,13 +1494,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1523,14 +1521,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1540,15 +1538,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1566,13 +1564,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1589,14 +1587,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1606,15 +1604,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1632,7 +1630,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: QUOTE_SERVICE_PORT
@@ -1657,14 +1655,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1674,15 +1672,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1700,19 +1698,19 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1729,14 +1727,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1746,15 +1744,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1772,13 +1770,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1793,14 +1791,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1810,15 +1808,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:
@@ -1836,7 +1834,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana-dashboards
+  name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: example-grafana-clusterrolebinding
+  name: grafana-clusterrolebinding
   labels:
     helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
-    name: example-grafana
+    name: grafana
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -50,13 +50,13 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://example-prometheus-server:9090
+      url: http://prometheus-server:9090
     - editable: true
       isDefault: false
       name: Jaeger
       type: jaeger
       uid: webstore-traces
-      url: http://example-jaeger-query:16686/jaeger/ui
+      url: http://jaeger-query:16686/jaeger/ui
     - access: proxy
       editable: true
       isDefault: false
@@ -70,7 +70,7 @@ data:
         version: 2.18.0
       name: OpenSearch
       type: grafana-opensearch-datasource
-      url: http://otel-demo-opensearch:9200/
+      url: http://opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -27,13 +27,13 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
+        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
-      serviceAccountName: example-grafana
+      serviceAccountName: grafana
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
@@ -84,17 +84,17 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               valueFrom:
                 configMapKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
@@ -121,9 +121,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: example-grafana
+            name: grafana
         - name: dashboards-default
           configMap:
-            name: example-grafana-dashboards
+            name: grafana-dashboards
         - name: storage
           emptyDir: {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -13,8 +13,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-grafana
+  name: grafana
 subjects:
 - kind: ServiceAccount
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-agent
+  name: jaeger-agent
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-collector
+  name: jaeger-collector
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:
@@ -108,5 +108,5 @@ spec:
         fsGroup: 10001
         runAsGroup: 10001
         runAsUser: 10001
-      serviceAccountName: example-jaeger
+      serviceAccountName: jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-query
+  name: jaeger-query
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -14,8 +14,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-otelcol
+  name: otelcol
 subjects:
 - kind: ServiceAccount
-  name: example-otelcol
+  name: otelcol
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-otelcol-agent
+  name: otelcol-agent
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -20,16 +20,16 @@ data:
       debug: {}
       opensearch:
         http:
-          endpoint: http://otel-demo-opensearch:9200
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
         logs_index: otel
       otlp:
-        endpoint: 'example-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -83,7 +83,7 @@ data:
     receivers:
       filelog:
         exclude:
-        - /var/log/pods/default_example-otelcol*_*/opentelemetry-collector/*.log
+        - /var/log/pods/default_otelcol*_*/opentelemetry-collector/*.log
         include:
         - /var/log/pods/*/*/*.log
         include_file_name: false
@@ -144,7 +144,7 @@ data:
           network: null
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+        - endpoint: http://frontendproxy:8080
       jaeger:
         protocols:
           grpc:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: example-otelcol-agent
+  name: otelcol-agent
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -15,7 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: example
       component: agent-collector
   updateStrategy:
@@ -23,18 +23,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0ff346b3f43d037338a5a4af050b6a5c80971391325d2ffd35e5db5769639621
+        checksum/config: 997e0efc1156c6015af86fb873c64cde1338cf9f8f64a718088b5efec750192d
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: agent-collector
         
     spec:
       
-      serviceAccountName: example-otelcol
+      serviceAccountName: otelcol
       securityContext:
         {}
       containers:
@@ -119,7 +119,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: example-otelcol-agent
+            name: otelcol-agent
             items:
               - key: relay
                 path: relay.yaml

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 subjects:
   - kind: ServiceAccount
-    name: example-prometheus-server
+    name: prometheus
     namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-prometheus-server
+  name: prometheus

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 data:
   allow-snippet-annotations: "false"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   selector:
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
-      serviceAccountName: example-prometheus-server
+      serviceAccountName: prometheus
       containers:
 
         - name: prometheus-server
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: example-prometheus-server
+            name: prometheus
         - name: storage-volume
           emptyDir:
             {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   ports:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
   annotations:
     {}

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -22,20 +22,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -47,20 +47,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -72,20 +72,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -97,20 +97,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -122,20 +122,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -150,20 +150,20 @@ spec:
       targetPort: 4000
   selector:
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -175,20 +175,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -200,20 +200,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -225,20 +225,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -253,20 +253,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -278,20 +278,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -303,20 +303,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -328,20 +328,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -353,20 +353,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -378,20 +378,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -403,20 +403,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -428,20 +428,20 @@ spec:
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-accountingservice
+  name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-accountingservice
+    opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: example-accountingservice
+    app.kubernetes.io/name: accountingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -451,15 +451,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-accountingservice
+      opentelemetry.io/name: accountingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-accountingservice
+        opentelemetry.io/name: accountingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: example-accountingservice
+        app.kubernetes.io/name: accountingservice
     spec:
       serviceAccountName: example
       containers:
@@ -473,11 +473,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -490,8 +490,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -500,14 +499,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-adservice
+  name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-adservice
+    opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: example-adservice
+    app.kubernetes.io/name: adservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -517,15 +516,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-adservice
+      opentelemetry.io/name: adservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-adservice
+        opentelemetry.io/name: adservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: example-adservice
+        app.kubernetes.io/name: adservice
     spec:
       serviceAccountName: example
       containers:
@@ -543,13 +542,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: AD_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -568,14 +567,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-cartservice
+  name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-cartservice
+    opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: example-cartservice
+    app.kubernetes.io/name: cartservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -585,15 +584,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-cartservice
+      opentelemetry.io/name: cartservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-cartservice
+        opentelemetry.io/name: cartservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: example-cartservice
+        app.kubernetes.io/name: cartservice
     spec:
       serviceAccountName: example
       containers:
@@ -611,7 +610,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CART_SERVICE_PORT
@@ -619,9 +618,9 @@ spec:
             - name: ASPNETCORE_URLS
               value: http://*:$(CART_SERVICE_PORT)
             - name: VALKEY_ADDR
-              value: 'example-valkey:6379'
+              value: valkey:6379
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -636,8 +635,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;
           image: busybox:latest
           name: wait-for-valkey
       volumes:
@@ -646,14 +644,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-checkoutservice
+  name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-checkoutservice
+    opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: example-checkoutservice
+    app.kubernetes.io/name: checkoutservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -663,15 +661,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-checkoutservice
+      opentelemetry.io/name: checkoutservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-checkoutservice
+        opentelemetry.io/name: checkoutservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: example-checkoutservice
+        app.kubernetes.io/name: checkoutservice
     spec:
       serviceAccountName: example
       containers:
@@ -689,27 +687,27 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CHECKOUT_SERVICE_PORT
               value: "8080"
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: EMAIL_SERVICE_ADDR
-              value: http://example-emailservice:8080
+              value: http://emailservice:8080
             - name: PAYMENT_SERVICE_ADDR
-              value: 'example-paymentservice:8080'
+              value: paymentservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -724,8 +722,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -734,14 +731,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-currencyservice
+  name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-currencyservice
+    opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: example-currencyservice
+    app.kubernetes.io/name: currencyservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -751,15 +748,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-currencyservice
+      opentelemetry.io/name: currencyservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-currencyservice
+        opentelemetry.io/name: currencyservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: example-currencyservice
+        app.kubernetes.io/name: currencyservice
     spec:
       serviceAccountName: example
       containers:
@@ -777,7 +774,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: CURRENCY_SERVICE_PORT
@@ -798,14 +795,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-emailservice
+  name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-emailservice
+    opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: example-emailservice
+    app.kubernetes.io/name: emailservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -815,15 +812,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-emailservice
+      opentelemetry.io/name: emailservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-emailservice
+        opentelemetry.io/name: emailservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: example-emailservice
+        app.kubernetes.io/name: emailservice
     spec:
       serviceAccountName: example
       containers:
@@ -841,7 +838,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: EMAIL_SERVICE_PORT
@@ -862,14 +859,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-flagd
+  name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-flagd
+    opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: example-flagd
+    app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -879,15 +876,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-flagd
+        opentelemetry.io/name: flagd
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: example-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: example
       containers:
@@ -897,6 +894,8 @@ spec:
           command:
             - /flagd-build
             - start
+            - --port
+            - "8013"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
@@ -910,7 +909,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -921,7 +920,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - name: config-rw
               mountPath: /etc/flagd
@@ -939,7 +938,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FLAGD_METRICS_EXPORTER
@@ -950,7 +949,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 75Mi
+              memory: 100Mi
           volumeMounts:
             - mountPath: /app/data
               name: config-rw
@@ -970,21 +969,21 @@ spec:
         - name: config-rw
           emptyDir: {}
         - configMap:
-            name: 'example-flagd-config'
+            name: flagd-config
           name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frauddetectionservice
+  name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frauddetectionservice
+    opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: example-frauddetectionservice
+    app.kubernetes.io/name: frauddetectionservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -994,15 +993,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frauddetectionservice
+      opentelemetry.io/name: frauddetectionservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frauddetectionservice
+        opentelemetry.io/name: frauddetectionservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: example-frauddetectionservice
+        app.kubernetes.io/name: frauddetectionservice
     spec:
       serviceAccountName: example
       containers:
@@ -1016,13 +1015,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_SERVICE_ADDR
-              value: 'example-kafka:9092'
+              value: kafka:9092
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1037,8 +1036,7 @@ spec:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 example-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
       volumes:
@@ -1047,14 +1045,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontend
+  name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontend
+    opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: example-frontend
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1064,15 +1062,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontend
+      opentelemetry.io/name: frontend
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontend
+        opentelemetry.io/name: frontend
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: example-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: example
       containers:
@@ -1090,7 +1088,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: FRONTEND_PORT
@@ -1098,21 +1096,21 @@ spec:
             - name: FRONTEND_ADDR
               value: :8080
             - name: AD_SERVICE_ADDR
-              value: 'example-adservice:8080'
+              value: adservice:8080
             - name: CART_SERVICE_ADDR
-              value: 'example-cartservice:8080'
+              value: cartservice:8080
             - name: CHECKOUT_SERVICE_ADDR
-              value: 'example-checkoutservice:8080'
+              value: checkoutservice:8080
             - name: CURRENCY_SERVICE_ADDR
-              value: 'example-currencyservice:8080'
+              value: currencyservice:8080
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: RECOMMENDATION_SERVICE_ADDR
-              value: 'example-recommendationservice:8080'
+              value: recommendationservice:8080
             - name: SHIPPING_SERVICE_ADDR
-              value: 'example-shippingservice:8080'
+              value: shippingservice:8080
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_COLLECTOR_HOST
@@ -1139,14 +1137,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1156,15 +1154,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-frontendproxy
+      opentelemetry.io/name: frontendproxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-frontendproxy
+        opentelemetry.io/name: frontendproxy
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: example-frontendproxy
+        app.kubernetes.io/name: frontendproxy
     spec:
       serviceAccountName: example
       containers:
@@ -1182,37 +1180,37 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: ENVOY_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: FLAGD_UI_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_UI_PORT
               value: "4000"
             - name: FRONTEND_HOST
-              value: 'example-frontend'
+              value: frontend
             - name: FRONTEND_PORT
               value: "8080"
             - name: GRAFANA_SERVICE_HOST
-              value: 'example-grafana'
+              value: grafana
             - name: GRAFANA_SERVICE_PORT
               value: "80"
             - name: IMAGE_PROVIDER_HOST
-              value: 'example-imageprovider'
+              value: imageprovider
             - name: IMAGE_PROVIDER_PORT
               value: "8081"
             - name: JAEGER_SERVICE_HOST
-              value: 'example-jaeger-query'
+              value: jaeger-query
             - name: JAEGER_SERVICE_PORT
               value: "16686"
             - name: LOCUST_WEB_HOST
-              value: 'example-loadgenerator'
+              value: loadgenerator
             - name: LOCUST_WEB_PORT
               value: "8089"
             - name: OTEL_COLLECTOR_HOST
@@ -1237,14 +1235,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-imageprovider
+  name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-imageprovider
+    opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: example-imageprovider
+    app.kubernetes.io/name: imageprovider
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1254,15 +1252,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-imageprovider
+      opentelemetry.io/name: imageprovider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-imageprovider
+        opentelemetry.io/name: imageprovider
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: example-imageprovider
+        app.kubernetes.io/name: imageprovider
     spec:
       serviceAccountName: example
       containers:
@@ -1280,7 +1278,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: IMAGE_PROVIDER_PORT
@@ -1301,14 +1299,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-kafka
+  name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-kafka
+    opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: example-kafka
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1318,15 +1316,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-kafka
+        opentelemetry.io/name: kafka
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: example-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: example
       containers:
@@ -1346,11 +1344,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: PLAINTEXT://example-kafka:9092
+              value: PLAINTEXT://kafka:9092
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: KAFKA_HEAP_OPTS
@@ -1371,14 +1369,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-loadgenerator
+  name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-loadgenerator
+    opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: example-loadgenerator
+    app.kubernetes.io/name: loadgenerator
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1388,15 +1386,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-loadgenerator
+      opentelemetry.io/name: loadgenerator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-loadgenerator
+        opentelemetry.io/name: loadgenerator
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: example-loadgenerator
+        app.kubernetes.io/name: loadgenerator
     spec:
       serviceAccountName: example
       containers:
@@ -1414,7 +1412,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: LOCUST_WEB_HOST
@@ -1426,7 +1424,7 @@ spec:
             - name: LOCUST_SPAWN_RATE
               value: "1"
             - name: LOCUST_HOST
-              value: http://example-frontendproxy:8080
+              value: http://frontendproxy:8080
             - name: LOCUST_HEADLESS
               value: "false"
             - name: LOCUST_AUTOSTART
@@ -1436,7 +1434,7 @@ spec:
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1453,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-paymentservice
+  name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-paymentservice
+    opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: example-paymentservice
+    app.kubernetes.io/name: paymentservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1470,15 +1468,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-paymentservice
+      opentelemetry.io/name: paymentservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-paymentservice
+        opentelemetry.io/name: paymentservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: example-paymentservice
+        app.kubernetes.io/name: paymentservice
     spec:
       serviceAccountName: example
       containers:
@@ -1496,13 +1494,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PAYMENT_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1523,14 +1521,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-productcatalogservice
+  name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-productcatalogservice
+    opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: example-productcatalogservice
+    app.kubernetes.io/name: productcatalogservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1540,15 +1538,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-productcatalogservice
+      opentelemetry.io/name: productcatalogservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-productcatalogservice
+        opentelemetry.io/name: productcatalogservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: example-productcatalogservice
+        app.kubernetes.io/name: productcatalogservice
     spec:
       serviceAccountName: example
       containers:
@@ -1566,13 +1564,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: PRODUCT_CATALOG_SERVICE_PORT
               value: "8080"
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1589,14 +1587,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-quoteservice
+  name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-quoteservice
+    opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: example-quoteservice
+    app.kubernetes.io/name: quoteservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1606,15 +1604,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-quoteservice
+      opentelemetry.io/name: quoteservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-quoteservice
+        opentelemetry.io/name: quoteservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: example-quoteservice
+        app.kubernetes.io/name: quoteservice
     spec:
       serviceAccountName: example
       containers:
@@ -1632,7 +1630,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: QUOTE_SERVICE_PORT
@@ -1657,14 +1655,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-recommendationservice
+  name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-recommendationservice
+    opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: example-recommendationservice
+    app.kubernetes.io/name: recommendationservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1674,15 +1672,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-recommendationservice
+      opentelemetry.io/name: recommendationservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-recommendationservice
+        opentelemetry.io/name: recommendationservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: example-recommendationservice
+        app.kubernetes.io/name: recommendationservice
     spec:
       serviceAccountName: example
       containers:
@@ -1700,19 +1698,19 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: RECOMMENDATION_SERVICE_PORT
               value: "8080"
             - name: PRODUCT_CATALOG_SERVICE_ADDR
-              value: 'example-productcatalogservice:8080'
+              value: productcatalogservice:8080
             - name: OTEL_PYTHON_LOG_CORRELATION
               value: "true"
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
             - name: FLAGD_HOST
-              value: 'example-flagd'
+              value: flagd
             - name: FLAGD_PORT
               value: "8013"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -1729,14 +1727,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-shippingservice
+  name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-shippingservice
+    opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: example-shippingservice
+    app.kubernetes.io/name: shippingservice
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1746,15 +1744,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-shippingservice
+      opentelemetry.io/name: shippingservice
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-shippingservice
+        opentelemetry.io/name: shippingservice
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: example-shippingservice
+        app.kubernetes.io/name: shippingservice
     spec:
       serviceAccountName: example
       containers:
@@ -1772,13 +1770,13 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: SHIPPING_SERVICE_PORT
               value: "8080"
             - name: QUOTE_SERVICE_ADDR
-              value: http://example-quoteservice:8080
+              value: http://quoteservice:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1793,14 +1791,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-valkey
+  name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-valkey
+    opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: example-valkey
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1810,15 +1808,15 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: example-valkey
+      opentelemetry.io/name: valkey
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: example-valkey
+        opentelemetry.io/name: valkey
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: example-valkey
+        app.kubernetes.io/name: valkey
     spec:
       serviceAccountName: example
       containers:
@@ -1836,7 +1834,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: OTEL_COLLECTOR_NAME
-              value: 'example-otelcol'
+              value: otelcol
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1855,14 +1853,14 @@ spec:
 apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
-  name: example-frontendproxy
+  name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example-frontendproxy
+    opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: example-frontendproxy
+    app.kubernetes.io/name: frontendproxy
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
@@ -1875,6 +1873,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: example-frontendproxy
+                name: frontendproxy
                 port:
                   number: 8080

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1223,7 +1223,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.12.0
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-flagd-config
+  name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana-dashboards
+  name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: example-grafana-clusterrolebinding
+  name: grafana-clusterrolebinding
   labels:
     helm.sh/chart: grafana-8.6.4
     app.kubernetes.io/name: grafana
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/version: "11.3.1"
 subjects:
   - kind: ServiceAccount
-    name: example-grafana
+    name: grafana
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: example-grafana-clusterrole
+  name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -50,13 +50,13 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://example-prometheus-server:9090
+      url: http://prometheus-server:9090
     - editable: true
       isDefault: false
       name: Jaeger
       type: jaeger
       uid: webstore-traces
-      url: http://example-jaeger-query:16686/jaeger/ui
+      url: http://jaeger-query:16686/jaeger/ui
     - access: proxy
       editable: true
       isDefault: false
@@ -70,7 +70,7 @@ data:
         version: 2.18.0
       name: OpenSearch
       type: grafana-opensearch-datasource
-      url: http://otel-demo-opensearch:9200/
+      url: http://opensearch:9200/
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -27,13 +27,13 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: a9f5a2b89c48190fe92c675736096573a2f0a3b5b3b9d4011a086412bf2bed80
+        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana
     spec:
       
-      serviceAccountName: example-grafana
+      serviceAccountName: grafana
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 472
@@ -84,17 +84,17 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-user
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: admin-password
             - name: GF_INSTALL_PLUGINS
               valueFrom:
                 configMapKeyRef:
-                  name: example-grafana
+                  name: grafana
                   key: plugins
             - name: GF_PATHS_DATA
               value: /var/lib/grafana/
@@ -121,9 +121,9 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: example-grafana
+            name: grafana
         - name: dashboards-default
           configMap:
-            name: example-grafana-dashboards
+            name: grafana-dashboards
         - name: storage
           emptyDir: {}

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4
@@ -13,8 +13,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-grafana
+  name: grafana
 subjects:
 - kind: ServiceAccount
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grafana
+  name: grafana
   namespace: default
   labels:
     helm.sh/chart: grafana-8.6.4

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "11.3.1"
-  name: example-grafana
+  name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-agent
+  name: jaeger-agent
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-collector
+  name: jaeger-collector
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://example-prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus-server:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:
@@ -108,5 +108,5 @@ spec:
         fsGroup: 10001
         runAsGroup: 10001
         runAsUser: 10001
-      serviceAccountName: example-jaeger
+      serviceAccountName: jaeger
       volumes:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-jaeger-query
+  name: jaeger-query
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-jaeger
+  name: jaeger
   labels:
     helm.sh/chart: jaeger-3.3.3
     app.kubernetes.io/name: jaeger

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/configmap.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: otel-demo-opensearch-config
+  name: opensearch-config
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 data:
   opensearch.yml: |
     cluster.name: opensearch-cluster

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/poddisruptionbudget.yaml
@@ -3,14 +3,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: "otel-demo-opensearch-pdb"
+  name: "opensearch-pdb"
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/service.yaml
@@ -3,14 +3,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     {}
 spec:
@@ -33,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: otel-demo-opensearch-headless
+  name: opensearch-headless
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opensearch/statefulset.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: otel-demo-opensearch
+  name: opensearch
   labels:
     helm.sh/chart: opensearch-2.27.1
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.18.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: otel-demo-opensearch
+    app.kubernetes.io/component: opensearch
   annotations:
     majorVersion: "2"
 spec:
-  serviceName: otel-demo-opensearch-headless
+  serviceName: opensearch-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: opensearch
@@ -25,16 +25,16 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: "otel-demo-opensearch"
+      name: "opensearch"
       labels:
         helm.sh/chart: opensearch-2.27.1
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "2.18.0"
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: otel-demo-opensearch
+        app.kubernetes.io/component: opensearch
       annotations:
-        configchecksum: 3fd357b077f0655ef353bece2513c5d5d810ec973c73d57851f6e159ba5be35
+        configchecksum: b23ba60d53c720b607e696c19c1e7779ed1e5131c7b4648d12e0693db63f97e
     spec:
       securityContext:
         fsGroup: 1000
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: otel-demo-opensearch-config
+          name: opensearch-config
       - emptyDir: {}
         name: config-emptydir
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -3,10 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: example-otelcol
+  name: otelcol
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -14,8 +14,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-otelcol
+  name: otelcol
 subjects:
 - kind: ServiceAccount
-  name: example-otelcol
+  name: otelcol
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -20,16 +20,16 @@ data:
       debug: {}
       opensearch:
         http:
-          endpoint: http://otel-demo-opensearch:9200
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
         logs_index: otel
       otlp:
-        endpoint: 'example-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://example-prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -79,7 +79,7 @@ data:
     receivers:
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+        - endpoint: http://frontendproxy:8080
       jaeger:
         protocols:
           grpc:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -17,7 +17,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: example
       component: standalone-collector
   strategy:
@@ -25,18 +25,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 62adfeddd71a96dc4b733857c6c6b1ca5ba8c9aae0e8464666dd8fce27f595cc
+        checksum/config: 8d7f3109987e88eb44c7bd9e8f30ca3254e1267ea2d95031ecd8c8fd3bff21a0
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: example
         component: standalone-collector
         
     spec:
       
-      serviceAccountName: example-otelcol
+      serviceAccountName: otelcol
       securityContext:
         {}
       containers:
@@ -98,7 +98,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: example-otelcol
+            name: otelcol
             items:
               - key: relay
                 path: relay.yaml

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -3,11 +3,11 @@
 apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +22,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: example-otelcol
+                name: otelcol
                 port:
                   number: 4318

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm
@@ -51,7 +51,7 @@ spec:
       targetPort: 9411
       protocol: TCP
   selector:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     component: standalone-collector
   internalTrafficPolicy: Cluster

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: example-otelcol
+  name: otelcol
   namespace: default
   labels:
     helm.sh/chart: opentelemetry-collector-0.110.3
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.114.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 rules:
   - apiGroups:
       - ""

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -10,12 +10,12 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
 subjects:
   - kind: ServiceAccount
-    name: example-prometheus-server
+    name: prometheus
     namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: example-prometheus-server
+  name: prometheus

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 data:
   allow-snippet-annotations: "false"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   selector:
@@ -34,7 +34,7 @@ spec:
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
-      serviceAccountName: example-prometheus-server
+      serviceAccountName: prometheus
       containers:
 
         - name: prometheus-server
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: example-prometheus-server
+            name: prometheus
         - name: storage-volume
           emptyDir:
             {}

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
 spec:
   ports:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: v3.0.0
     helm.sh/chart: prometheus-26.0.0
     app.kubernetes.io/part-of: prometheus
-  name: example-prometheus-server
+  name: prometheus
   namespace: default
   annotations:
     {}

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,11 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.34.1
+    helm.sh/chart: opentelemetry-demo-0.35.0
     
-    opentelemetry.io/name: example
     app.kubernetes.io/instance: example
-    app.kubernetes.io/name: example
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/templates/NOTES.txt
+++ b/charts/opentelemetry-demo/templates/NOTES.txt
@@ -11,7 +11,7 @@
 
 - All services are available via the Frontend proxy: http://localhost:8080
   by running these commands:
-     kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "otel-demo.name" . }}-frontendproxy 8080:8080
+     kubectl --namespace {{ .Release.Namespace }} port-forward svc/frontendproxy 8080:8080
 
   The following services are available at these paths after the frontendproxy service is exposed with port forwarding:
   Webstore             http://localhost:8080/

--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -35,9 +35,7 @@ Workload (Pod) labels
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .name }}
 app.kubernetes.io/component: {{ .name}}
-app.kubernetes.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
-{{- else }}
-app.kubernetes.io/name: {{ include "otel-demo.name" . }}
+app.kubernetes.io/name: {{ .name }}
 {{- end }}
 {{- end }}
 
@@ -49,9 +47,7 @@ Selector labels
 */}}
 {{- define "otel-demo.selectorLabels" -}}
 {{- if .name }}
-opentelemetry.io/name: {{ include "otel-demo.name" . }}-{{ .name }}
-{{- else }}
-opentelemetry.io/name: {{ include "otel-demo.name" . }}
+opentelemetry.io/name: {{ .name }}
 {{- end }}
 {{- end }}
 

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -6,7 +6,7 @@ Demo component Deployment template
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "otel-demo.name" . }}-{{ .name }}
+  name: {{ .name }}
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
 spec:
@@ -132,7 +132,7 @@ spec:
             {{- if .existingConfigMap }}
             name: {{ tpl .existingConfigMap $ }}
             {{- else }}
-            name: {{ include "otel-demo.name" $ }}-{{ $.name }}-{{ .name | lower }}
+            name: {{ $.name }}-{{ .name | lower }}
             {{- end }}
         {{- end }}
         {{- range .mountedEmptyDirs }}
@@ -154,7 +154,7 @@ Demo component Service template
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "otel-demo.name" . }}-{{ .name }}
+  name: {{ .name }}
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}
   {{- with $service.annotations }}
@@ -214,7 +214,7 @@ Demo component ConfigMap template
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "otel-demo.name" $ }}-{{ $.name }}-{{ .name | lower }}
+  name: {{ $.name }}-{{ .name | lower }}
   labels:
         {{- include "otel-demo.labels" $ | nindent 4 }}
 data:
@@ -250,9 +250,9 @@ apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   {{- if .name }}
-  name: {{include "otel-demo.name" $ }}-{{ $.name }}-{{ .name | lower }}
+  name: {{ $.name }}-{{ .name | lower }}
   {{- else }}
-  name: {{include "otel-demo.name" $ }}-{{ $.name }}
+  name: {{ $.name }}
   {{- end }}
   labels:
     {{- include "otel-demo.labels" $ | nindent 4 }}
@@ -286,7 +286,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "otel-demo.name" $ }}-{{ $.name }}
+                name: {{ $.name }}
                 port:
                   number: {{ .port }}
           {{- end }}

--- a/charts/opentelemetry-demo/templates/flagd-config.yaml
+++ b/charts/opentelemetry-demo/templates/flagd-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "otel-demo.name" . }}-flagd-config
+  name: flagd-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}

--- a/charts/opentelemetry-demo/templates/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/templates/grafana-dashboards.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "otel-demo.name" . }}-grafana-dashboards
+  name: grafana-dashboards
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "otel-demo.labels" . | nindent 4 }}

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -311,7 +311,7 @@ components:
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
-        command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;" ]
+        command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
 
   frontend:
     enabled: true

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -8,7 +8,7 @@ default:
           apiVersion: v1
           fieldPath: "metadata.labels['app.kubernetes.io/component']"
     - name: OTEL_COLLECTOR_NAME
-      value: '{{ include "otel-demo.name" . }}-otelcol'
+      value: otelcol
     - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
       value: cumulative
     - name: OTEL_RESOURCE_ATTRIBUTES
@@ -162,7 +162,7 @@ components:
       env: true
     env:
       - name: KAFKA_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-kafka:9092'
+        value: kafka:9092
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4318
     resources:
@@ -171,7 +171,7 @@ components:
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
-        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-kafka 9092; do echo waiting for kafka; sleep 2; done;']
+        command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
 
   adService:
     enabled: true
@@ -183,7 +183,7 @@ components:
       - name: AD_SERVICE_PORT
         value: "8080"
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -206,9 +206,9 @@ components:
       - name: ASPNETCORE_URLS
         value: http://*:$(CART_SERVICE_PORT)
       - name: VALKEY_ADDR
-        value: '{{ include "otel-demo.name" . }}-valkey:6379'
+        value: valkey:6379
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -219,7 +219,7 @@ components:
     initContainers:
       - name: wait-for-valkey
         image: busybox:latest
-        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-valkey 6379; do echo waiting for valkey; sleep 2; done;']
+        command: ["sh", "-c", "until nc -z -v -w30 valkey 6379; do echo waiting for valkey; sleep 2; done;"]
 
   checkoutService:
     enabled: true
@@ -231,21 +231,21 @@ components:
       - name: CHECKOUT_SERVICE_PORT
         value: "8080"
       - name: CART_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-cartservice:8080'
+        value: cartservice:8080
       - name: CURRENCY_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-currencyservice:8080'
+        value: currencyservice:8080
       - name: EMAIL_SERVICE_ADDR
-        value: 'http://{{ include "otel-demo.name" . }}-emailservice:8080'
+        value: http://emailservice:8080
       - name: PAYMENT_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-paymentservice:8080'
+        value: paymentservice:8080
       - name: PRODUCT_CATALOG_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
+        value: productcatalogservice:8080
       - name: SHIPPING_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-shippingservice:8080'
+        value: shippingservice:8080
       - name: KAFKA_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-kafka:9092'
+        value: kafka:9092
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -256,7 +256,7 @@ components:
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
-        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-kafka 9092; do echo waiting for kafka; sleep 2; done;']
+        command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
 
   currencyService:
     enabled: true
@@ -298,9 +298,9 @@ components:
       env: true
     env:
       - name: KAFKA_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-kafka:9092'
+        value: kafka:9092
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -311,7 +311,7 @@ components:
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
-        command: ['sh', '-c', 'until nc -z -v -w30 {{ include "otel-demo.name" . }}-kafka 9092; do echo waiting for kafka; sleep 2; done;']
+        command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;" ]
 
   frontend:
     enabled: true
@@ -325,21 +325,21 @@ components:
       - name: FRONTEND_ADDR
         value: :8080
       - name: AD_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-adservice:8080'
+        value: adservice:8080
       - name: CART_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-cartservice:8080'
+        value: cartservice:8080
       - name: CHECKOUT_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-checkoutservice:8080'
+        value: checkoutservice:8080
       - name: CURRENCY_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-currencyservice:8080'
+        value: currencyservice:8080
       - name: PRODUCT_CATALOG_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
+        value: productcatalogservice:8080
       - name: RECOMMENDATION_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-recommendationservice:8080'
+        value: recommendationservice:8080
       - name: SHIPPING_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-shippingservice:8080'
+        value: shippingservice:8080
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_COLLECTOR_HOST
@@ -368,31 +368,31 @@ components:
       - name: ENVOY_PORT
         value: "8080"
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: FLAGD_UI_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_UI_PORT
         value: "4000"
       - name: FRONTEND_HOST
-        value: '{{ include "otel-demo.name" . }}-frontend'
+        value: frontend
       - name: FRONTEND_PORT
         value: "8080"
       - name: GRAFANA_SERVICE_HOST
-        value: '{{ include "otel-demo.name" . }}-grafana'
+        value: grafana
       - name: GRAFANA_SERVICE_PORT
         value: "80"
       - name: IMAGE_PROVIDER_HOST
-        value: '{{ include "otel-demo.name" . }}-imageprovider'
+        value: imageprovider
       - name: IMAGE_PROVIDER_PORT
         value: "8081"
       - name: JAEGER_SERVICE_HOST
-        value: '{{ include "otel-demo.name" . }}-jaeger-query'
+        value: jaeger-query
       - name: JAEGER_SERVICE_PORT
         value: "16686"
       - name: LOCUST_WEB_HOST
-        value: '{{ include "otel-demo.name" . }}-loadgenerator'
+        value: loadgenerator
       - name: LOCUST_WEB_PORT
         value: "8089"
       - name: OTEL_COLLECTOR_HOST
@@ -442,7 +442,7 @@ components:
       - name: LOCUST_SPAWN_RATE
         value: "1"
       - name: LOCUST_HOST
-        value: 'http://{{ include "otel-demo.name" . }}-frontendproxy:8080'
+        value: http://frontendproxy:8080
       - name: LOCUST_HEADLESS
         value: "false"
       - name: LOCUST_AUTOSTART
@@ -452,7 +452,7 @@ components:
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -471,7 +471,7 @@ components:
       - name: PAYMENT_SERVICE_PORT
         value: "8080"
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -494,7 +494,7 @@ components:
       - name: PRODUCT_CATALOG_SERVICE_PORT
         value: "8080"
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -534,13 +534,13 @@ components:
       - name: RECOMMENDATION_SERVICE_PORT
         value: "8080"
       - name: PRODUCT_CATALOG_SERVICE_ADDR
-        value: '{{ include "otel-demo.name" . }}-productcatalogservice:8080'
+        value: productcatalogservice:8080
       - name: OTEL_PYTHON_LOG_CORRELATION
         value: "true"
       - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
         value: python
       - name: FLAGD_HOST
-        value: '{{ include "otel-demo.name" . }}-flagd'
+        value: flagd
       - name: FLAGD_PORT
         value: "8013"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -559,7 +559,7 @@ components:
       - name: SHIPPING_SERVICE_PORT
         value: "8080"
       - name: QUOTE_SERVICE_ADDR
-        value: 'http://{{ include "otel-demo.name" . }}-quoteservice:8080'
+        value: http://quoteservice:8080
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
@@ -583,10 +583,12 @@ components:
         value: $(OTEL_COLLECTOR_NAME):4317
     resources:
       limits:
-        memory: 75Mi
+        memory: 100Mi
     command:
       - "/flagd-build"
       - "start"
+      - "--port"
+      - "8013"
       - "--uri"
       - "file:./etc/flagd/demo.flagd.json"
     mountedEmptyDirs:
@@ -606,14 +608,14 @@ components:
             value: http://$(OTEL_COLLECTOR_NAME):4318
         resources:
           limits:
-            memory: 75Mi
+            memory: 100Mi
         volumeMounts:
           - name: config-rw
             mountPath: /app/data
     initContainers:
       - name: init-config
         image: busybox
-        command: ['sh', '-c', 'cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json']
+        command: ["sh", "-c", "cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json"]
         volumeMounts:
           - mountPath: /config-ro
             name: config-ro
@@ -622,7 +624,7 @@ components:
     additionalVolumes:
       - name: config-ro
         configMap:
-          name: '{{ include "otel-demo.name" . }}-flagd-config'
+          name: flagd-config
 
   kafka:
     enabled: true
@@ -636,7 +638,7 @@ components:
         value: 9093
     env:
       - name: KAFKA_ADVERTISED_LISTENERS
-        value: 'PLAINTEXT://{{ include "otel-demo.name" . }}-kafka:9092'
+        value: PLAINTEXT://kafka:9092
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4318
       - name: KAFKA_HEAP_OPTS
@@ -669,10 +671,10 @@ components:
       runAsNonRoot: true
 
 opentelemetry-collector:
+  enabled: true
   image:
     repository: "otel/opentelemetry-collector-contrib"
-  enabled: true
-  nameOverride: otelcol
+  fullnameOverride: otelcol
   mode: deployment
   presets:
     kubernetesAttributes:
@@ -707,7 +709,7 @@ opentelemetry-collector:
                 - "https://*"
       httpcheck/frontendproxy:
         targets:
-          - endpoint: 'http://{{ include "otel-demo.name" . }}-frontendproxy:8080'
+          - endpoint: http://frontendproxy:8080
       redis:
         endpoint: "valkey-cart:6379"
         collection_interval: 10s
@@ -715,18 +717,18 @@ opentelemetry-collector:
     exporters:
       ## Create an exporter to Jaeger using the standard `otlp` export format
       otlp:
-        endpoint: '{{ include "otel-demo.name" . }}-jaeger-collector:4317'
+        endpoint: jaeger-collector:4317
         tls:
           insecure: true
       # Create an exporter to Prometheus (metrics)
       otlphttp/prometheus:
-        endpoint: 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090/api/v1/otlp'
+        endpoint: http://prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
       opensearch:
         logs_index: otel
         http:
-          endpoint: "http://otel-demo-opensearch:9200"
+          endpoint: http://opensearch:9200
           tls:
             insecure: true
 
@@ -766,6 +768,7 @@ opentelemetry-collector:
 
 jaeger:
   enabled: true
+  fullnameOverride: jaeger
   provisionDataStore:
     cassandra: false
   allInOne:
@@ -773,7 +776,7 @@ jaeger:
     args:
       - "--memory.max-traces=5000"
       - "--query.base-path=/jaeger/ui"
-      - "--prometheus.server-url=http://{{ include \"otel-demo.name\" . }}-prometheus-server:9090"
+      - "--prometheus.server-url=http://prometheus-server:9090"
       - "--prometheus.query.normalize-calls=true"
       - "--prometheus.query.normalize-duration=true"
     extraEnv:
@@ -808,8 +811,8 @@ prometheus:
     enabled: false
   prometheus-pushgateway:
     enabled: false
-
   server:
+    fullnameOverride: prometheus
     extraFlags:
       - "enable-feature=exemplar-storage"
       - "web.enable-otlp-receiver"
@@ -865,6 +868,7 @@ prometheus:
 
 grafana:
   enabled: true
+  fullnameOverride: grafana
   testFramework:
     enabled: false
   grafana.ini:
@@ -887,7 +891,7 @@ grafana:
         - name: Prometheus
           uid: webstore-metrics
           type: prometheus
-          url: 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090'
+          url: http://prometheus-server:9090
           editable: true
           isDefault: true
           jsonData:
@@ -902,13 +906,13 @@ grafana:
         - name: Jaeger
           uid: webstore-traces
           type: jaeger
-          url: 'http://{{ include "otel-demo.name" . }}-jaeger-query:16686/jaeger/ui'
+          url: http://jaeger-query:16686/jaeger/ui
           editable: true
           isDefault: false
 
         - name: OpenSearch
           type: grafana-opensearch-datasource
-          url: 'http://otel-demo-opensearch:9200/'
+          url: http://opensearch:9200/
           access: proxy
           editable: true
           isDefault: false
@@ -933,14 +937,14 @@ grafana:
           options:
             path: /var/lib/grafana/dashboards/default
   dashboardsConfigMaps:
-    default: '{{ include "otel-demo.name" . }}-grafana-dashboards'
+    default: grafana-dashboards
   resources:
     limits:
       memory: 150Mi
 
 opensearch:
   enabled: true
-  fullnameOverride: otel-demo-opensearch
+  fullnameOverride: opensearch
   clusterName: demo-cluster
   nodeGroup: otel-demo
   singleNode: true


### PR DESCRIPTION
This PR introduces a significant change to the Demo's deployment, leading to the upcoming Demo 2.0 release.

A concerted effort has been made to simplify and standardize the names of the 25+ components deployed by the OpenTelemetry Demo, as outlined in #1392 and [#1788](https://github.com/open-telemetry/opentelemetry-demo/issues/1788) on the Demo project. This PR removes the release name prefix from all demo components. 

Though this change is against Helm's idiomatic standards for naming components, the release name prefix doesn't make sense, given how the demo is used. This change will showcase the various demo component names more clearly across all Observability platforms.

To set some precedence:

1. The OpenTelemetry Demo does not support being installed multiple times in the same Kubernetes namespace
2. The Demo has previously updated the upgrade notes to indicate that upgrading the Demo is not supported. A delete followed by a re-install set of actions is recommended.