### PR TITLE
[Draft] [operator] Fix bug in the operator secret when using a helm hook

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.83.0
+version: 0.84.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.83.0
+        helm.sh/chart: opentelemetry-operator-0.84.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.120.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.83.0
+        helm.sh/chart: opentelemetry-operator-0.84.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.120.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.83.0
+    helm.sh/chart: opentelemetry-operator-0.84.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -7,12 +7,10 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
+  {{- if .Values.admissionWebhooks.secretAnnotations }}
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    {{- if .Values.admissionWebhooks.secretAnnotations }}
-    {{- toYaml .Values.admissionWebhooks.secretAnnotations | nindent 4 }}
-    {{- end }}
+  {{- toYaml .Values.admissionWebhooks.secretAnnotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "opentelemetry-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: webhook

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -311,7 +311,9 @@ admissionWebhooks:
   serviceAnnotations: {}
 
   ## Secret annotations
-  secretAnnotations: {}
+  secretAnnotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
   ## Secret labels
   secretLabels: {}
 


### PR DESCRIPTION
Related Issue: [#1529](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1529)
Description:
- Issue: When `admissionWebhooks.certManager.enabled=false`, a Helm `pre-install/pre-upgrade` hook deploys the required secret. However, this provides no clear benefit and introduces several downsides:
  - Helm Lifecycle Management: Objects deployed via Helm hooks are not managed by the Helm lifecycle, leading to orphaned secrets on chart uninstallation. Causing potential future installations to fail. It also blocks users from migrating to or from certificate providers like cert-manager.
  - Conflicts with a`dmissionWebhooks.autoGenerateCert.recreate` (still validating): This value regenerates the certificate on install/update but conflicts with the Helm hook behavior.
  - Unnecessary Complexity: Helm already ensures proper installation ordering, making the pre-install hook redundant. ([Reference](https://helm.sh/docs/intro/using_helm/#helm-install-installing-a-package))
  - I can make it so the disabling of the helm hooks with the secret are optional via the values.yaml file, but currently I think this would just be bloating the values.yaml file when we can just remove the hooks from the templates. Taking suggestions from others on this if you have them.
- Fix: Remove the "helm.sh/hook": "pre-install,pre-upgrade" annotation from the operator webhook secret to align with standard Helm behavior.
- Follow up: After some final validations and input from this community, if we decide to move forward I'll add changes for CI/CD changes to pass (lint, render examples, bump the chart version). I have other fixes in flight and will keep this changeset small at the start.


When migrating from a cert-manager cert to a Helm generated or user supplied certificate you can see an error like such.
Upgrading from certmanager to helm generated cert
```
Error: Received unexpected error:
  pre-upgrade hooks failed: warning: Hook pre-upgrade splunk-otel-collector/charts/operator/templates/admission-webhooks/operator-webhook.yaml failed: 1 error occurred: * secrets "sock-operator-controller-manager-service-cert" already exists
```		