### PR TITLE
[operator] Fix bug in the operator validation webhook using the wrong certificate

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.80.1
+version: 0.80.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -222,7 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -240,7 +240,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -90,7 +90,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -29,7 +29,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -256,7 +256,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -274,7 +274,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.80.1
+    helm.sh/chart: opentelemetry-operator-0.80.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -133,8 +133,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook


### PR DESCRIPTION
Related Issue: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1529
Description:
- Issue: The operator validation webhook can incorrectly use a cert-manager-generated certificate (if a cert-manager exists within the cluster) even when a Helm-generated or user-supplied certificate is specified (`admissionWebhooks.certManager.enabled=false`). This was likely a slight oversight that just has not been caught yet.
- Impact: cert-manager overriding the intended certificates to be used or causing Helm install/upgrade failures for the operator.
- Fix: Ensures that the validation webhook respects the designated certificate source by not including the cert-manager annotation inappropriately, the same way the [mutating webhook does](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/28c3708993c0ff1e57ec1e5f24040e8cd345987a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml#L31).