### PR TITLE
fix: use part-of kubernetes label instead of instance in demo chart

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.37.1
+version: 0.37.2
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -504,10 +504,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -525,7 +525,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -572,10 +572,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -593,7 +593,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -650,10 +650,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -671,7 +671,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -737,10 +737,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -758,7 +758,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -801,10 +801,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -822,7 +822,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -865,10 +865,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -886,7 +886,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -986,10 +986,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1007,7 +1007,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1055,10 +1055,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1076,7 +1076,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1147,10 +1147,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1168,7 +1168,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1245,10 +1245,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1266,7 +1266,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1309,10 +1309,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1330,7 +1330,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1379,10 +1379,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1400,7 +1400,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1461,10 +1461,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1482,7 +1482,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1531,10 +1531,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1552,7 +1552,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1604,10 +1604,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1625,7 +1625,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1672,10 +1672,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1693,7 +1693,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1744,10 +1744,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1765,7 +1765,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1808,10 +1808,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1829,7 +1829,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -504,10 +504,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -525,7 +525,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -572,10 +572,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -593,7 +593,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -650,10 +650,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -671,7 +671,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -737,10 +737,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -758,7 +758,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -801,10 +801,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -822,7 +822,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -865,10 +865,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -886,7 +886,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -986,10 +986,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1007,7 +1007,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1055,10 +1055,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1076,7 +1076,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1147,10 +1147,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1168,7 +1168,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1245,10 +1245,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1266,7 +1266,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1309,10 +1309,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1330,7 +1330,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1379,10 +1379,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1400,7 +1400,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1461,10 +1461,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1482,7 +1482,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1531,10 +1531,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1552,7 +1552,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1604,10 +1604,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1625,7 +1625,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1672,10 +1672,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1693,7 +1693,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1744,10 +1744,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1765,7 +1765,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1808,10 +1808,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1829,7 +1829,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,9 +6,9 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -506,10 +506,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -527,7 +527,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -576,10 +576,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -597,7 +597,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -656,10 +656,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -677,7 +677,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -745,10 +745,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -766,7 +766,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -811,10 +811,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -832,7 +832,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -877,10 +877,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -898,7 +898,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -998,10 +998,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1019,7 +1019,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1069,10 +1069,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1090,7 +1090,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1163,10 +1163,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1184,7 +1184,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1261,10 +1261,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1282,7 +1282,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1325,10 +1325,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1346,7 +1346,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1395,10 +1395,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1416,7 +1416,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1479,10 +1479,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1500,7 +1500,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1551,10 +1551,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1572,7 +1572,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1626,10 +1626,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1647,7 +1647,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1696,10 +1696,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1717,7 +1717,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1770,10 +1770,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1791,7 +1791,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1836,10 +1836,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1857,7 +1857,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,9 +6,9 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -504,10 +504,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -525,7 +525,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -572,10 +572,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -593,7 +593,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -650,10 +650,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -671,7 +671,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -737,10 +737,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -758,7 +758,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -801,10 +801,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -822,7 +822,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -865,10 +865,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -886,7 +886,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -986,10 +986,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1007,7 +1007,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1055,10 +1055,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1076,7 +1076,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1147,10 +1147,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1168,7 +1168,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1245,10 +1245,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1266,7 +1266,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1309,10 +1309,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1330,7 +1330,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1379,10 +1379,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1400,7 +1400,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1461,10 +1461,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1482,7 +1482,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1531,10 +1531,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1552,7 +1552,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1604,10 +1604,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1625,7 +1625,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1672,10 +1672,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1693,7 +1693,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1744,10 +1744,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1765,7 +1765,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1808,10 +1808,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1829,7 +1829,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,9 +6,9 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -504,10 +504,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -525,7 +525,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -572,10 +572,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -593,7 +593,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -650,10 +650,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -671,7 +671,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -737,10 +737,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -758,7 +758,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -801,10 +801,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -822,7 +822,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -865,10 +865,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -886,7 +886,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -986,10 +986,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1007,7 +1007,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1055,10 +1055,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1076,7 +1076,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1147,10 +1147,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1168,7 +1168,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1245,10 +1245,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1266,7 +1266,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1309,10 +1309,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1330,7 +1330,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1379,10 +1379,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1400,7 +1400,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1461,10 +1461,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1482,7 +1482,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1531,10 +1531,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1552,7 +1552,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1604,10 +1604,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1625,7 +1625,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1672,10 +1672,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1693,7 +1693,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1744,10 +1744,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1765,7 +1765,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1808,10 +1808,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1829,7 +1829,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,9 +6,9 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -30,10 +30,10 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -80,10 +80,10 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -105,10 +105,10 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -161,10 +161,10 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -186,10 +186,10 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -211,10 +211,10 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -236,10 +236,10 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -264,10 +264,10 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -289,10 +289,10 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -314,10 +314,10 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -339,10 +339,10 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -364,10 +364,10 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -389,10 +389,10 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -414,10 +414,10 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -439,10 +439,10 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: accounting
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: accounting
     app.kubernetes.io/name: accounting
     app.kubernetes.io/version: "2.0.2"
