### PR TITLE
Remove 'operator.observability.prometheus' from Helm chart comments

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.88.4
+version: 0.88.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.4
+        helm.sh/chart: opentelemetry-operator-0.88.5
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.4
+        helm.sh/chart: opentelemetry-operator-0.88.5
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -87,7 +87,6 @@ manager:
   # operator.targetallocator.fallbackstrategy: false
   # operator.collector.targetallocatorcr: false
   # operator.sidecarcontainers.native: false
-  # operator.observability.prometheus: false
   # operator.golang.flags: false
   # operator.collector.default.config: false
   ports:


### PR DESCRIPTION
As per https://github.com/open-telemetry/opentelemetry-helm-charts/blob/0bdda7e6b65507833bdd71555c975f7e4706fd34/charts/opentelemetry-operator/UPGRADING.md, the property is no longer supported here, removed in commit f9707d3aa2ce2debea19c93e5f949deb7cc80ceb