### PR TITLE
fix(opentelemetry-operator): allow rbac subjectaccessreviews

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.90.2
+version: 0.90.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -345,13 +345,19 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -370,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -383,11 +389,5 @@ rules:
       - authentication.k8s.io
     resources:
       - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
     verbs:
       - create

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.90.2
+        helm.sh/chart: opentelemetry-operator-0.90.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.126.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -345,13 +345,19 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -370,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -383,11 +389,5 @@ rules:
       - authentication.k8s.io
     resources:
       - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
     verbs:
       - create

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.90.2
+        helm.sh/chart: opentelemetry-operator-0.90.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.126.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.90.2
+    helm.sh/chart: opentelemetry-operator-0.90.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -364,6 +364,12 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 
 {{ if .Values.kubeRBACProxy.enabled }}
 ---
@@ -392,12 +398,6 @@ rules:
       - authentication.k8s.io
     resources:
       - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
     verbs:
       - create
 {{- end }}


### PR DESCRIPTION
Hi,

The operator tries to create multiple SubjectAccessReview at startup in order to test rights and enable/disable features dynamically such as RBAC creation (cf [this](https://github.com/open-telemetry/opentelemetry-operator/blob/a419080834a9f5e382652e795e499cd3689b0ff5/internal/config/config.go#L143)). Without this right all these features remain disabled.

Some error logs I was having:
```
{"level":"LEVEL(-2)","timestamp":"2025-05-25T19:34:46Z","logger":"config","message":"the rbac permissions are not set for the operator","reason":"unable to check rbac rules: subjectaccessreviews.authorization.k8s.io is forbidden: User \"system:serviceaccount:opentelemetry-operator:opentelemetry-operator\" cannot create resource \"subjectaccessreviews\" in API group \"authorization.k8s.io\" at the cluster scope"}
```