### PR TITLE
[chore] Update Helm dependencies used in github workflows to 3.18.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,20 +12,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Helm
-      uses: azure/setup-helm@v4.2.0
+    - name: Install Helm
+      uses: azure/setup-helm@v4
       with:
-        version: ${{ inputs.helm-version }}
+        version: v3.18.0
 
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.6.0
+      uses: helm/chart-testing-action@v2.7.0
 
     - name: Create kind cluster
-      uses: helm/kind-action@v1.8.0
+      uses: helm/kind-action@v1.12.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
       with:
         config: ./.github/kind-1.24.yaml

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: helm/kind-action@v1.12.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
       with:
-        config: ./.github/kind-1.24.yaml
+        config: ./.github/kind-1.32.yaml
 
     - name: Add Dependencies
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,7 +15,7 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@v4
       with:
-        version: v3.18.0
+        version: v3.18.1
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/kind-1.32.yaml
+++ b/.github/kind-1.32.yaml
@@ -4,7 +4,7 @@ networking:
   ipFamily: dual
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab
+    image: kindest/node:v1.32.5@sha256:5d5a4d793d2a3d9727013b8b0cf6c95008c71abeb547759a273ef27e9c564984
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration

--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.14.4"
 
       - name: Run chart-testing (install)
         run: "ct install --charts charts/opentelemetry-demo

--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -21,9 +21,4 @@ jobs:
           create-kind-cluster: "true"
 
       - name: Run chart-testing (install)
-        run: "ct install --charts charts/opentelemetry-demo
-          --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
-          --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
-          --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
-          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"
+        run: "ct install --charts charts/opentelemetry-demo"

--- a/.github/workflows/kube-stack-test.yaml
+++ b/.github/workflows/kube-stack-test.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.11.3"
 
       # We'll need this eventually, but for now leave it commented.
       - name: Install cert-manager

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,12 +19,7 @@ jobs:
           create-kind-cluster: "false"
 
       - name: Run chart-testing (lint)
-        run: "ct lint --target-branch main
-          --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
-          --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
-          --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
-          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"
+        run: "ct lint --target-branch main"
 
       - name: Run make check-examples
         run: make check-examples

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "false"
-          helm-version: "v3.14.4"
 
       - name: Run chart-testing (lint)
         run: "ct lint --target-branch main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,18 +26,8 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-        with:
-          version: v3.9.0
-
-      - name: Add dependent repositories
-        run: |
-          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-          helm repo add prometheus https://prometheus-community.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo add jaeger https://jaegertracing.github.io/helm-charts
-          helm repo add opensearch https://opensearch-project.github.io/helm-charts
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains [Helm](https://helm.sh/) charts for OpenTelemetry proje
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use the charts.
-Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+- Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+- This project is maintained using Helm v3.18.0.
 
 Once Helm is set up properly, add the repo as follows:
 

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.6.1
+version: 0.6.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -187,7 +187,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.6.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.6.2

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.6.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.6.2

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
@@ -13,9 +13,9 @@ collectors:
       allocationStrategy: per-node
       prometheusCR:
         enabled: true
-        podMonitorSelector:
+        podMonitorSelector: {}
         scrapeInterval: "30s"
-        serviceMonitorSelector:
+        serviceMonitorSelector: {}
     config:
       exporters:
         otlp:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
@@ -13,9 +13,9 @@ collectors:
       allocationStrategy: per-node
       prometheusCR:
         enabled: true
-        podMonitorSelector: {}
+        podMonitorSelector:
         scrapeInterval: "30s"
-        serviceMonitorSelector: {}
+        serviceMonitorSelector:
     config:
       exporters:
         otlp:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -192,7 +192,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.6.1
+    helm.sh/chart: opentelemetry-kube-stack-0.6.2
     app.kubernetes.io/version: "0.120.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -62,4 +62,4 @@ spec:
           - -c
           - |
             kubectl delete instrumentations,opampbridges,opentelemetrycollectors \
-              -l helm.sh/chart=opentelemetry-kube-stack-0.6.1
+              -l helm.sh/chart=opentelemetry-kube-stack-0.6.2


### PR DESCRIPTION
- Helm Dependency Update:  
  - Updated Helm dependencies in GitHub workflows from version 3.X to 3.18.0.
  - This update ensures quality Helm-rendered examples, in other projects I noticed example render issues caused by using outdated Helm dependencies. No breaking changes were identified in this project.
- Documentation Enhancement:  
  - Added the Helm version (3.18.0) used to maintain this project to the README.md.
  - This provides clarity for customers who may be using older Helm versions, helping them avoid functionality issues with the charts in this project.
- Code Cleanup:  
  - Improved uniformity across related areas for better consistency and maintainability.