### PR TITLE
[demo] Fix prometheus and valkey services config reference

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.35.0
+version: 0.35.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -569,7 +569,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -646,7 +646,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -733,7 +733,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -861,7 +861,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -978,7 +978,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1047,7 +1047,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1139,7 +1139,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1301,7 +1301,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1371,7 +1371,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -569,7 +569,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -646,7 +646,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -733,7 +733,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -861,7 +861,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -978,7 +978,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1047,7 +1047,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1139,7 +1139,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1301,7 +1301,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1371,7 +1371,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -50,7 +50,7 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://prometheus-server:9090
+      url: http://prometheus:9090
     - editable: true
       isDefault: false
       name: Jaeger

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
+        checksum/config: b68209829a463f154d3438b9bef7ca2276e4116b1548d5ba7d65840a267566b3
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -29,7 +29,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -110,7 +110,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: valkey-cart:6379
+        endpoint: valkey:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 49145188d1b6b8656a00b28386fbf83d0db15e2b946864db5c71bb90c03414d5
+        checksum/config: bc2b61f25feb3036dac588a1293cf5632196b9912a86690a9c1aaf3ab13af27e
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -503,7 +503,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -573,7 +573,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -652,7 +652,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -741,7 +741,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -807,7 +807,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -873,7 +873,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -990,7 +990,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1061,7 +1061,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1155,7 +1155,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1253,7 +1253,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1317,7 +1317,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1387,7 +1387,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1471,7 +1471,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1543,7 +1543,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1611,7 +1611,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1681,7 +1681,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1755,7 +1755,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1821,7 +1821,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -50,7 +50,7 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://prometheus-server:9090
+      url: http://prometheus:9090
     - editable: true
       isDefault: false
       name: Jaeger

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
+        checksum/config: b68209829a463f154d3438b9bef7ca2276e4116b1548d5ba7d65840a267566b3
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -29,7 +29,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -117,7 +117,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: valkey-cart:6379
+        endpoint: valkey:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bbf9d60e3fb78dc8144e43eb3c9839dd67b68b2e377b8989c71e8f29e9a6c449
+        checksum/config: 40bacd80a907d224d2f96e5ec295db8a8232f6f226b2d2a5ba73f8d6691661a7
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -569,7 +569,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -646,7 +646,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -733,7 +733,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -861,7 +861,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -978,7 +978,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1047,7 +1047,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1139,7 +1139,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1301,7 +1301,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1371,7 +1371,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -50,7 +50,7 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://prometheus-server:9090
+      url: http://prometheus:9090
     - editable: true
       isDefault: false
       name: Jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
+        checksum/config: b68209829a463f154d3438b9bef7ca2276e4116b1548d5ba7d65840a267566b3
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -29,7 +29,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -108,7 +108,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: valkey-cart:6379
+        endpoint: valkey:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8d7f3109987e88eb44c7bd9e8f30ca3254e1267ea2d95031ecd8c8fd3bff21a0
+        checksum/config: 9388044d1fcde932f3bb14b2746bd01b44dbffd9c6e60f460d9c51c3b94f00de
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -569,7 +569,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -646,7 +646,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -733,7 +733,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -861,7 +861,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -978,7 +978,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1047,7 +1047,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1139,7 +1139,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1301,7 +1301,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1371,7 +1371,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -50,7 +50,7 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://prometheus-server:9090
+      url: http://prometheus:9090
     - editable: true
       isDefault: false
       name: Jaeger

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
+        checksum/config: b68209829a463f154d3438b9bef7ca2276e4116b1548d5ba7d65840a267566b3
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -29,7 +29,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -177,7 +177,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: valkey-cart:6379
+        endpoint: valkey:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 997e0efc1156c6015af86fb873c64cde1338cf9f8f64a718088b5efec750192d
+        checksum/config: 69ae187968ecacd849ea77959ac2c0bf5c29f27d75e572ed721b241bb6b08bb4
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -158,7 +158,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +183,7 @@ kind: Service
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -233,7 +233,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +261,7 @@ kind: Service
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -286,7 +286,7 @@ kind: Service
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -336,7 +336,7 @@ kind: Service
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -361,7 +361,7 @@ kind: Service
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -386,7 +386,7 @@ kind: Service
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -411,7 +411,7 @@ kind: Service
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -436,7 +436,7 @@ kind: Deployment
 metadata:
   name: accountingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: accountingservice
     app.kubernetes.io/instance: example
@@ -501,7 +501,7 @@ kind: Deployment
 metadata:
   name: adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: adservice
     app.kubernetes.io/instance: example
@@ -569,7 +569,7 @@ kind: Deployment
 metadata:
   name: cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: cartservice
     app.kubernetes.io/instance: example
@@ -646,7 +646,7 @@ kind: Deployment
 metadata:
   name: checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: checkoutservice
     app.kubernetes.io/instance: example
@@ -733,7 +733,7 @@ kind: Deployment
 metadata:
   name: currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: currencyservice
     app.kubernetes.io/instance: example
@@ -797,7 +797,7 @@ kind: Deployment
 metadata:
   name: emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: emailservice
     app.kubernetes.io/instance: example
