### PR TITLE
[operator] always include SERVICE_ACCOUNT_NAME env var

### DIFF
--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -84,8 +84,12 @@ spec:
             {{-  end  }}
           command:
             - /manager
-          {{- if or .Values.manager.env .Values.manager.extraEnvs .Values.manager.createRbacPermissions }}
           env:
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            {{- if or .Values.manager.env .Values.manager.extraEnvs }}
             {{- range $name, $value := .Values.manager.env }}
             - name: {{ $name }}
               value: {{ $value | quote }}
@@ -93,13 +97,7 @@ spec:
             {{- with .Values.manager.extraEnvs }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}
-            {{- if .Values.manager.createRbacPermissions }}
-            - name: SERVICE_ACCOUNT_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
             {{- end }}
-          {{- end }}
           image: {{ include "opentelemetry-operator.image" . | quote }}
           name: manager
           ports:


### PR DESCRIPTION
The environment variable SERVICE_ACCOUNT_NAME is needed by the operator in order to auto detect permissions.
Up till now it was set only if `manager.createRbacPermissions=true` but it is also needed to auto detect cert manager permissions for enabling the mTLS communication between the TA and the Collector.

This moves the environment variable to always be present so the operator can preform the necessary checks.

closes https://github.com/open-telemetry/opentelemetry-operator/issues/3811