### PR TITLE
fix(opentelemetry-kube-stack): Custom collectors missing empty volumes and volumeMounts arrays during dry-runs

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.6.1
+version: 0.6.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/templates/collector.yaml
+++ b/charts/opentelemetry-kube-stack/templates/collector.yaml
@@ -113,6 +113,7 @@ spec:
   {{- toYaml . | nindent 4}}
   {{- end }}
   volumeMounts:
+  {{- if or ($collector.presets.logsCollection.enabled) ($collector.presets.logsCollection.storeCheckpoints) ($collector.presets.hostMetrics.enabled) ($collector.volumeMounts) }}
   {{- if $collector.presets.logsCollection.enabled }}
   - name: varlogpods
     mountPath: /var/log/pods
@@ -133,6 +134,9 @@ spec:
   {{- end }}
   {{- with $collector.volumeMounts }}
   {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- else }}
+  {{- toYaml $collector.volumeMounts | nindent 4 }}
   {{- end }}
   {{- with $collector.ports }}
   ports:
@@ -180,11 +184,12 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   volumes:
+  {{- if or ($collector.presets.logsCollection.enabled) ($collector.presets.logsCollection.storeCheckpoints) ($collector.presets.hostMetrics.enabled) ($collector.volumes) }}
   {{- if $collector.presets.logsCollection.enabled }}
   - name: varlogpods
     hostPath:
       path: /var/log/pods
-  {{- if $collector.presets.logsCollection.storeCheckpoints}}
+  {{- if $collector.presets.logsCollection.storeCheckpoints }}
   - name: varlibotelcol
     hostPath:
       path: /var/lib/otelcol
@@ -201,6 +206,9 @@ spec:
   {{- end }}
   {{- with $collector.volumes }}
   {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- else }}
+  {{- toYaml $collector.volumes | nindent 4 }}
   {{- end }}
   {{- with $collector.initContainers }}
   initContainers:


### PR DESCRIPTION
Signed-off-by: AvivGuiser <avivguiser@gmail.com>