### PR TITLE
[kube-stack]: align cluster and daemon resource limits

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.4.1
+version: 0.4.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -138,11 +138,11 @@ spec:
   terminationGracePeriodSeconds: 30
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 500Mi
     requests:
       cpu: 100m
-      memory: 500Mi
+      memory: 250Mi
   securityContext:
     {}
   volumeMounts:
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -590,11 +590,11 @@ spec:
   terminationGracePeriodSeconds: 30
   resources:
     limits:
-      cpu: 100m
-      memory: 250Mi
+      cpu: 200m
+      memory: 500Mi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 250Mi
   securityContext:
     {}
   volumeMounts:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.2

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
@@ -297,11 +297,11 @@ spec:
   terminationGracePeriodSeconds: 30
   resources:
     limits:
-      cpu: 100m
-      memory: 250Mi
+      cpu: 200m
+      memory: 500Mi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 250Mi
   securityContext:
     {}
   targetAllocator:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.1
+    helm.sh/chart: opentelemetry-kube-stack-0.4.2
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.2

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -459,11 +459,11 @@ collectors:
     enabled: true
     resources:
       limits:
-        cpu: 100m
-        memory: 250Mi
+        cpu: 200m
+        memory: 500Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 250Mi
     # A scrape config file to instruct the daemon collector to pull metrics from any matching targets on the same node with
     # prometheus.io/scrape=true
     # This config also scrapes a running node exporter and the kubelet CAdvisor metrics which aren't currently supported.
@@ -530,11 +530,11 @@ collectors:
     enabled: true
     resources:
       limits:
-        cpu: 100m
+        cpu: 200m
         memory: 500Mi
       requests:
         cpu: 100m
-        memory: 500Mi
+        memory: 250Mi
     presets:
       kubernetesAttributes:
         enabled: true


### PR DESCRIPTION
Is there any reasoning on having different resource limits for the cluster and daemonset pods? In my tests I normally see much CPU and memory usage on the daemonset ones:

```
$ k top pod -n opentelemetry-operator-system
NAME                                                              CPU(cores)   MEMORY(bytes)
opentelemetry-kube-stack-cluster-stats-collector-654ccc595wlqtl   2m           27Mi
opentelemetry-kube-stack-daemon-collector-72rcq                   21m          34Mi
opentelemetry-kube-stack-daemon-collector-dlsn2                   29m          34Mi
opentelemetry-kube-stack-daemon-collector-wgcdl                   19m          34Mi
opentelemetry-kube-stack-daemon-collector-xhtgd                   25m          34Mi
opentelemetry-kube-stack-opentelemetry-operator-6695b8446c98xxz   2m           29Mi
```

This PR proposes increasing the daemon resource limits to 500MiB to avoid OOM kills on heavy loaded environments. At the same time, it decreases the memory requested for the cluster pod as it was set to the limit value.