### PR TITLE
[chore] Update Kubernetes to 1.32.5 and Helm to 3.18.1; add version docs; improve code uniformity

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,23 +12,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Helm
-      uses: azure/setup-helm@v4.2.0
+    - name: Install Helm
+      uses: azure/setup-helm@v4
       with:
-        version: ${{ inputs.helm-version }}
+        version: v3.18.1
 
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.6.0
+      uses: helm/chart-testing-action@v2.7.0
 
     - name: Create kind cluster
-      uses: helm/kind-action@v1.8.0
+      uses: helm/kind-action@v1.12.0
       if: ${{ inputs.create-kind-cluster == 'true' }}
       with:
-        config: ./.github/kind-1.24.yaml
+        config: ./.github/kind-1.32.yaml
 
     - name: Add Dependencies
       shell: bash

--- a/.github/kind-1.32.yaml
+++ b/.github/kind-1.32.yaml
@@ -4,7 +4,7 @@ networking:
   ipFamily: dual
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab
+    image: kindest/node:v1.32.5@sha256:5d5a4d793d2a3d9727013b8b0cf6c95008c71abeb547759a273ef27e9c564984
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration

--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -19,12 +19,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.14.4"
 
       - name: Run chart-testing (install)
-        run: "ct install --charts charts/opentelemetry-demo
-          --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
-          --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
-          --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
-          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"
+        run: "ct install --charts charts/opentelemetry-demo"

--- a/.github/workflows/kube-stack-test.yaml
+++ b/.github/workflows/kube-stack-test.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.11.3"
 
       # We'll need this eventually, but for now leave it commented.
       - name: Install cert-manager

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,15 +17,9 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "false"
-          helm-version: "v3.14.4"
 
       - name: Run chart-testing (lint)
-        run: "ct lint --target-branch main
-          --chart-repos opentelemetry-collector=https://open-telemetry.github.io/opentelemetry-helm-charts
-          --chart-repos prometheus=https://prometheus-community.github.io/helm-charts
-          --chart-repos grafana=https://grafana.github.io/helm-charts
-          --chart-repos jaeger=https://jaegertracing.github.io/helm-charts
-          --chart-repos opensearch=https://opensearch-project.github.io/helm-charts"
+        run: "ct lint --target-branch main"
 
       - name: Run make check-examples
         run: make check-examples

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,18 +26,8 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-        with:
-          version: v3.9.0
-
-      - name: Add dependent repositories
-        run: |
-          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-          helm repo add prometheus https://prometheus-community.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo add jaeger https://jaegertracing.github.io/helm-charts
-          helm repo add opensearch https://opensearch-project.github.io/helm-charts
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains [Helm](https://helm.sh/) charts for OpenTelemetry proje
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use the charts.
-Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+- Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+- This project is maintained using Kubernetes 1.32 and Helm v3.18.1.
 
 Once Helm is set up properly, add the repo as follows:
 


### PR DESCRIPTION
- Kubernetes and Helm Dependency Update:
  - Updated Kubernetes (kind) version from 1.24 (maintenance support ended on July 28th, 2023) to 1.32.5 (latest)
  - Updated Helm and related dependencies in GitHub workflows from version 3.X to 3.18.1.
  - This update ensures quality of Helm-rendered examples, in other projects I noticed example render issues caused by using outdated Helm dependencies. 
  - No breaking changes were identified in this project when using Kubernetes 1.32 and Helm 3.18.1.
    - But a breaking change was identified specifically for Helm 3.18.0 which causes a chart lint bug and maybe a Helm install/upgrade bug in the opentelemetry-kube-stack chart (CC: @jaronoff97).
    - [Github workflow run example](https://github.com/open-telemetry/opentelemetry-helm-charts/actions/runs/15393266228/job/43307474948?pr=1698#step:5:821)  
    - _"error converting YAML to JSON: yaml: line X: mapping values are not allowed in this context" in charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml._ 
    - The fix is already out, just use Helm 3.18.1 which is currently latest.
- Documentation Enhancement:  
  - Documented versions Kubernetes and Helm versions used to maintain this project in README.md. This is important for customers and really should be a matrix like document that grows over time, keeping it simple for now and just adding a couple static doc lines.
- Code Cleanup:  
  - Improved uniformity across related areas for better consistency and maintainability.