### PR TITLE
Add k8sLeaderElector to clusterMetrics preset

### DIFF
--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -228,13 +228,14 @@ presets:
     enabled: true
 ```
 
-#### High Availability with k8sleaderelector
+#### Using leader election to keep cluster metrics from duplicating
 
 When running multiple collector replicas, you'll want to enable leader election to ensure only one collector instance is collecting cluster metrics at a time. This prevents duplicate metrics and reduces resource consumption.
 
-This feature requires:
-- The [k8sleaderelector extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector) 
-- Appropriate RBAC permissions to create and manage lease objects
+The clusterMetrics preset supports built-in leader election configuration that automatically:
+- Adds the [k8sleaderelector extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector)
+- Configures the necessary service extensions
+- Sets up appropriate RBAC permissions
 
 Here's an example configuration:
 
@@ -242,25 +243,21 @@ Here's an example configuration:
 mode: deployment
 replicaCount: 2
 
-# Add the k8s_leader_elector extension
 config:
   extensions:
     health_check:
       endpoint: ${env:MY_POD_IP}:13133
-    k8s_leader_elector:
-      lease_name: otel-collector-leader
-      lease_namespace: default
 
   service:
     extensions:
       - health_check
-      - k8s_leader_elector
 
 presets:
   clusterMetrics:
     enabled: true
-    # Reference the k8s_leader_elector extension
-    k8sLeaderElector: k8s_leader_elector
+    # Enable leader election to ensure only one collector instance
+    # is collecting cluster metrics at a time
+    enableLeaderElection: true
 ```
 
 See the [clusteMetricsWithLeaderElector example](./examples/clusteMetricsWithLeaderElector) for more details.

--- a/charts/opentelemetry-collector/ci/preset-clustermetrics-with-leader-election-values.yaml
+++ b/charts/opentelemetry-collector/ci/preset-clustermetrics-with-leader-election-values.yaml
@@ -1,0 +1,18 @@
+mode: deployment
+replicaCount: 2
+
+image:
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
+
+command:
+  name: "otelcol-k8s"
+
+presets:
+  clusterMetrics:
+    enabled: true
+    enableLeaderElection: true
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M

--- a/charts/opentelemetry-collector/examples/clusteMetricsWithLeaderElector/values.yaml
+++ b/charts/opentelemetry-collector/examples/clusteMetricsWithLeaderElector/values.yaml
@@ -1,0 +1,34 @@
+mode: deployment
+replicaCount: 2
+
+image:
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
+  
+command:
+  name: "otelcol-k8s"
+
+# Add the k8s_leader_elector extension
+config:
+  extensions:
+    health_check:
+      endpoint: ${env:MY_POD_IP}:13133
+    k8s_leader_elector:
+      lease_name: otel-collector-leader
+      lease_namespace: default
+
+  service:
+    extensions:
+      - health_check
+      - k8s_leader_elector
+
+presets:
+  clusterMetrics:
+    enabled: true
+    # Reference the k8s_leader_elector extension to ensure only one collector instance
+    # is collecting cluster metrics at a time
+    k8sLeaderElector: k8s_leader_elector
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 400M

--- a/charts/opentelemetry-collector/examples/clusteMetricsWithLeaderElector/values.yaml
+++ b/charts/opentelemetry-collector/examples/clusteMetricsWithLeaderElector/values.yaml
@@ -7,26 +7,21 @@ image:
 command:
   name: "otelcol-k8s"
 
-# Add the k8s_leader_elector extension
 config:
   extensions:
     health_check:
       endpoint: ${env:MY_POD_IP}:13133
-    k8s_leader_elector:
-      lease_name: otel-collector-leader
-      lease_namespace: default
 
   service:
     extensions:
       - health_check
-      - k8s_leader_elector
 
 presets:
   clusterMetrics:
     enabled: true
-    # Reference the k8s_leader_elector extension to ensure only one collector instance
+    # Enable leader election to ensure only one collector instance
     # is collecting cluster metrics at a time
-    k8sLeaderElector: k8s_leader_elector
+    enableLeaderElection: true
 
 resources:
   limits:

--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -10,13 +10,11 @@
 {{- fail "[ERROR] dnsConfig should be provided when dnsPolicy is None" }}
 {{ end }}
 
-{{- if .Values.presets.clusterMetrics.enabled }}
-{{- if eq .Values.mode "daemonset"}}
-{{- fail "Cluster Metrics preset is not suitable for daemonset mode. Please use statefulset or deployment mode with replicaCount: 1"}}
+{{- if and .Values.presets.clusterMetrics.enabled .Values.presets.clusterMetrics.k8sLeaderElector (not (regexMatch "^[^[:space:]]+$" .Values.presets.clusterMetrics.k8sLeaderElector)) }}
+{{- fail "Cluster Metrics preset k8sLeaderElector value must be a valid extension ID or empty." }}
 {{ end }}
-{{- if gt (int .Values.replicaCount) 1 }}
-{{- fail "Cluster Metrics preset is not suitable for replicaCount greater than one. Please change replica count to one." }}
-{{ end }}
+{{- if and .Values.presets.clusterMetrics.enabled (gt (int .Values.replicaCount) 1) (eq .Values.presets.clusterMetrics.k8sLeaderElector "") }}
+[WARNING] Running multiple replicas with clusterMetrics preset without configuring k8sLeaderElector may cause duplicate metrics. Consider setting up the k8sleaderelector extension.
 {{ end }}
 
 {{/* validate extensions must include health_check */}}

