### PR TITLE
docs: Change comment on how to activate go instrumentation

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.86.4
+version: 0.86.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -66,7 +66,7 @@ manager:
       repository: ""
       tag: ""
     # The Go instrumentation support in the operator is disabled by default.
-    # To enable it, use the operator.autoinstrumentation.go feature gate.
+    # To enable it, set manager.extraArgs[0] to "--enable-go-instrumentation"
     go:
       repository: ""
       tag: ""


### PR DESCRIPTION
Aligning the comment with the test case: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/10638c2317826a598e653bd831368ce6deea5e26/.github/workflows/operator-test.yaml#L60

And the instrumentation's changelog: https://github.com/open-telemetry/opentelemetry-operator/blob/65af20a9d627b053728bf6e53666f44324584c9c/CHANGELOG.md?plain=1#L961