### PR TITLE
Document sed workaround on Mac OS X

### DIFF
--- a/charts/opentelemetry-operator/CONTRIBUTING.md
+++ b/charts/opentelemetry-operator/CONTRIBUTING.md
@@ -3,8 +3,23 @@
 ## Bumping Default Operator Version
 
 1. Increase the minor version of the chart by one and set the patch version to zero.
-1. Update the chart's `appVersion` to match the new operator version.
-1. In the values.yaml, update `manager.collectorImage.tag` to match the version of the collector managed by default by the operator.
-1. Run `make generate-examples CHARTS=opentelemetry-operator`.
-1. Run `make update-operator-crds` to update the CRDs in this chart to match the operator's.
-1. Review the [Operator release notes](https://github.com/open-telemetry/opentelemetry-operator/releases).  If any changes affect the helm chart, adjust the helm chart accordingly.
+2. Update the chart's `appVersion` to match the new operator version.
+3. In the values.yaml, update `manager.collectorImage.tag` to match the version of the collector managed by default by the operator.
+4. Run `make generate-examples CHARTS=opentelemetry-operator`.
+5. Run `make update-operator-crds` to update the CRDs in this chart to match the operator's.
+6. Review the [Operator release notes](https://github.com/open-telemetry/opentelemetry-operator/releases).  If any changes affect the helm chart, adjust the helm chart accordingly.
+
+### sed on Mac OS X
+
+If you're performing the above steps on Mac OS X, you may need to install `gnu-sed` via Homebrew
+as the pre-installed `sed` version has some incompatible differences:
+
+```sh
+brew install gnu-sed
+```
+
+Then, you can use it for make instead of the system's `sed`:
+
+```sh
+PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH" make ...
+```

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.82.1
+version: 0.82.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.82.1
+        helm.sh/chart: opentelemetry-operator-0.82.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.119.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.82.1
+        helm.sh/chart: opentelemetry-operator-0.82.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.119.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,7 +44,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.82.1
+    helm.sh/chart: opentelemetry-operator-0.82.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.119.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Describe how to update the operator chart on Mac OS X which comes with a different sed flavour. Also fix list numbering.

Split from https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1566