### PR TITLE
[demo] - load-generator Adapt OpenFeature OFREP instead of IN_PROCESS

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.36.4
+version: 0.37.0
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - name: puckpuck
   - name: tylerhelmuth
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 2.0.1
+appVersion: 2.0.2
 dependencies:
   - name: opentelemetry-collector
     version: 0.117.1

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -481,7 +481,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -529,7 +529,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -556,7 +556,7 @@ spec:
             - name: OTEL_LOGS_EXPORTER
               value: otlp
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -626,7 +626,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -675,7 +675,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -714,7 +714,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -783,9 +783,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -826,7 +826,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -849,7 +849,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -918,7 +918,7 @@ spec:
             - name: FLAGD_OTEL_COLLECTOR_URI
               value: $(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 75Mi
@@ -926,7 +926,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -947,7 +947,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1007,7 +1007,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1028,7 +1028,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1123,7 +1123,7 @@ spec:
             - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://localhost:8080/otlp-http/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1168,7 +1168,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1221,7 +1221,7 @@ spec:
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 65Mi
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1266,7 +1266,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1289,7 +1289,7 @@ spec:
             - name: OTEL_COLLECTOR_HOST
               value: $(OTEL_COLLECTOR_NAME)
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1330,7 +1330,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1355,7 +1355,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: -Xmx400M -Xms400M
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1400,7 +1400,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1441,7 +1441,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 1500Mi
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1482,7 +1482,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1507,7 +1507,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1530,7 +1530,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1552,7 +1552,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1579,7 +1579,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1603,7 +1603,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1625,7 +1625,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1648,7 +1648,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1693,7 +1693,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1724,7 +1724,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1765,7 +1765,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1788,7 +1788,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1807,7 +1807,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1846,7 +1846,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -501,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -569,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -647,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -734,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -798,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -862,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -897,12 +900,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -979,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1140,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1238,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1302,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1372,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1436,8 +1443,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1454,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1524,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1597,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1665,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1737,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1801,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -481,7 +481,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -529,7 +529,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -556,7 +556,7 @@ spec:
             - name: OTEL_LOGS_EXPORTER
               value: otlp
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -626,7 +626,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -675,7 +675,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -714,7 +714,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -783,9 +783,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -826,7 +826,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -849,7 +849,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -918,7 +918,7 @@ spec:
             - name: FLAGD_OTEL_COLLECTOR_URI
               value: $(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 75Mi
@@ -926,7 +926,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -947,7 +947,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1007,7 +1007,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1028,7 +1028,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1123,7 +1123,7 @@ spec:
             - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://localhost:8080/otlp-http/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1168,7 +1168,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1221,7 +1221,7 @@ spec:
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 65Mi
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1266,7 +1266,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1289,7 +1289,7 @@ spec:
             - name: OTEL_COLLECTOR_HOST
               value: $(OTEL_COLLECTOR_NAME)
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1330,7 +1330,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1355,7 +1355,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: -Xmx400M -Xms400M
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1400,7 +1400,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1441,7 +1441,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 1500Mi
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1482,7 +1482,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1507,7 +1507,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1530,7 +1530,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1552,7 +1552,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1579,7 +1579,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1603,7 +1603,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1625,7 +1625,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1648,7 +1648,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1693,7 +1693,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1724,7 +1724,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1765,7 +1765,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1788,7 +1788,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1807,7 +1807,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1846,7 +1846,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -501,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -569,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -647,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -734,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -798,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -862,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -897,12 +900,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -979,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1140,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1238,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1302,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1372,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1436,8 +1443,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1454,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1524,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1597,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1665,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1737,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1801,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -503,7 +506,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -573,7 +576,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -653,7 +656,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -742,7 +745,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -808,7 +811,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -874,7 +877,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -909,12 +912,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -991,7 +998,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1062,7 +1069,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1156,7 +1163,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1254,7 +1261,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1318,7 +1325,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1388,7 +1395,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1452,8 +1459,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: TEAM_NAME
@@ -1472,7 +1479,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1544,7 +1551,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1619,7 +1626,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1689,7 +1696,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1763,7 +1770,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1829,7 +1836,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -531,7 +531,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -601,7 +601,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -681,7 +681,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -770,7 +770,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -791,7 +791,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: TEAM_NAME
               value: orion
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -814,7 +814,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -836,7 +836,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -880,7 +880,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -938,7 +938,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -997,7 +997,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1019,7 +1019,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1068,7 +1068,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1090,7 +1090,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1162,7 +1162,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1184,7 +1184,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1260,7 +1260,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1282,7 +1282,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1324,7 +1324,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1346,7 +1346,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1416,7 +1416,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1500,7 +1500,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1550,7 +1550,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1572,7 +1572,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1625,7 +1625,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1647,7 +1647,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1695,7 +1695,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1717,7 +1717,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1769,7 +1769,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1791,7 +1791,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1835,7 +1835,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -481,7 +481,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -529,7 +529,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -556,7 +556,7 @@ spec:
             - name: OTEL_LOGS_EXPORTER
               value: otlp
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -626,7 +626,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -675,7 +675,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -714,7 +714,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -783,9 +783,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -826,7 +826,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -849,7 +849,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -918,7 +918,7 @@ spec:
             - name: FLAGD_OTEL_COLLECTOR_URI
               value: $(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 75Mi
@@ -926,7 +926,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -947,7 +947,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1007,7 +1007,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1028,7 +1028,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1123,7 +1123,7 @@ spec:
             - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://localhost:8080/otlp-http/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1168,7 +1168,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1221,7 +1221,7 @@ spec:
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 65Mi
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1266,7 +1266,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1289,7 +1289,7 @@ spec:
             - name: OTEL_COLLECTOR_HOST
               value: $(OTEL_COLLECTOR_NAME)
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1330,7 +1330,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1355,7 +1355,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: -Xmx400M -Xms400M
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1400,7 +1400,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1441,7 +1441,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 1500Mi
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1482,7 +1482,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1507,7 +1507,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1530,7 +1530,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1552,7 +1552,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1579,7 +1579,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1603,7 +1603,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1625,7 +1625,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1648,7 +1648,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1693,7 +1693,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1724,7 +1724,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1765,7 +1765,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1788,7 +1788,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1807,7 +1807,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1846,7 +1846,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -501,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -569,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -647,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -734,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -798,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -862,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -897,12 +900,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -979,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1140,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1238,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1302,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1372,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1436,8 +1443,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1454,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1524,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1597,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1665,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1737,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1801,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -481,7 +481,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -529,7 +529,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -556,7 +556,7 @@ spec:
             - name: OTEL_LOGS_EXPORTER
               value: otlp
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -626,7 +626,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -675,7 +675,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -714,7 +714,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -783,9 +783,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -826,7 +826,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -849,7 +849,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -918,7 +918,7 @@ spec:
             - name: FLAGD_OTEL_COLLECTOR_URI
               value: $(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 75Mi
@@ -926,7 +926,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -947,7 +947,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1007,7 +1007,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1028,7 +1028,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1123,7 +1123,7 @@ spec:
             - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://localhost:8080/otlp-http/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1168,7 +1168,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1221,7 +1221,7 @@ spec:
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 65Mi
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1266,7 +1266,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1289,7 +1289,7 @@ spec:
             - name: OTEL_COLLECTOR_HOST
               value: $(OTEL_COLLECTOR_NAME)
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1330,7 +1330,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1355,7 +1355,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: -Xmx400M -Xms400M
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1400,7 +1400,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1441,7 +1441,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 1500Mi
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1482,7 +1482,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1507,7 +1507,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1530,7 +1530,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1552,7 +1552,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1579,7 +1579,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1603,7 +1603,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1625,7 +1625,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1648,7 +1648,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1693,7 +1693,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1724,7 +1724,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1765,7 +1765,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1788,7 +1788,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1807,7 +1807,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1846,7 +1846,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -501,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -569,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -647,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -734,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -798,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -862,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -897,12 +900,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -979,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1140,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1238,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1302,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1372,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1436,8 +1443,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1454,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1524,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1597,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1665,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1737,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1801,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -143,8 +143,11 @@ spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
     - port: 4000
       name: tcp-service-0
       targetPort: 4000
@@ -158,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -183,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -208,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -233,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -261,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -286,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -311,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -336,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -361,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -386,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -411,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -436,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: accounting
     app.kubernetes.io/instance: example
@@ -501,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: ad
     app.kubernetes.io/instance: example
@@ -569,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: cart
     app.kubernetes.io/instance: example
@@ -647,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: checkout
     app.kubernetes.io/instance: example
@@ -734,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: currency
     app.kubernetes.io/instance: example
@@ -798,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: email
     app.kubernetes.io/instance: example
@@ -862,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: flagd
     app.kubernetes.io/instance: example
@@ -897,12 +900,16 @@ spec:
             - start
             - --port
             - "8013"
+            - --ofrep-port
+            - "8016"
             - --uri
             - file:./etc/flagd/demo.flagd.json
           ports:
             
             - containerPort: 8013
-              name: service
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
             - name: OTEL_SERVICE_NAME
               valueFrom:
@@ -979,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: fraud-detection
     app.kubernetes.io/instance: example
@@ -1048,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend
     app.kubernetes.io/instance: example
@@ -1140,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example
@@ -1238,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: image-provider
     app.kubernetes.io/instance: example
@@ -1302,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: kafka
     app.kubernetes.io/instance: example
@@ -1372,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: load-generator
     app.kubernetes.io/instance: example
@@ -1436,8 +1443,8 @@ spec:
               value: python
             - name: FLAGD_HOST
               value: flagd
-            - name: FLAGD_PORT
-              value: "8013"
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1454,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: payment
     app.kubernetes.io/instance: example
@@ -1524,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: product-catalog
     app.kubernetes.io/instance: example
@@ -1597,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: quote
     app.kubernetes.io/instance: example
@@ -1665,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: recommendation
     app.kubernetes.io/instance: example
@@ -1737,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: shipping
     app.kubernetes.io/instance: example
@@ -1801,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: valkey-cart
     app.kubernetes.io/instance: example
@@ -1863,7 +1870,7 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     opentelemetry.io/name: frontend-proxy
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,7 +136,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -214,7 +214,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -267,7 +267,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -464,7 +464,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: accounting
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-accounting'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -481,7 +481,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -529,7 +529,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: ad
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-ad'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -556,7 +556,7 @@ spec:
             - name: OTEL_LOGS_EXPORTER
               value: otlp
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: cart
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-cart'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -626,7 +626,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -675,7 +675,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: checkout
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-checkout'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -714,7 +714,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: currency
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-currency'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -783,9 +783,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: VERSION
-              value: '2.0.1'
+              value: '2.0.2'
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -826,7 +826,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: email
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-email'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -849,7 +849,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -918,7 +918,7 @@ spec:
             - name: FLAGD_OTEL_COLLECTOR_URI
               value: $(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 75Mi
@@ -926,7 +926,7 @@ spec:
             - name: config-rw
               mountPath: /etc/flagd
         - name: flagd-ui
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-flagd-ui'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -947,7 +947,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1007,7 +1007,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: fraud-detection
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-fraud-detection'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
           imagePullPolicy: IfNotPresent
           env:
             - name: OTEL_SERVICE_NAME
@@ -1028,7 +1028,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1076,7 +1076,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1123,7 +1123,7 @@ spec:
             - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: https://otel-demo-collector.example.com/v1/traces
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1168,7 +1168,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: frontend-proxy
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-frontend-proxy'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1221,7 +1221,7 @@ spec:
             - name: OTEL_COLLECTOR_PORT_HTTP
               value: "4318"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 65Mi
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1266,7 +1266,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: image-provider
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-image-provider'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1289,7 +1289,7 @@ spec:
             - name: OTEL_COLLECTOR_HOST
               value: $(OTEL_COLLECTOR_NAME)
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1330,7 +1330,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1355,7 +1355,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: -Xmx400M -Xms400M
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1400,7 +1400,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: load-generator
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-load-generator'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1441,7 +1441,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 1500Mi
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1482,7 +1482,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: payment
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-payment'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1507,7 +1507,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1530,7 +1530,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1552,7 +1552,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: product-catalog
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-product-catalog'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1579,7 +1579,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1603,7 +1603,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1625,7 +1625,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: quote
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-quote'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1648,7 +1648,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4318
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1693,7 +1693,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: recommendation
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-recommendation'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1724,7 +1724,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1765,7 +1765,7 @@ spec:
       serviceAccountName: example
       containers:
         - name: shipping
-          image: 'ghcr.io/open-telemetry/demo:2.0.1-shipping'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -1788,7 +1788,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1807,7 +1807,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1846,7 +1846,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.1
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1869,7 +1869,7 @@ metadata:
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.36.4
+    helm.sh/chart: opentelemetry-demo-0.37.0
     
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: opentelemetry-demo-0.36.4
     
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -453,8 +453,8 @@ components:
         value: python
       - name: FLAGD_HOST
         value: flagd
-      - name: FLAGD_PORT
-        value: "8013"
+      - name: FLAGD_OFREP_PORT
+        value: "8016"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
     resources:
@@ -580,8 +580,11 @@ components:
     useDefault:
       env: true
     replicas: 1
-    service:
-      port: 8013
+    ports:
+      - name: rpc
+        value: 8013
+      - name: ofrep
+        value: 8016
     env:
       - name: FLAGD_METRICS_EXPORTER
         value: otel
@@ -595,6 +598,8 @@ components:
       - "start"
       - "--port"
       - "8013"
+      - "--ofrep-port "
+      - "8016"
       - "--uri"
       - "file:./etc/flagd/demo.flagd.json"
     mountedEmptyDirs:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -598,7 +598,7 @@ components:
       - "start"
       - "--port"
       - "8013"
-      - "--ofrep-port "
+      - "--ofrep-port"
       - "8016"
       - "--uri"
       - "file:./etc/flagd/demo.flagd.json"


### PR DESCRIPTION
OpenFeature supports multiple different modes.
The newest implementation relies on threads and other python internal, which seem to be monkeypatched by locust.
Due to this, the IN_PROCESS mode is not working properly anymore and is causing issues.

Instead we suggest to switch to the OFREP (OpenFeature Remote Evaluation Protocol) for this usecase. This is a simple http call which will return all evaluate flags, and will regularly poll for changes.

This pr contains the helm changes matching https://github.com/open-telemetry/opentelemetry-demo/pull/2114 - but my helm knowledge is limited, please let me know, if i am missing anything here.