### PR TITLE
feat(opentelemetry-kube-stack): Added option for user to provide existingServiceAccount for cleanup job

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.4.4
+version: 0.4.5
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.4
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.5

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.4
+    helm.sh/chart: opentelemetry-kube-stack-0.4.5
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.4
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.5

--- a/charts/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/templates/hooks.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cleanupJob.enabled }}
+{{- if not .Values.cleanupJob.existingServiceAccount}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -6,6 +7,7 @@ metadata:
   name: delete-resources-sa
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- end}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -36,8 +38,13 @@ roleRef:
   kind: Role
   name: delete-resources-role
 subjects:
+{{- if not .Values.cleanupJob.existingServiceAccount}}
   - kind: ServiceAccount
     name: delete-resources-sa
+{{- else}}
+  - kind: ServiceAccount
+    name: {{ .Values.cleanupJob.existingServiceAccount }}
+{{- end}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -50,7 +57,11 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      {{- if not .Values.cleanupJob.existingServiceAccount}}
       serviceAccountName: delete-resources-sa
+      {{- else}}
+      serviceAccountName: {{ .Values.cleanupJob.existingServiceAccount }}
+      {{- end}}
       containers:
       - name: delete-resources
         {{- if $.Values.cleanupJob.image.digest }}

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -21,6 +21,8 @@ cleanupJob:
     tag: latest
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
+  # To use the existingServiceAccount
+  existingServiceAccount: ""
 
 # Should the CRDs be installed by this chart.
 crds:


### PR DESCRIPTION
This PR introduces the ability to specify an existing service account for the cleanup job. This enhancement allows users to use a pre-existing service account instead of creating a new one, providing more flexibility and control over the service account used for cleanup operations.

Changes:

1. hooks.yaml:

- Added conditional logic to check if existingServiceAccount is specified and not empty.
- If existingServiceAccount is provided, it will be used for the RoleBinding and Job resources.
- If existingServiceAccount is not provided, the default delete-resources-sa service account will be created and used.

3. values.yaml:

- Added a new field existingServiceAccount under cleanupJob to allow users to specify an existing service account.