### PR TITLE
chore(Collector):! Move to new Telemetry setup

### DIFF
--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -138,7 +138,12 @@ config:
   service:
     telemetry:
       metrics:
-        address: ${env:MY_POD_IP}:8888
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '${env:MY_POD_IP}'
+                port: 8888
     extensions:
       - health_check
     pipelines:


### PR DESCRIPTION
Endpoint config is deprecated. Move to new Reader Setup

I think this can be a breaking change in some setups. Because when address is manually defined there are 2 Port Bindings on Port.  