@@ -460,7 +460,7 @@ spec:
       labels:
         
         opentelemetry.io/name: accounting
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: accounting
         app.kubernetes.io/name: accounting
     spec:
@@ -504,10 +504,10 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: ad
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: ad
     app.kubernetes.io/name: ad
     app.kubernetes.io/version: "2.0.2"
@@ -525,7 +525,7 @@ spec:
       labels:
         
         opentelemetry.io/name: ad
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: ad
         app.kubernetes.io/name: ad
     spec:
@@ -572,10 +572,10 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: cart
     app.kubernetes.io/name: cart
     app.kubernetes.io/version: "2.0.2"
@@ -593,7 +593,7 @@ spec:
       labels:
         
         opentelemetry.io/name: cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: cart
         app.kubernetes.io/name: cart
     spec:
@@ -650,10 +650,10 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: checkout
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: checkout
     app.kubernetes.io/name: checkout
     app.kubernetes.io/version: "2.0.2"
@@ -671,7 +671,7 @@ spec:
       labels:
         
         opentelemetry.io/name: checkout
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: checkout
         app.kubernetes.io/name: checkout
     spec:
@@ -737,10 +737,10 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: currency
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: currency
     app.kubernetes.io/name: currency
     app.kubernetes.io/version: "2.0.2"
@@ -758,7 +758,7 @@ spec:
       labels:
         
         opentelemetry.io/name: currency
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: currency
         app.kubernetes.io/name: currency
     spec:
@@ -801,10 +801,10 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: email
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: email
     app.kubernetes.io/name: email
     app.kubernetes.io/version: "2.0.2"
@@ -822,7 +822,7 @@ spec:
       labels:
         
         opentelemetry.io/name: email
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: email
         app.kubernetes.io/name: email
     spec:
@@ -865,10 +865,10 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: flagd
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: flagd
     app.kubernetes.io/name: flagd
     app.kubernetes.io/version: "2.0.2"
@@ -886,7 +886,7 @@ spec:
       labels:
         
         opentelemetry.io/name: flagd
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: flagd
         app.kubernetes.io/name: flagd
     spec:
@@ -986,10 +986,10 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: fraud-detection
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: fraud-detection
     app.kubernetes.io/name: fraud-detection
     app.kubernetes.io/version: "2.0.2"
@@ -1007,7 +1007,7 @@ spec:
       labels:
         
         opentelemetry.io/name: fraud-detection
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: fraud-detection
         app.kubernetes.io/name: fraud-detection
     spec:
@@ -1055,10 +1055,10 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend
     app.kubernetes.io/name: frontend
     app.kubernetes.io/version: "2.0.2"
@@ -1076,7 +1076,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend
         app.kubernetes.io/name: frontend
     spec:
@@ -1147,10 +1147,10 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"
@@ -1168,7 +1168,7 @@ spec:
       labels:
         
         opentelemetry.io/name: frontend-proxy
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: frontend-proxy
         app.kubernetes.io/name: frontend-proxy
     spec:
@@ -1245,10 +1245,10 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: image-provider
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: image-provider
     app.kubernetes.io/name: image-provider
     app.kubernetes.io/version: "2.0.2"
@@ -1266,7 +1266,7 @@ spec:
       labels:
         
         opentelemetry.io/name: image-provider
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: image-provider
         app.kubernetes.io/name: image-provider
     spec:
@@ -1309,10 +1309,10 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: kafka
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: kafka
     app.kubernetes.io/name: kafka
     app.kubernetes.io/version: "2.0.2"
@@ -1330,7 +1330,7 @@ spec:
       labels:
         
         opentelemetry.io/name: kafka
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: kafka
         app.kubernetes.io/name: kafka
     spec:
@@ -1379,10 +1379,10 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: load-generator
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: load-generator
     app.kubernetes.io/name: load-generator
     app.kubernetes.io/version: "2.0.2"
@@ -1400,7 +1400,7 @@ spec:
       labels:
         
         opentelemetry.io/name: load-generator
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: load-generator
         app.kubernetes.io/name: load-generator
     spec:
@@ -1461,10 +1461,10 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: payment
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: payment
     app.kubernetes.io/name: payment
     app.kubernetes.io/version: "2.0.2"
@@ -1482,7 +1482,7 @@ spec:
       labels:
         
         opentelemetry.io/name: payment
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: payment
         app.kubernetes.io/name: payment
     spec:
@@ -1531,10 +1531,10 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: product-catalog
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: product-catalog
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/version: "2.0.2"
@@ -1552,7 +1552,7 @@ spec:
       labels:
         
         opentelemetry.io/name: product-catalog
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: product-catalog
         app.kubernetes.io/name: product-catalog
     spec:
@@ -1604,10 +1604,10 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: quote
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: quote
     app.kubernetes.io/name: quote
     app.kubernetes.io/version: "2.0.2"
@@ -1625,7 +1625,7 @@ spec:
       labels:
         
         opentelemetry.io/name: quote
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: quote
         app.kubernetes.io/name: quote
     spec:
@@ -1672,10 +1672,10 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: recommendation
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: recommendation
     app.kubernetes.io/name: recommendation
     app.kubernetes.io/version: "2.0.2"
@@ -1693,7 +1693,7 @@ spec:
       labels:
         
         opentelemetry.io/name: recommendation
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: recommendation
         app.kubernetes.io/name: recommendation
     spec:
@@ -1744,10 +1744,10 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: shipping
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: shipping
     app.kubernetes.io/name: shipping
     app.kubernetes.io/version: "2.0.2"
@@ -1765,7 +1765,7 @@ spec:
       labels:
         
         opentelemetry.io/name: shipping
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: shipping
         app.kubernetes.io/name: shipping
     spec:
@@ -1808,10 +1808,10 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: valkey-cart
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: valkey-cart
     app.kubernetes.io/name: valkey-cart
     app.kubernetes.io/version: "2.0.2"
@@ -1829,7 +1829,7 @@ spec:
       labels:
         
         opentelemetry.io/name: valkey-cart
-        app.kubernetes.io/instance: example
+        app.kubernetes.io/part-of: example
         app.kubernetes.io/component: valkey-cart
         app.kubernetes.io/name: valkey-cart
     spec:
@@ -1870,10 +1870,10 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
     opentelemetry.io/name: frontend-proxy
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/component: frontend-proxy
     app.kubernetes.io/name: frontend-proxy
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,9 +6,9 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,9 +6,9 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
@@ -6,9 +6,9 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.1
+    helm.sh/chart: opentelemetry-demo-0.37.2
     
-    app.kubernetes.io/instance: example
+    app.kubernetes.io/part-of: example
     app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/templates/_helpers.tpl
+++ b/charts/opentelemetry-demo/templates/_helpers.tpl
@@ -32,7 +32,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Workload (Pod) labels
 */}}
 {{- define "otel-demo.workloadLabels" -}}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- if .name }}
 app.kubernetes.io/component: {{ .name}}
 app.kubernetes.io/name: {{ .name }}


### PR DESCRIPTION
The [Kubernetes Recommended Labels docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) say that instance should be a unique identifier for an instance of an application. Here, it's set to the helm installation name everywhere. I think `part-of` is more appropriate in this case.

Using `instance` creates issues when scraping service labels per the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#how-servicename-should-be-calculated): since no `resource.opentelemetry.io/service.name` annotation is provided, this well known k8s label `app.kubernetes.io/instance` is checked next. The result is that all of the data from the workload pods sent through `k8sattributes processor` using the `service.name` metadata will come out with the same `service.name` (ex: "my-otel-demo" when using [the example install command](https://opentelemetry.io/docs/platforms/kubernetes/helm/demo/#installation)).

If you think this is an issue with the semantic conventions, please let me know and I will take this discussion to that repo instead. Thanks in advance!

(note: this is a one-line diff on `charts/opentelemetry-demo/templates/_helpers.tpl` plus the result of `make generate-examples`)