### PR TITLE
Pin image tags and repositories on values.yaml file

### DIFF
--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -72,8 +72,8 @@ manager:
     # The Go instrumentation support in the operator is disabled by default.
     # To enable it, use the operator.autoinstrumentation.go feature gate.
     go:
-      repository: "ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go"
-      tag: "v0.21.0"
+      repository: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+      tag: v0.21.0
   # Feature Gates are a comma-delimited list of feature gate identifiers.
   # Prefix a gate with '-' to disable support.
   # Prefixing a gate with '+' or no prefix will enable support.

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -43,37 +43,37 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: ""
+    tag: 0.126.0
   collectorImage:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
     tag: 0.126.0
   opampBridgeImage:
-    repository: ""
-    tag: ""
+    repository: ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge
+    tag: 0.126.0
   targetAllocatorImage:
-    repository: ""
-    tag: ""
+    repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+    tag: 0.126.0
   autoInstrumentationImage:
     java:
-      repository: ""
-      tag: ""
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java
+      tag: 1.33.6
     nodejs:
-      repository: ""
-      tag: ""
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
+      tag: 0.58.1
     python:
-      repository: ""
-      tag: ""
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
+      tag: 0.54b1
     dotnet:
-      repository: ""
-      tag: ""
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet
+      tag: 1.2.0
     apacheHttpd:
-      repository: ""
-      tag: ""
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd
+      tag: 1.0.4
     # The Go instrumentation support in the operator is disabled by default.
     # To enable it, use the operator.autoinstrumentation.go feature gate.
     go:
-      repository: ""
-      tag: ""
+      repository: "ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go"
+      tag: "v0.21.0"
   # Feature Gates are a comma-delimited list of feature gate identifiers.
   # Prefix a gate with '-' to disable support.
   # Prefixing a gate with '+' or no prefix will enable support.

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -43,16 +43,16 @@ pdb:
 manager:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    tag: 0.126.0
+    tag: 0.127.0
   collectorImage:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
-    tag: 0.126.0
+    tag: 0.127.0
   opampBridgeImage:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge
-    tag: 0.126.0
+    tag: 0.127.0
   targetAllocatorImage:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
-    tag: 0.126.0
+    tag: 0.127.0
   autoInstrumentationImage:
     java:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java


### PR DESCRIPTION
Hi Team, 

When using this chart in an air gape environment, we should not have to specify tags but only the new repository.
This problem was already mentioned in this [issue](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1585).