### PR TITLE
Restrict operator version to 63 chars

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.92.1
+version: 0.92.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -376,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.92.1
+        helm.sh/chart: opentelemetry-operator-0.92.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.129.1"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -376,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.92.1
+        helm.sh/chart: opentelemetry-operator-0.92.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.129.1"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.1
+    helm.sh/chart: opentelemetry-operator-0.92.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Create chart name and version as used by the chart label.
 Create Operator version.
 */}}
 {{- define "opentelemetry-operator.appVersion" -}}
-{{ default .Chart.AppVersion .Values.manager.image.tag }}
+{{ default .Chart.AppVersion .Values.manager.image.tag | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
 There are multiple resources deployed by the otel operator that have the following required label
[app.kubernetes.io/version](http://app.kubernetes.io/version) . The label value must be below 63 char, defined [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).

The image tag is being set in the opentelemetry operator  here - [https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-ope[…]tor-0.76.0/charts/opentelemetry-operator/templates/_helpers.tpl](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-operator-0.76.0/charts/opentelemetry-operator/templates/_helpers.tpl#L37)
and used in the label here - [https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-ope[…]tor-0.76.0/charts/opentelemetry-operator/templates/_helpers.tpl](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-operator-0.76.0/charts/opentelemetry-operator/templates/_helpers.tpl#L46)

Previously it was set to appVersion and did not cause any problems. But if image SHA256 digest is used, the image tag can easily be over 63 char and hence deployment is not possible for people using this as a subchart.

Related issue: #1637