### PR TITLE
Promote jvoravong to approver and codeowner for operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Approvers ([@open-telemetry/helm-approvers](https://github.com/orgs/open-telemet
 
 - [Alex Birca](https://github.com/Allex1), Adobe
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
+- [Josh Voravong](https://github.com/jvoravong), Splunk
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 - [Povilas](https://github.com/povilasv), Coralogix
 


### PR DESCRIPTION
@jvoravong has been doing great work on this repo recently, especially on the Operator Helm chart. The maintainers would like to propose @jvoravong as an approver of the repo and codeowner for the Operator helm chart.

@jvoravong please approve if you agree.