@@ -861,7 +861,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -978,7 +978,7 @@ kind: Deployment
 metadata:
   name: frauddetectionservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frauddetectionservice
     app.kubernetes.io/instance: example
@@ -1047,7 +1047,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1139,7 +1139,7 @@ kind: Deployment
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example
@@ -1237,7 +1237,7 @@ kind: Deployment
 metadata:
   name: imageprovider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: imageprovider
     app.kubernetes.io/instance: example
@@ -1301,7 +1301,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1371,7 +1371,7 @@ kind: Deployment
 metadata:
   name: loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: loadgenerator
     app.kubernetes.io/instance: example
@@ -1453,7 +1453,7 @@ kind: Deployment
 metadata:
   name: paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: paymentservice
     app.kubernetes.io/instance: example
@@ -1523,7 +1523,7 @@ kind: Deployment
 metadata:
   name: productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: productcatalogservice
     app.kubernetes.io/instance: example
@@ -1589,7 +1589,7 @@ kind: Deployment
 metadata:
   name: quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: quoteservice
     app.kubernetes.io/instance: example
@@ -1657,7 +1657,7 @@ kind: Deployment
 metadata:
   name: recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: recommendationservice
     app.kubernetes.io/instance: example
@@ -1729,7 +1729,7 @@ kind: Deployment
 metadata:
   name: shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: shippingservice
     app.kubernetes.io/instance: example
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: valkey
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: valkey
     app.kubernetes.io/instance: example
@@ -1855,7 +1855,7 @@ kind: Ingress
 metadata:
   name: frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     opentelemetry.io/name: frontendproxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -50,7 +50,7 @@ data:
       name: Prometheus
       type: prometheus
       uid: webstore-metrics
-      url: http://prometheus-server:9090
+      url: http://prometheus:9090
     - editable: true
       isDefault: false
       name: Jaeger

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "11.3.1"
       annotations:
-        checksum/config: 409a844f60a4278b3f179a8e508a51c7894ae40cbcd26346d04355bab4fe4a0e
+        checksum/config: b68209829a463f154d3438b9bef7ca2276e4116b1548d5ba7d65840a267566b3
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
         checksum/secret: bed677784356b2af7fb0d87455db21f077853059b594101a4f6532bfbd962a7f
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -58,7 +58,7 @@ spec:
           args:
             - "--memory.max-traces=5000"
             - "--query.base-path=/jaeger/ui"
-            - "--prometheus.server-url=http://prometheus-server:9090"
+            - "--prometheus.server-url=http://prometheus:9090"
             - "--prometheus.query.normalize-calls=true"
             - "--prometheus.query.normalize-duration=true"
           ports:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -29,7 +29,7 @@ data:
         tls:
           insecure: true
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
     extensions:
@@ -108,7 +108,7 @@ data:
               - ${env:MY_POD_IP}:8888
       redis:
         collection_interval: 10s
-        endpoint: valkey-cart:6379
+        endpoint: valkey:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8d7f3109987e88eb44c7bd9e8f30ca3254e1267ea2d95031ecd8c8fd3bff21a0
+        checksum/config: 9388044d1fcde932f3bb14b2746bd01b44dbffd9c6e60f460d9c51c3b94f00de
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.35.0
+    helm.sh/chart: opentelemetry-demo-0.35.1
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.12.0"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -711,7 +711,7 @@ opentelemetry-collector:
         targets:
           - endpoint: http://frontendproxy:8080
       redis:
-        endpoint: "valkey-cart:6379"
+        endpoint: "valkey:6379"
         collection_interval: 10s
 
     exporters:
@@ -722,7 +722,7 @@ opentelemetry-collector:
           insecure: true
       # Create an exporter to Prometheus (metrics)
       otlphttp/prometheus:
-        endpoint: http://prometheus-server:9090/api/v1/otlp
+        endpoint: http://prometheus:9090/api/v1/otlp
         tls:
           insecure: true
       opensearch:
@@ -776,7 +776,7 @@ jaeger:
     args:
       - "--memory.max-traces=5000"
       - "--query.base-path=/jaeger/ui"
-      - "--prometheus.server-url=http://prometheus-server:9090"
+      - "--prometheus.server-url=http://prometheus:9090"
       - "--prometheus.query.normalize-calls=true"
       - "--prometheus.query.normalize-duration=true"
     extraEnv:
@@ -891,7 +891,7 @@ grafana:
         - name: Prometheus
           uid: webstore-metrics
           type: prometheus
-          url: http://prometheus-server:9090
+          url: http://prometheus:9090
           editable: true
           isDefault: true
           jsonData:


### PR DESCRIPTION
Services renamed in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1520

Collector fails to export to Prometheus:

```
2025-02-13T16:08:29.346Z        info    internal/retry_sender.go:126    Exporting failed. Will retry the request after interval.        {"kind": "exporter", "data_type": "metrics", "name": "otlphttp/prometheus", "error": "failed to make an HTTP request: Post \"http://prometheus:9090/api/v1/otlp/v1/metrics\": dial tcp 10.96.37.243:9090: connect: connection refused", "interval": "6.229029363s"}
```