### PR TITLE
[opentelemetry-kube-stack]: Merge both collectors in a single one with leader election

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.lock
+++ b/charts/opentelemetry-kube-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.84.2
+  version: 0.90.4
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.21.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.37.3
-digest: sha256:210ead814b2f995a8dabdb6f376c3f7284cbf78cc9fc12dfade08cc669e3d078
-generated: "2025-05-13T19:25:32.669708+03:00"
+digest: sha256:6e4901cac61d86b2333d6a674221daa057ae1a4831babc82cf0ca5c2f5fa4605
+generated: "2025-06-27T13:34:54.752777+02:00"

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.6.1
+version: 0.7.0
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -16,7 +16,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 # the appVersion stays aligned with the operator's latest version. If the collector has a patch
 # release, the collector's latest patch will be manually overridden.
-appVersion: 0.120.0
+appVersion: 0.126.0
 dependencies:
   - name: otel-crds
     version: "0.0.0"
@@ -26,7 +26,7 @@ dependencies:
     condition: crds.install,crds.installPrometheus
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.84.2
+    version: 0.90.4
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "5.21.*"

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -177,6 +177,19 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $eventsEnabled = true }}
 {{- end }}
 {{- end }}
+{{- if or $clusterMetricsEnabled $eventsEnabled}}
+- verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
 {{- if $clusterMetricsEnabled }}
 - apiGroups:
   - ""
@@ -239,6 +252,7 @@ Optionally include the RBAC for the k8sCluster receiver
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -481,6 +481,10 @@ collectors:
         enabled: true
       kubernetesAttributes:
         enabled: true
+      kubernetesEvents:
+        enabled: true
+      clusterMetrics:
+        enabled: true
     config:
       receivers:
         otlp:
@@ -527,48 +531,6 @@ collectors:
               - batch
             exporters:
               - debug
-  cluster:
-    suffix: cluster-stats
-    replicas: 1
-    mode: deployment
-    enabled: true
-    resources:
-      limits:
-        cpu: 200m
-        memory: 500Mi
-      requests:
-        cpu: 100m
-        memory: 250Mi
-    presets:
-      kubernetesAttributes:
-        enabled: true
-      kubernetesEvents:
-        enabled: true
-      clusterMetrics:
-        enabled: true
-    config:
-      receivers: {}
-      processors:
-        batch:
-          send_batch_size: 1000
-          timeout: 1s
-          send_batch_max_size: 1500
-        resourcedetection/env:
-          detectors: [env]
-          timeout: 2s
-          override: false
-      exporters:
-        debug: {}
-      service:
-        pipelines:
-          metrics:
-            receivers: [k8s_cluster]
-            processors: [resourcedetection/env, batch]
-            exporters: [debug]
-          logs:
-            receivers: [k8sobjects]
-            processors: [resourcedetection/env, batch]
-            exporters: [debug]
 
 # Cluster role configuration
 clusterRole:


### PR DESCRIPTION
This PR bumps the operator dependency and merges both collectors in a single one running as daemonset with support to leader election for k8s api receivers, getting rid of the collector deployed as single instance deployment

Fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1726