### PR TITLE
[FEATURE] adding annotation discovery preset

### DIFF
--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -63,3 +63,7 @@
 {{- if .Values.config.service.telemetry.metrics.address }}
 [WARNING] config.service.telemetry.metrics.address should not be used and will be removed in the future. Use internalTelemetryViaOTLP or config.service.telemetry.metrics.readers  instead"
 {{ end }}
+
+{{- if and .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
+{{- fail "[ERROR] logsCollection and annotationDiscovery.logs are mutually exclusive" }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -95,6 +95,9 @@ Build config file for daemonset OpenTelemetry Collector
 {{- if .Values.presets.logsCollection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
+{{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $config = (include "opentelemetry-collector.applyAnnotationDiscoveryConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
 {{- if .Values.presets.hostMetrics.enabled }}
 {{- $config = (include "opentelemetry-collector.applyHostMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -119,6 +122,9 @@ Build config file for deployment OpenTelemetry Collector
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
 {{- if .Values.presets.logsCollection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $config = (include "opentelemetry-collector.applyAnnotationDiscoveryConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
 {{- if .Values.presets.hostMetrics.enabled }}
 {{- $config = (include "opentelemetry-collector.applyHostMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
@@ -259,6 +265,46 @@ receivers:
         id: container-parser
         max_log_size: {{ $.Values.presets.logsCollection.maxRecombineLogSize }}
 {{- end }}
+
+{{- define "opentelemetry-collector.applyAnnotationDiscoveryConfig" -}}
+{{- $config := mustMergeOverwrite (include "opentelemetry-collector.annotationDiscoveryConfig" .Values | fromYaml) .config }}
+{{- $_ := set $config.service "extensions" (append $config.service.extensions "k8s_observer" | uniq) }}
+{{- if .Values.presets.annotationDiscovery.logs.enabled }}
+{{- $_ := set $config.service.pipelines "logs/discovery" (dict "receivers" (list "receiver_creator/logs") "processors" (list "memory_limiter") "exporters" (list)) }}
+{{- end }}
+{{- if .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "receiver_creator/metrics" | uniq) }}
+{{- end }}
+{{- $config | toYaml }}
+{{- end }}
+
+{{- define "opentelemetry-collector.annotationDiscoveryConfig" -}}
+extensions:
+  k8s_observer:
+    auth_type: serviceAccount
+    node: ${env:K8S_NODE_NAME}
+
+receivers:
+  {{- if .Values.presets.annotationDiscovery.logs.enabled }}
+  receiver_creator/logs:
+    watch_observers:
+      - k8s_observer
+    discovery:
+      enabled: true
+      default_annotations:
+        io.opentelemetry.discovery.logs/enabled: true
+    receivers:
+  {{- end }}
+  {{- if .Values.presets.annotationDiscovery.metrics.enabled }}
+  receiver_creator/metrics:
+    watch_observers:
+      - k8s_observer
+    discovery:
+      enabled: true
+    receivers:
+  {{- end }}
+{{- end }}
+
 
 {{- define "opentelemetry-collector.applyKubernetesAttributesConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.kubernetesAttributesConfig" .Values | fromYaml) .config }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -52,7 +52,7 @@ containers:
           fieldRef:
             apiVersion: v1
             fieldPath: status.podIP
-      {{- if or .Values.presets.kubeletMetrics.enabled (and .Values.presets.kubernetesAttributes.enabled (eq .Values.mode "daemonset")) }}
+      {{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled .Values.presets.kubeletMetrics.enabled (and .Values.presets.kubernetesAttributes.enabled (eq .Values.mode "daemonset")) }}
       - name: K8S_NODE_NAME
         valueFrom:
           fieldRef:
@@ -145,7 +145,7 @@ containers:
       - mountPath: /conf
         name: {{ include "opentelemetry-collector.lowercase_chartname" . }}-configmap
       {{- end }}
-      {{- if .Values.presets.logsCollection.enabled }}
+      {{- if or .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
       - name: varlogpods
         mountPath: /var/log/pods
         readOnly: true
@@ -185,7 +185,7 @@ volumes:
         - key: relay
           path: relay.yaml
   {{- end }}
-  {{- if .Values.presets.logsCollection.enabled }}
+  {{- if or .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
   - name: varlogpods
     hostPath:
       path: /var/log/pods

--- a/charts/opentelemetry-collector/templates/clusterrole.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole.yaml
@@ -53,4 +53,17 @@ rules:
     resources: ["events"]
     verbs: ["watch", "list"]
   {{- end }}
+  {{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats"]
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -77,6 +77,12 @@ presets:
   clusterMetrics:
     enabled: false
 
+  annotationDiscovery:
+    logs:
+      enabled: false
+    metrics:
+      enabled: false
+
 configMap:
   # Specifies whether a configMap should be created (true by default)
   create: true


### PR DESCRIPTION
This pull request introduces support for annotation-based discovery of logs and metrics in the OpenTelemetry Collector Helm chart. It adds new configuration options, updates templates to handle the new presets, and ensures mutual exclusivity between certain features. Below is a summary of the most important changes:

### New Feature: Annotation-Based Discovery
* Added a new `annotationDiscovery` preset in `values.yaml` that allows enabling discovery of logs and metrics based on Kubernetes annotations. (`charts/opentelemetry-collector/values.yaml`, [charts/opentelemetry-collector/values.yamlR80-R85](diffhunk://#diff-eba1f4eaa1181faf6ab17062aea0b2a92c389a268983766d94eb72f5ec8caa2fR80-R85))
* Introduced new Helm template definitions for `annotationDiscoveryConfig` and `applyAnnotationDiscoveryConfig` to configure the OpenTelemetry Collector for annotation-based discovery. These include setting up pipelines and receivers for logs and metrics. (`charts/opentelemetry-collector/templates/_config.tpl`, [charts/opentelemetry-collector/templates/_config.tplR269-R308](diffhunk://#diff-d3c8687b50b2f7b2ca10ff878367b16b76ead0cfdf62548091b5bcc507dc2d68R269-R308))

### Configuration Updates
* Updated `_config.tpl` to include `applyAnnotationDiscoveryConfig` when either logs or metrics discovery is enabled. (`charts/opentelemetry-collector/templates/_config.tpl`, [[1]](diffhunk://#diff-d3c8687b50b2f7b2ca10ff878367b16b76ead0cfdf62548091b5bcc507dc2d68R98-R100) [[2]](diffhunk://#diff-d3c8687b50b2f7b2ca10ff878367b16b76ead0cfdf62548091b5bcc507dc2d68R126-R128)
* Added a warning in `NOTES.txt` to ensure `logsCollection` and `annotationDiscovery.logs` are not enabled simultaneously, as they are mutually exclusive. (`charts/opentelemetry-collector/templates/NOTES.txt`, [charts/opentelemetry-collector/templates/NOTES.txtR66-R69](diffhunk://#diff-2fb737005349f26461a300a9384dcdda67c6aa6a6ae664434177c5a8b80b2ab0R66-R69))

### Kubernetes Role Adjustments
* Updated `clusterrole.yaml` to grant necessary permissions for annotation-based discovery, including access to `pods`, `nodes`, and related resources. (`charts/opentelemetry-collector/templates/clusterrole.yaml`, [charts/opentelemetry-collector/templates/clusterrole.yamlR56-R68](diffhunk://#diff-90d239d89326a6deff28c0f8b4ba4b44b3e813d58df9c1dd696d77f5740c7089R56-R68))

### Pod Configuration
* Modified `_pod.tpl` to set the `K8S_NODE_NAME` environment variable when annotation-based discovery is enabled and to adjust volume mounts for logs collection. (`charts/opentelemetry-collector/templates/_pod.tpl`, [[1]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L55-R55) [[2]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L148-R148) [[3]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L188-R188)