### PR TITLE
fix(opentelemetry-operator): add revisionHistoryLimit option

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.88.3
+version: 0.88.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -15,6 +15,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-operator
@@ -24,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.3
+        helm.sh/chart: opentelemetry-operator-0.88.4
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -15,6 +15,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-operator
@@ -24,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.3
+        helm.sh/chart: opentelemetry-operator-0.88.4
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.3
+    helm.sh/chart: opentelemetry-operator-0.88.4
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "opentelemetry-operator.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -40,6 +40,14 @@
         1
       ]
     },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "default": 10,
+      "title": "The revisionHistoryLimit Schema",
+      "examples": [
+        1
+      ]
+    },
     "nameOverride": {
       "type": "string",
       "default": "",

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+## The number of old history to retain to allow rollback.
+##
+revisionHistoryLimit: 10
+
 ## Provide a name in place of opentelemetry-operator (includes the chart's release name).
 ##
 nameOverride: ""


### PR DESCRIPTION
The PR adds configuration option for `revisionHistoryLimit` to control the number of old ReplicaSets for rollback.

There will be no changes in default behaviour.
