### PR TITLE
[opentelemetry-kube-stack] Update opentelemetry-operator dependency to v0.90.4

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.6.2
+version: 0.6.3
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -16,7 +16,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 # the appVersion stays aligned with the operator's latest version. If the collector has a patch
 # release, the collector's latest patch will be manually overridden.
-appVersion: 0.120.0
+appVersion: 0.126.0
 dependencies:
   - name: otel-crds
     version: "0.0.0"
@@ -26,7 +26,7 @@ dependencies:
     condition: crds.install,crds.installPrometheus
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.84.2
+    version: 0.90.4
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "5.21.*"


### PR DESCRIPTION
## Description
Updates the opentelemetry-operator chart dependency from v0.84.2 to v0.90.4, which brings the operator version from 0.120.0 to 0.126.0.

## Problem
The current kube-stack chart uses an older operator version (0.120.0) that has telemetry configuration compatibility issues. Users experience collector startup failures with the error: 

```
'service.telemetry.metrics' decoding failed due to the following error(s): '' has invalid keys: address
```

## Solution
- Bump chart version: 0.6.2 → 0.6.3
- Bump appVersion: 0.120.0 → 0.126.0  
- Update opentelemetry-operator dependency: 0.84.2 → 0.90.4

## Testing
- [ ] Helm chart linting passes
- [ ] Chart installs successfully with new operator version
- [ ] Resolves telemetry configuration conflicts

## Related Issues
Fixes compatibility issues with deprecated telemetry address field injection.

