### PR TITLE
[operator] Fix bug where the operator can be scheduled on windows nodes

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.84.1
+version: 0.84.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.86.0
+version: 0.86.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -3,8 +3,9 @@
 > [!WARNING]
 > Version 0.58.0 of this Chart includes a new version of the `OpenTelemetryCollector` CRD. See [this document][v1beta1_migration] for upgrade instructions for the new Operator CRD. Please make sure you also follow the [helm upgrade instructions](./UPGRADING.md#0560-to-0570) for helm chart 0.57.0.
 
-The Helm chart installs [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) in Kubernetes cluster.
+The Helm chart installs [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) in a Kubernetes cluster.
 The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://www.openshift.com/learn/topics/operators).
+The Operator's Docker image supports **only Linux** and cannot run on Windows nodes.
 At this point, it has [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) as the only managed component.
 
 ## Prerequisites

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.84.1
+        helm.sh/chart: opentelemetry-operator-0.84.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.120.0"
         app.kubernetes.io/managed-by: Helm
@@ -103,6 +103,8 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+      nodeSelector: 
+        kubernetes.io/os: linux
       serviceAccountName: opentelemetry-operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.86.0
+        helm.sh/chart: opentelemetry-operator-0.86.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.122.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,6 +44,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,6 +44,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532
@@ -57,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -95,6 +97,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -257,7 +257,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -276,7 +276,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.84.1
+        helm.sh/chart: opentelemetry-operator-0.84.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.120.0"
         app.kubernetes.io/managed-by: Helm
@@ -104,6 +104,8 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+      nodeSelector: 
+        kubernetes.io/os: linux
       serviceAccountName: opentelemetry-operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.86.0
+        helm.sh/chart: opentelemetry-operator-0.86.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.122.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,6 +44,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.86.0
+    helm.sh/chart: opentelemetry-operator-0.86.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -44,6 +44,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532
@@ -57,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.84.1
+    helm.sh/chart: opentelemetry-operator-0.84.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
@@ -95,6 +97,8 @@ spec:
             seccompProfile:
               type: RuntimeDefault
   restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
   securityContext:
     fsGroup: 65532
     runAsGroup: 65532

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -339,7 +339,8 @@ clusterRole:
 
 affinity: {}
 tolerations: []
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 topologySpreadConstraints: []
 hostNetwork: false
 


### PR DESCRIPTION
- Fix bug where the operator can be scheduled on windows nodes and cause pull image errors. The operator docker image doesn't support windows nodes.
- Tested locally via Minikube by deploying the operator to a Linux node.
- https://github.com/open-telemetry/opentelemetry-operator/issues/642