### PR TITLE
Example ta collector deployments

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.126.0
+version: 0.126.1
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/README.md
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/README.md
@@ -1,0 +1,109 @@
+# Collector Fleet example
+
+This example shows a complete deployment of the Helm chart in conjunction with a set of collectors and Prometheus targets exposed via prometheus.io annotations using the consistent-hashing approach.
+
+The goal is to show a complete setup involving collectors, Prometheus scrape endpoints and the Target Allocator.
+
+# Prerequisites
+
+You will need a computer with Docker installed, [kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/) and optionally [Helm](https://helm.sh/).
+
+# Set up
+
+## Kind cluster
+Create a kind cluster with:
+```shell
+kind create cluster
+```
+
+## Deploy the helm chart
+
+From the root of the checkout of this repository:
+```shell
+helm upgrade --install ta charts/opentelemetry-target-allocator --values charts/opentelemetry-target-allocator/examples/collector-fleet/values.yaml
+```
+
+You can also apply the rendered manifests:
+
+```shell
+kubectl apply -f ./charts/opentelemetry-target-allocator/examples/collector-fleet/rendered
+```
+
+## Deploy Prometheus targets
+
+```shell
+kubectl apply -f ./charts/opentelemetry-target-allocator/examples/collector-fleet/prometheus_example_pods.yaml
+```
+
+## Deploy collectors
+
+```shell
+kubectl apply -f ./charts/opentelemetry-target-allocator/examples/collector-fleet/collectors.yaml
+```
+
+# Investigate and check the outputs
+
+## Check the target allocator scrape configs
+
+Expose the target allocator service to your host with:
+```shell
+kubectl port-forward service/ta-opentelemetry-target-allocator-ta 8080:80
+```
+
+You can then visit `http://localhost:8080/jobs/prom/targets` on your web browser to see the discovered targets.
+
+Example:
+```json
+{
+  "example-opentelemetry-collector-57fdb66b6-4np86": {
+    "_link": "/jobs/prom/targets?collector_id=example-opentelemetry-collector-57fdb66b6-4np86",
+    "targets": [
+      {
+        "targets": [
+          "10.244.0.22:8080"
+        ],
+        "labels": {
+          "__address__": "10.244.0.22:8080",
+          "__meta_kubernetes_namespace": "default",
+          "__meta_kubernetes_pod_annotation_prometheus_io_path": "/metrics",
+          "__meta_kubernetes_pod_annotation_prometheus_io_port": "8080",
+          "__meta_kubernetes_pod_annotation_prometheus_io_scrape": "true",
+          "__meta_kubernetes_pod_annotationpresent_prometheus_io_path": "true",
+          "__meta_kubernetes_pod_annotationpresent_prometheus_io_port": "true",
+          "__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape": "true",
+          "__meta_kubernetes_pod_container_id": "containerd://ecd848db8f93545de3ca0dc79d84b876a6babff166495c41db76a48216ee9ec4",
+          "__meta_kubernetes_pod_container_image": "quay.io/brancz/prometheus-example-app:v0.3.0",
+          "__meta_kubernetes_pod_container_init": "false",
+          "__meta_kubernetes_pod_container_name": "prom",
+          "__meta_kubernetes_pod_container_port_name": "http-port",
+          "__meta_kubernetes_pod_container_port_number": "8080",
+          "__meta_kubernetes_pod_container_port_protocol": "TCP",
+          "__meta_kubernetes_pod_controller_kind": "ReplicaSet",
+          "__meta_kubernetes_pod_controller_name": "prometheus-1-85bfd98dc6",
+          "__meta_kubernetes_pod_host_ip": "172.18.0.2",
+          "__meta_kubernetes_pod_ip": "10.244.0.22",
+          "__meta_kubernetes_pod_label_app": "prom",
+          "__meta_kubernetes_pod_label_pod_template_hash": "85bfd98dc6",
+          "__meta_kubernetes_pod_labelpresent_app": "true",
+          "__meta_kubernetes_pod_labelpresent_pod_template_hash": "true",
+          "__meta_kubernetes_pod_name": "prometheus-1-85bfd98dc6-gnq54",
+          "__meta_kubernetes_pod_node_name": "kind-control-plane",
+          "__meta_kubernetes_pod_phase": "Running",
+          "__meta_kubernetes_pod_ready": "true",
+          "__meta_kubernetes_pod_uid": "c746569e-34ee-4e6e-b80a-e5bd31b3f39f"
+        }
+      },
+<snip>
+```
+
+You can even visit individual links to see each collector's allocation.
+
+## Check out the collector outputs.
+
+Find a collector pod, get its logs:
+
+```shell
+kubectl logs $(kubectl get pods | grep collector | awk '{print $1}' | head -n 1)
+```
+
+You will see the collector logs metrics using the debug exporter.

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/collectors.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/collectors.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-configmap
+  namespace: default
+data:
+  relay: |
+    exporters:
+      debug:
+        verbosity: detailed
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      prometheus:
+        target_allocator:
+          endpoint: http://ta-opentelemetry-target-allocator-ta
+          interval: 30s
+          collector_id: ${env:K8S_POD_NAME}
+    service:
+      extensions:
+      - health_check
+      pipelines:
+        metrics:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-opentelemetry-collector
+  namespace: default
+  labels:
+    my-collector: "true"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      my-collector: "true"
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        my-collector: "true"
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-k8s
+          args:
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.123.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GOMEMLIMIT
+              value: "128MiB"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: "1"
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: collector-configmap
+            items:
+              - key: relay
+                path: relay.yaml
+      hostNetwork: false

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/prometheus_example_pods.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/prometheus_example_pods.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: prometheus-1
+spec:
+  replicas: 20
+  selector:
+    matchLabels:
+      app: prom
+  template:
+    metadata:
+      labels:
+        app: prom
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: prom
+          image: quay.io/brancz/prometheus-example-app:v0.3.0
+          ports:
+            - containerPort: 8080
+              name: http-port

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -1,0 +1,51 @@
+---
+# Source: opentelemetry-target-allocator/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: default
+  name: example-opentelemetry-target-allocator-ta-clusterRole
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheuses/finalizers
+      - alertmanagers/finalizers
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: opentelemetry-target-allocator/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
+  labels:
+    app.kubernetes.io/name: opentelemetry-target-allocator
+    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.123.0"
+    app: opentelemetry-target-allocator
+    chart: opentelemetry-target-allocator-0.0.1
+    release: example
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-opentelemetry-target-allocator-ta-clusterRole
+subjects:
+- kind: ServiceAccount
+  name: example-opentelemetry-target-allocator-ta
+  namespace: default

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -1,0 +1,38 @@
+---
+# Source: opentelemetry-target-allocator/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-target-allocator-ta-configmap
+  namespace: default
+  labels:
+    app.kubernetes.io/name: opentelemetry-target-allocator
+    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.123.0"
+    app: opentelemetry-target-allocator
+    chart: opentelemetry-target-allocator-0.0.1
+    release: example
+    heritage: Helm
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_namespace: default
+    collector_selector:
+      matchLabels:
+        my-collector: "true"
+      matchlabels:
+        app.kubernetes.io/component: agent-collector
+    config:
+      scrape_configs:
+      - job_name: prom
+        kubernetes_sd_configs:
+        - role: pod
+        scheme: http
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: false
+      pod_monitor_selector: {}
+      scrapeInterval: 30s
+      service_monitor_selector: {}

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -1,0 +1,57 @@
+---
+# Source: opentelemetry-target-allocator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: example-opentelemetry-target-allocator-ta
+  labels:
+    app: targetAllocator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: targetAllocator
+  template:
+    metadata:
+      labels:
+        app: targetAllocator
+    spec:
+      serviceAccountName: example-opentelemetry-target-allocator-ta
+      automountServiceAccountToken: false
+      containers:
+        - name: targetallocator
+          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0
+          ports:
+            - containerPort: 8080
+              name: http-port
+          volumeMounts:
+            - name: config-volume
+              mountPath: /conf/
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: serviceaccount-token
+              readOnly: true
+          env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
+            - name: OTELCOL_NAMESPACE
+              value: default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: example-opentelemetry-target-allocator-ta-configmap
+        - name: serviceaccount-token
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/service.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/service.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-target-allocator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: example-opentelemetry-target-allocator-ta
+spec:
+  selector:
+    app: targetAllocator
+  ports:
+    - name: http-port
+      protocol: TCP
+      port: 80
+      targetPort: http-port

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: opentelemetry-target-allocator/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: example-opentelemetry-target-allocator-ta
+  namespace: default
+  labels:
+    app.kubernetes.io/name: opentelemetry-target-allocator
+    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.123.0"
+    app: opentelemetry-target-allocator
+    chart: opentelemetry-target-allocator-0.0.1
+    release: example
+    heritage: Helm

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/values.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/values.yaml
@@ -1,0 +1,15 @@
+targetAllocator:
+  config:
+    allocation_strategy: consistent-hashing
+    collector_namespace: default
+    collector_selector:
+      matchLabels:
+        my-collector: "true"
+    prometheus_cr:
+      enabled: false
+    config:
+      scrape_configs:
+        - job_name: prom
+          scheme: http
+          kubernetes_sd_configs:
+            - role: pod


### PR DESCRIPTION
Built on top of #1657 - this adds a bit more information on how you can realistically use the helm chart with a set of prometheus targets and collectors.