### PR TITLE
[opentelemetry-kube-stack] Support extra kubernetes manifests

### DIFF
--- a/charts/opentelemetry-kube-stack/templates/extramanifests.yaml
+++ b/charts/opentelemetry-kube-stack/templates/extramanifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -1742,3 +1742,25 @@ prometheus-node-exporter:
     ## If true, create PSPs for node-exporter
     ##
     pspEnabled: false
+
+## Array of extra manifests to deploy
+## This will deploy arbitrary manifests as part of the helm relase
+extraObjects: []
+# - apiVersion: secrets-store.csi.x-k8s.io/v1
+#   kind: SecretProviderClass
+#   metadata:
+#     name: my-secret-provider
+#   spec:
+#     parameters:
+#       objects: >
+#         - secretPath: xxxxxxx/yyyy
+#           objectName: "imagePullSecret"
+#           secretKey: registry-credentials
+#       vaultAddress: xxxxxxx
+#     provider: vault
+#     secretObjects:
+#       - data:
+#           - key: .dockerconfigjson
+#             objectName: imagePullSecret
+#         secretName: demo-image-pull-secrets
+#         type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Support for extra kubernetes manifest without coupling the chart to other CRDs.

For example, if secrets need to be recovered from Secrets CSI Driver, it can be done like

```yaml
extraObjects: 
- apiVersion: secrets-store.csi.x-k8s.io/v1
  kind: SecretProviderClass
  metadata:
    name: demo
    namespace: test-app
  spec:
    parameters:
      objects: >
        - secretPath: xxxxxxx/data/registry-credentials
          objectName: "imagePullSecret"
          secretKey: registry-credentials
      vaultAddress: xxxxxxx
    provider: vault
    secretObjects:
      - data:
          - key: .dockerconfigjson
            objectName: imagePullSecret
        secretName: demo-image-pull-secrets
        type: kubernetes.io/dockerconfigjson
```