### PR TITLE
[Docs] Update default collectorImage.repository in Helm chart examples due to DockerHub Image deprecation

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.88.4
+version: 0.88.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/README.md
+++ b/charts/opentelemetry-operator/README.md
@@ -43,7 +43,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 
 ```console
 $ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
---set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s"
+--set "manager.collectorImage.repository=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
 ```
 
 If you created a custom namespace, like in the TLS Certificate Requirement section above, you will need to specify the namespace with the `--namespace` helm option:
@@ -51,14 +51,14 @@ If you created a custom namespace, like in the TLS Certificate Requirement secti
 ```console
 $ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
 --namespace opentelemetry-operator-system \
---set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s"
+--set "manager.collectorImage.repository=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
 ```
 
 If you wish for helm to create an automatically generated self-signed certificate, make sure to set the appropriate values when installing the chart:
 
 ```console
 $ helm install opentelemetry-operator open-telemetry/opentelemetry-operator \
---set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
+--set "manager.collectorImage.repository=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s \
 --set admissionWebhooks.certManager.enabled=false \
 --set admissionWebhooks.autoGenerateCert.enabled=true
 ```

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.4
+        helm.sh/chart: opentelemetry-operator-0.88.5
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.124.1
+            - --collector-image=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.124.1
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/values.yaml
+++ b/charts/opentelemetry-operator/examples/default/values.yaml
@@ -1,3 +1,3 @@
 manager:
   collectorImage:
-    repository: "otel/opentelemetry-collector-k8s"
+    repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -269,7 +269,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -288,7 +288,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.88.4
+        helm.sh/chart: opentelemetry-operator-0.88.5
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.124.0"
         app.kubernetes.io/managed-by: Helm
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.124.1
+            - --collector-image=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.124.1
             - --feature-gates=-operator.collector.targetallocatorcr,operator.targetallocator.mtls
           command:
             - /manager

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.88.4
+    helm.sh/chart: opentelemetry-operator-0.88.5
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.124.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/values.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/values.yaml
@@ -1,6 +1,6 @@
 manager:
   collectorImage:
-    repository: "otel/opentelemetry-collector-k8s"
+    repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
   featureGatesMap:
     operator.targetallocator.mtls: true
     operator.collector.targetallocatorcr: false


### PR DESCRIPTION
Update documentation examples to use the correct collector image repository.

This change follows the context of [Issue #1664](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1664), which highlights that the current default collectorImage.repository used in Helm install examples (otel/opentelemetry-collector-k8s) no longer provides updated images (after v0.123.1). This causes failed deployments when trying to use newer versions like v0.124.1.

This PR updates the install examples in the documentation to:
`
ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
`

as described in the [upgrading guidelines](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md).