### PR TITLE
[kube-stack] Reformat values.schema.json 

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.4.3
+version: 0.4.4
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.3
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.4

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.4.3
+    helm.sh/chart: opentelemetry-kube-stack-0.4.4
     app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.4.3
+              -l helm.sh/chart=opentelemetry-kube-stack-0.4.4

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -18,7 +18,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["volumeID"]
+      "required": [
+        "volumeID"
+      ]
     },
     "Affinity": {
       "properties": {
@@ -85,7 +87,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["diskName", "diskURI"]
+      "required": [
+        "diskName",
+        "diskURI"
+      ]
     },
     "AzureFileVolumeSource": {
       "properties": {
@@ -101,7 +106,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["secretName", "shareName"]
+      "required": [
+        "secretName",
+        "shareName"
+      ]
     },
     "CSIVolumeSource": {
       "properties": {
@@ -126,7 +134,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["driver"]
+      "required": [
+        "driver"
+      ]
     },
     "Capabilities": {
       "properties": {
@@ -172,7 +182,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["monitors"]
+      "required": [
+        "monitors"
+      ]
     },
     "CinderVolumeSource": {
       "properties": {
@@ -191,7 +203,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["volumeID"]
+      "required": [
+        "volumeID"
+      ]
     },
     "ClusterTrustBundleProjection": {
       "properties": {
@@ -213,7 +227,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["path"]
+      "required": [
+        "path"
+      ]
     },
     "ConfigMapEnvSource": {
       "properties": {
@@ -241,7 +257,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["key"]
+      "required": [
+        "key"
+      ]
     },
     "ConfigMapProjection": {
       "properties": {
@@ -293,7 +311,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name", "mountPath"]
+      "required": [
+        "name",
+        "mountPath"
+      ]
     },
     "Container": {
       "properties": {
@@ -396,7 +417,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "ContainerPort": {
       "properties": {
@@ -418,7 +441,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["containerPort"]
+      "required": [
+        "containerPort"
+      ]
     },
     "ContainerResizePolicy": {
       "properties": {
@@ -431,7 +456,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["resourceName", "restartPolicy"]
+      "required": [
+        "resourceName",
+        "restartPolicy"
+      ]
     },
     "DaemonSetUpdateStrategy": {
       "properties": {
@@ -486,7 +514,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["path"]
+      "required": [
+        "path"
+      ]
     },
     "DownwardAPIVolumeSource": {
       "properties": {
@@ -544,7 +574,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "EnvVarSource": {
       "properties": {
@@ -640,7 +672,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["driver"]
+      "required": [
+        "driver"
+      ]
     },
     "FlockerVolumeSource": {
       "properties": {
@@ -671,7 +705,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["pdName"]
+      "required": [
+        "pdName"
+      ]
     },
     "GitRepoVolumeSource": {
       "properties": {
@@ -687,7 +723,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["repository"]
+      "required": [
+        "repository"
+      ]
     },
     "GlusterfsVolumeSource": {
       "properties": {
@@ -703,7 +741,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["endpoints", "path"]
+      "required": [
+        "endpoints",
+        "path"
+      ]
     },
     "HPAScalingPolicy": {
       "properties": {
@@ -719,7 +760,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["type", "value", "periodSeconds"]
+      "required": [
+        "type",
+        "value",
+        "periodSeconds"
+      ]
     },
     "HPAScalingRules": {
       "properties": {
@@ -745,7 +790,10 @@
           "type": "string"
         },
         "port": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "host": {
           "type": "string"
@@ -762,7 +810,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["port"]
+      "required": [
+        "port"
+      ]
     },
     "HTTPHeader": {
       "properties": {
@@ -775,7 +825,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name", "value"]
+      "required": [
+        "name",
+        "value"
+      ]
     },
     "HorizontalPodAutoscalerBehavior": {
       "properties": {
@@ -800,7 +853,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["path"]
+      "required": [
+        "path"
+      ]
     },
     "ISCSIVolumeSource": {
       "properties": {
@@ -843,7 +898,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["targetPortal", "iqn", "lun"]
+      "required": [
+        "targetPortal",
+        "iqn",
+        "lun"
+      ]
     },
     "Ingress": {
       "properties": {
@@ -907,7 +966,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["Type", "IntVal", "StrVal"]
+      "required": [
+        "Type",
+        "IntVal",
+        "StrVal"
+      ]
     },
     "KeyToPath": {
       "properties": {
@@ -923,7 +986,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["key", "path"]
+      "required": [
+        "key",
+        "path"
+      ]
     },
     "LabelSelector": {
       "properties": {
@@ -960,7 +1026,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["key", "operator"]
+      "required": [
+        "key",
+        "operator"
+      ]
     },
     "Lifecycle": {
       "properties": {
@@ -1039,7 +1108,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "MetricSpec": {
       "properties": {
@@ -1052,7 +1123,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MetricTarget": {
       "properties": {
@@ -1071,7 +1144,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "MetricsConfigSpec": {
       "properties": {
@@ -1096,7 +1171,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["status"]
+      "required": [
+        "status"
+      ]
     },
     "NFSVolumeSource": {
       "properties": {
@@ -1112,7 +1189,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["server", "path"]
+      "required": [
+        "server",
+        "path"
+      ]
     },
     "NodeAffinity": {
       "properties": {
@@ -1140,7 +1220,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["nodeSelectorTerms"]
+      "required": [
+        "nodeSelectorTerms"
+      ]
     },
     "NodeSelectorRequirement": {
       "properties": {
@@ -1159,7 +1241,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["key", "operator"]
+      "required": [
+        "key",
+        "operator"
+      ]
     },
     "NodeSelectorTerm": {
       "properties": {
@@ -1190,7 +1275,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["fieldPath"]
+      "required": [
+        "fieldPath"
+      ]
     },
     "ObjectMeta": {
       "properties": {
@@ -1468,7 +1555,11 @@
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["IfNotPresent", "Always", "Never"]
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
             }
           }
         },
@@ -1697,7 +1788,12 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["apiVersion", "kind", "name", "uid"]
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ]
     },
     "PersistentVolumeClaim": {
       "properties": {
@@ -1743,7 +1839,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["type", "status"]
+      "required": [
+        "type",
+        "status"
+      ]
     },
     "PersistentVolumeClaimSpec": {
       "properties": {
@@ -1831,7 +1930,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["spec"]
+      "required": [
+        "spec"
+      ]
     },
     "PersistentVolumeClaimVolumeSource": {
       "properties": {
@@ -1844,7 +1945,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["claimName"]
+      "required": [
+        "claimName"
+      ]
     },
     "PhotonPersistentDiskVolumeSource": {
       "properties": {
@@ -1857,7 +1960,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["pdID"]
+      "required": [
+        "pdID"
+      ]
     },
     "PodAffinity": {
       "properties": {
@@ -1909,7 +2014,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["topologyKey"]
+      "required": [
+        "topologyKey"
+      ]
     },
     "PodAntiAffinity": {
       "properties": {
@@ -1932,10 +2039,16 @@
     "PodDisruptionBudgetSpec": {
       "properties": {
         "minAvailable": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "maxUnavailable": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         }
       },
       "additionalProperties": false,
@@ -1994,7 +2107,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["metric", "target"]
+      "required": [
+        "metric",
+        "target"
+      ]
     },
     "PortworxVolumeSource": {
       "properties": {
@@ -2010,7 +2126,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["volumeID"]
+      "required": [
+        "volumeID"
+      ]
     },
     "PreferredSchedulingTerm": {
       "properties": {
@@ -2023,7 +2141,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["weight", "preference"]
+      "required": [
+        "weight",
+        "preference"
+      ]
     },
     "Probe": {
       "properties": {
@@ -2063,7 +2184,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["sources"]
+      "required": [
+        "sources"
+      ]
     },
     "Quantity": {
       "properties": {
@@ -2073,7 +2196,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["Format"]
+      "required": [
+        "Format"
+      ]
     },
     "QuobyteVolumeSource": {
       "properties": {
@@ -2098,7 +2223,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["registry", "volume"]
+      "required": [
+        "registry",
+        "volume"
+      ]
     },
     "RBDVolumeSource": {
       "properties": {
@@ -2132,7 +2260,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["monitors", "image"]
+      "required": [
+        "monitors",
+        "image"
+      ]
     },
     "ResourceClaim": {
       "properties": {
@@ -2142,7 +2273,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "ResourceFieldSelector": {
       "properties": {
@@ -2158,7 +2291,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["resource"]
+      "required": [
+        "resource"
+      ]
     },
     "ResourceList": {
       "additionalProperties": {
@@ -2175,7 +2310,10 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": ["string", "integer"]
+              "type": [
+                "string",
+                "integer"
+              ]
             },
             "memory": {
               "type": "string"
@@ -2187,7 +2325,10 @@
           "additionalProperties": false,
           "properties": {
             "cpu": {
-              "type": ["string", "integer"]
+              "type": [
+                "string",
+                "integer"
+              ]
             },
             "memory": {
               "type": "string"
@@ -2199,10 +2340,16 @@
     "RollingUpdateDaemonSet": {
       "properties": {
         "maxUnavailable": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "maxSurge": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         }
       },
       "additionalProperties": false,
@@ -2211,10 +2358,16 @@
     "RollingUpdateDeployment": {
       "properties": {
         "maxUnavailable": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "maxSurge": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         }
       },
       "additionalProperties": false,
@@ -2273,7 +2426,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["gateway", "system", "secretRef"]
+      "required": [
+        "gateway",
+        "system",
+        "secretRef"
+      ]
     },
     "SeccompProfile": {
       "properties": {
@@ -2286,7 +2443,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "SecretEnvSource": {
       "properties": {
@@ -2314,7 +2473,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["key"]
+      "required": [
+        "key"
+      ]
     },
     "SecretProjection": {
       "properties": {
@@ -2408,7 +2569,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["path"]
+      "required": [
+        "path"
+      ]
     },
     "PortsSpec": {
       "properties": {
@@ -2425,7 +2588,10 @@
           "type": "integer"
         },
         "targetPort": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "hostPort": {
           "type": "integer"
@@ -2436,7 +2602,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["port"]
+      "required": [
+        "port"
+      ]
     },
     "ServicePort": {
       "properties": {
@@ -2453,7 +2621,10 @@
           "type": "integer"
         },
         "targetPort": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "nodePort": {
           "type": "integer"
@@ -2461,7 +2632,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["port"]
+      "required": [
+        "port"
+      ]
     },
     "SleepAction": {
       "properties": {
@@ -2471,7 +2644,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "StorageOSVolumeSource": {
       "properties": {
@@ -2505,12 +2680,18 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name", "value"]
+      "required": [
+        "name",
+        "value"
+      ]
     },
     "TCPSocketAction": {
       "properties": {
         "port": {
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "host": {
           "type": "string"
@@ -2518,7 +2699,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["port"]
+      "required": [
+        "port"
+      ]
     },
     "Time": {
       "properties": {},
@@ -2578,7 +2761,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"]
+      "required": [
+        "maxSkew",
+        "topologyKey",
+        "whenUnsatisfiable"
+      ]
     },
     "TypedLocalObjectReference": {
       "properties": {
@@ -2594,7 +2781,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["apiGroup", "kind", "name"]
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ]
     },
     "TypedObjectReference": {
       "properties": {
@@ -2613,7 +2804,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["apiGroup", "kind", "name"]
+      "required": [
+        "apiGroup",
+        "kind",
+        "name"
+      ]
     },
     "Volume": {
       "properties": {
@@ -2710,7 +2905,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "VolumeDevice": {
       "properties": {
@@ -2723,7 +2920,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name", "devicePath"]
+      "required": [
+        "name",
+        "devicePath"
+      ]
     },
     "VolumeMount": {
       "properties": {
@@ -2748,7 +2948,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["name", "mountPath"]
+      "required": [
+        "name",
+        "mountPath"
+      ]
     },
     "VolumeProjection": {
       "properties": {
@@ -2800,7 +3003,9 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["volumePath"]
+      "required": [
+        "volumePath"
+      ]
     },
     "WeightedPodAffinityTerm": {
       "properties": {
@@ -2813,7 +3018,10 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["weight", "podAffinityTerm"]
+      "required": [
+        "weight",
+        "podAffinityTerm"
+      ]
     },
     "WindowsSecurityContextOptions": {
       "properties": {
@@ -3119,7 +3327,9 @@
               }
             }
           },
-          "required": ["enabled"]
+          "required": [
+            "enabled"
+          ]
         },
         "enabled": {
           "type": "boolean"
@@ -3203,7 +3413,11 @@
             },
             "pullPolicy": {
               "type": "string",
-              "enum": ["IfNotPresent", "Always", "Never"]
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
             }
           }
         },
@@ -3264,7 +3478,11 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["endpoint", "capabilities", "upgradeStrategy"]
+      "required": [
+        "endpoint",
+        "capabilities",
+        "upgradeStrategy"
+      ]
     },
     "AdditionalLabels": {
       "type": "object",
@@ -3279,7 +3497,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "title": "EnableConfigBlock"
     },
     "AttachMetadata": {
@@ -3290,7 +3510,9 @@
           "type": "boolean"
         }
       },
-      "required": ["node"],
+      "required": [
+        "node"
+      ],
       "title": "AttachMetadata"
     },
     "KubeAPIServer": {
@@ -3307,7 +3529,11 @@
           "$ref": "#/$defs/Monitor"
         }
       },
-      "required": ["enabled", "serviceMonitor", "tlsConfig"],
+      "required": [
+        "enabled",
+        "serviceMonitor",
+        "tlsConfig"
+      ],
       "title": "KubeAPIServer"
     },
     "TLSConfig": {
@@ -3321,7 +3547,10 @@
           "type": "boolean"
         }
       },
-      "required": ["insecureSkipVerify", "serverName"],
+      "required": [
+        "insecureSkipVerify",
+        "serverName"
+      ],
       "title": "TLSConfig"
     },
     "KubeDNS": {
@@ -3338,7 +3567,11 @@
           "$ref": "#/$defs/KubeServiceMonitor"
         }
       },
-      "required": ["enabled", "service", "serviceMonitor"],
+      "required": [
+        "enabled",
+        "service",
+        "serviceMonitor"
+      ],
       "title": "KubeDNS"
     },
     "KubeDNSService": {
@@ -3352,7 +3585,10 @@
           "$ref": "#/$defs/Dnsmasq"
         }
       },
-      "required": ["dnsmasq", "skydns"],
+      "required": [
+        "dnsmasq",
+        "skydns"
+      ],
       "title": "KubeDNSService"
     },
     "Dnsmasq": {
@@ -3366,7 +3602,10 @@
           "type": "integer"
         }
       },
-      "required": ["port", "targetPort"],
+      "required": [
+        "port",
+        "targetPort"
+      ],
       "title": "Dnsmasq"
     },
     "Kubelet": {
@@ -3383,7 +3622,11 @@
           "$ref": "#/$defs/KubeletServiceMonitor"
         }
       },
-      "required": ["enabled", "namespace", "serviceMonitor"],
+      "required": [
+        "enabled",
+        "namespace",
+        "serviceMonitor"
+      ],
       "title": "Kubelet"
     },
     "KubeletServiceMonitor": {
@@ -3440,7 +3683,12 @@
           "$ref": "#/$defs/KubeServiceMonitor"
         }
       },
-      "required": ["enabled", "endpoints", "service", "serviceMonitor"],
+      "required": [
+        "enabled",
+        "endpoints",
+        "service",
+        "serviceMonitor"
+      ],
       "title": "KubeServiceMonitorDefinition"
     },
     "KubeService": {
@@ -3481,7 +3729,9 @@
           ]
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "title": "KubeService"
     },
     "KubeServiceMonitor": {
@@ -3639,7 +3889,9 @@
           "$ref": "#/$defs/Monitor"
         }
       },
-      "required": ["monitor"],
+      "required": [
+        "monitor"
+      ],
       "title": "Prometheus"
     },
     "Monitor": {
@@ -3726,7 +3978,11 @@
           }
         }
       },
-      "required": ["action", "regex", "sourceLabels"],
+      "required": [
+        "action",
+        "regex",
+        "sourceLabels"
+      ],
       "title": "MetricRelabeling"
     },
     "Selector": {
@@ -3737,7 +3993,9 @@
           "$ref": "#/$defs/MatchLabels"
         }
       },
-      "required": ["matchLabels"],
+      "required": [
+        "matchLabels"
+      ],
       "title": "Selector"
     },
     "MatchLabels": {
@@ -3751,7 +4009,10 @@
           "type": "string"
         }
       },
-      "required": ["component", "provider"],
+      "required": [
+        "component",
+        "provider"
+      ],
       "title": "MatchLabels"
     },
     "KubeStateMetricsRbac": {
@@ -3762,7 +4023,9 @@
           "type": "boolean"
         }
       },
-      "required": ["create"],
+      "required": [
+        "create"
+      ],
       "title": "KubeStateMetricsRbac"
     },
     "PrometheusNodeExporter": {
@@ -3816,7 +4079,9 @@
           "type": "string"
         }
       },
-      "required": ["jobLabel"],
+      "required": [
+        "jobLabel"
+      ],
       "title": "PodLabels"
     },
     "PrometheusNodeExporterRbac": {
@@ -3827,7 +4092,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pspEnabled"],
+      "required": [
+        "pspEnabled"
+      ],
       "title": "PrometheusNodeExporterRbac"
     },
     "PrometheusNodeExporterService": {
@@ -3838,7 +4105,9 @@
           "type": "string"
         }
       },
-      "required": ["portName"],
+      "required": [
+        "portName"
+      ],
       "title": "PrometheusNodeExporterService"
     }
   },
@@ -3899,7 +4168,9 @@
           }
         }
       },
-      "required": ["enabled"]
+      "required": [
+        "enabled"
+      ]
     },
     "opAMPBridge": {
       "$ref": "#/$defs/OpAMPBridgeSpec"
@@ -3927,7 +4198,10 @@
           "type": "boolean"
         }
       },
-      "required": ["enabled", "ignoreNamespaceSelectors"]
+      "required": [
+        "enabled",
+        "ignoreNamespaceSelectors"
+      ]
     },
     "kubeApiServer": {
       "$ref": "#/$defs/KubeAPIServer"


### PR DESCRIPTION
Description:
Reformatting values.schema.json to standardize indentation and formatting with pre-commit pretty-format-json hook automation. There were no mismatching indentation in this file like there are in other charts, only list entries were split out to use multiple lines. No json values were added, modified, or removed.

Related PRs: 
- Helps unblock https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1573.