### PR TITLE
[charts/target-allocator] update to 0.126.0

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.0.1
+version: 0.126.0
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -9,4 +9,4 @@ sources:
 maintainers:
   - name: atoulme
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
-appVersion: 0.123.0
+appVersion: 0.126.0

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 rules:

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,9 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 roleRef:

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 data:

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 spec:
@@ -20,9 +20,9 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.0.1
+        helm.sh/chart: opentelemetry-target-allocator-0.126.0
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "0.123.0"
+        app.kubernetes.io/version: "0.126.0"
         app.kubernetes.io/name: opentelemetry-target-allocator
         app.kubernetes.io/instance: example
     spec:
@@ -30,7 +30,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: targetallocator
-          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0
+          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.126.0
           ports:
             - containerPort: 8080
               name: http-port

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,8 +7,8 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 data:

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 spec:
@@ -20,9 +20,9 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.0.1
+        helm.sh/chart: opentelemetry-target-allocator-0.126.0
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "0.123.0"
+        app.kubernetes.io/version: "0.126.0"
         app.kubernetes.io/name: opentelemetry-target-allocator
         app.kubernetes.io/instance: example
     spec:
@@ -30,7 +30,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: targetallocator
-          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0
+          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.126.0
           ports:
             - containerPort: 8080
               name: http-port

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 rules:

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,9 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 roleRef:

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 data:

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example
 spec:
@@ -20,9 +20,9 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.0.1
+        helm.sh/chart: opentelemetry-target-allocator-0.126.0
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "0.123.0"
+        app.kubernetes.io/version: "0.126.0"
         app.kubernetes.io/name: opentelemetry-target-allocator
         app.kubernetes.io/instance: example
     spec:
@@ -30,7 +30,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: targetallocator
-          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0
+          image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.126.0
           ports:
             - containerPort: 8080
               name: http-port

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,8 +7,8 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.0.1
+    helm.sh/chart: opentelemetry-target-allocator-0.126.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "0.123.0"
+    app.kubernetes.io/version: "0.126.0"
     app.kubernetes.io/name: opentelemetry-target-allocator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-target-allocator/templates/_helpers.tpl
+++ b/charts/opentelemetry-target-allocator/templates/_helpers.tpl
@@ -84,3 +84,10 @@ Create the name of the target allocator cluster role binding to use
 {{- define "helper.targetAllocatorClusterRoleBindingName" -}}
 {{- printf "%s-ta-clusterRoleBinding" ( include "helper.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the target allocator docker image name.
+*/}}
+{{- define "helper.dockerImageName" -}}
+{{- printf "%s:%s" .Values.targetAllocator.image.repository (.Values.targetAllocator.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/opentelemetry-target-allocator/templates/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: targetallocator
-          image: {{ .Values.targetAllocator.image }}
+          image: {{ template "helper.dockerImageName" . }}
           ports:
             - containerPort: 8080
               name: http-port

--- a/charts/opentelemetry-target-allocator/values.schema.json
+++ b/charts/opentelemetry-target-allocator/values.schema.json
@@ -23,7 +23,7 @@
       "additionalProperties": false,
       "properties": {
         "image": {
-          "$ref": "#/definitions/DockerImage"
+          "$ref": "#/definitions/ContainerImage"
         },
         "imagePullSecrets": {
           "type": "array"
@@ -37,7 +37,7 @@
       },
       "title": "TargetAllocator"
     },
-    "DockerImage": {
+    "ContainerImage": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/charts/opentelemetry-target-allocator/values.schema.json
+++ b/charts/opentelemetry-target-allocator/values.schema.json
@@ -23,7 +23,7 @@
       "additionalProperties": false,
       "properties": {
         "image": {
-          "type": "string"
+          "$ref": "#/definitions/DockerImage"
         },
         "imagePullSecrets": {
           "type": "array"
@@ -36,6 +36,18 @@
         }
       },
       "title": "TargetAllocator"
+    },
+    "DockerImage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
     },
     "Config": {
       "type": "object",

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -14,7 +14,10 @@ nameOverride: ""
 fullnameOverride: ""
 
 targetAllocator:
-  image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.124.0
+  image:
+    repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+    # The tag of the Target Allocator image, default value is the chart appVersion
+    tag: ""
   # Secrets to attach to the respective serviceaccount to pull docker images
   imagePullSecrets: []
   serviceAccount:


### PR DESCRIPTION
This PR:
* changes the default tag used by the target allocator image to use the appVersion if not set explicitly
* changes the tag used to pull the target allocator image to 0.126.0 from 0.123.0
* changes the version of the chart to 0.126.0 from 0.0.1 to match the release cycle of targetAllocator.