--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -10,11 +10,8 @@
 {{- fail "[ERROR] dnsConfig should be provided when dnsPolicy is None" }}
 {{ end }}
 
-{{- if and .Values.presets.clusterMetrics.enabled .Values.presets.clusterMetrics.k8sLeaderElector (not (regexMatch "^[^[:space:]]+$" .Values.presets.clusterMetrics.k8sLeaderElector)) }}
-{{- fail "Cluster Metrics preset k8sLeaderElector value must be a valid extension ID or empty." }}
-{{ end }}
-{{- if and .Values.presets.clusterMetrics.enabled (gt (int .Values.replicaCount) 1) (eq .Values.presets.clusterMetrics.k8sLeaderElector "") }}
-[WARNING] Running multiple replicas with clusterMetrics preset without configuring k8sLeaderElector may cause duplicate metrics. Consider setting up the k8sleaderelector extension.
+{{- if and .Values.presets.clusterMetrics.enabled (gt (int .Values.replicaCount) 1) (not .Values.presets.clusterMetrics.enableLeaderElection) }}
+[WARNING] Running multiple replicas with clusterMetrics preset without enableLeaderElection may cause duplicate metrics. Consider setting enableLeaderElection to true.
 {{ end }}
 
 {{/* validate extensions must include health_check */}}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -204,6 +204,9 @@ receivers:
 receivers:
   k8s_cluster:
     collection_interval: 10s
+    {{- if and .Values.presets.clusterMetrics.k8sLeaderElector (regexMatch "^[^[:space:]]+$" .Values.presets.clusterMetrics.k8sLeaderElector) }}
+    k8s_leader_elector: {{ .Values.presets.clusterMetrics.k8sLeaderElector }}
+    {{- end }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -73,15 +73,14 @@ presets:
   # Adds the k8s_cluster receiver to the metrics pipeline
   # and adds the necessary rules to ClusterRole.
   # Can be used with mode = deployment, statefulset, or daemonset.
-  # When running multiple replicas, the k8sleaderelector extension can be configured
+  # When running multiple replicas, leader election should be enabled
   # to ensure only one collector instance is collecting metrics at a time.
   # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver for details on the receiver.
   clusterMetrics:
     enabled: false
-    # Specify the k8sleaderelector extension ID to enable leader election when multiple replicas are used.
-    # This requires configuring and enabling the k8sleaderelector extension separately.
-    # Example: k8sleaderelector
-    k8sLeaderElector: ""
+    # When set to true, automatically configures leader election for k8s_cluster receiver
+    # to prevent duplicate metrics when running multiple replicas
+    enableLeaderElection: false
 
 configMap:
   # Specifies whether a configMap should be created (true by default)

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -72,10 +72,16 @@ presets:
   # Configures the Kubernetes Cluster Receiver to collect cluster-level metrics.
   # Adds the k8s_cluster receiver to the metrics pipeline
   # and adds the necessary rules to ClusterRole.
-  # Best used with mode = deployment or statefulset.
+  # Can be used with mode = deployment, statefulset, or daemonset.
+  # When running multiple replicas, the k8sleaderelector extension can be configured
+  # to ensure only one collector instance is collecting metrics at a time.
   # See https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver for details on the receiver.
   clusterMetrics:
     enabled: false
+    # Specify the k8sleaderelector extension ID to enable leader election when multiple replicas are used.
+    # This requires configuring and enabling the k8sleaderelector extension separately.
+    # Example: k8sleaderelector
+    k8sLeaderElector: ""
 
 configMap:
   # Specifies whether a configMap should be created (true by default)


### PR DESCRIPTION
This pull request introduces enhancements to the OpenTelemetry Collector Helm chart to support high availability for cluster metrics collection using the `k8sleaderelector` extension. The changes include documentation updates, configuration examples, validation improvements, and support for leader election in multi-replica setups.

### High Availability and Leader Election Support:
* Added documentation in `charts/opentelemetry-collector/README.md` to explain how to configure the `k8sleaderelector` extension for high availability when running multiple replicas. This ensures only one collector instance collects cluster metrics at a time.
* Introduced a new example configuration in `charts/opentelemetry-collector/examples/clusteMetricsWithLeaderElector/values.yaml` to demonstrate the use of `k8sleaderelector` with deployment mode and multiple replicas.

### Validation and Configuration Updates:
* Updated `charts/opentelemetry-collector/templates/NOTES.txt` to include validation for the `k8sLeaderElector` extension and warnings about potential duplicate metrics when running multiple replicas without leader election.
* Modified `charts/opentelemetry-collector/templates/_config.tpl` to conditionally add the `k8s_leader_elector` configuration to the Kubernetes Cluster Receiver based on the `k8sLeaderElector` value.
* Updated `charts/opentelemetry-collector/values.yaml` to include a new `k8sLeaderElector` field under `clusterMetrics` for specifying the leader election extension ID. Adjusted comments to reflect support for deployment, statefulset, and daemonset modes.