### PR TITLE
fix: image tags longer than 63 chars getting truncated

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.92.2
+version: 0.92.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -376,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.92.2
+        helm.sh/chart: opentelemetry-operator-0.92.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.129.1"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -376,7 +376,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.92.2
+        helm.sh/chart: opentelemetry-operator-0.92.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.129.1"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.92.2
+    helm.sh/chart: opentelemetry-operator-0.92.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.129.1"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/_helpers.tpl
+++ b/charts/opentelemetry-operator/templates/_helpers.tpl
@@ -171,7 +171,7 @@ Return the name of the cert-manager.io/inject-ca-from annotation for webhooks an
 The image to use for opentelemetry-operator.
 */}}
 {{- define "opentelemetry-operator.image" -}}
-{{- printf "%s:%s" .Values.manager.image.repository (include "opentelemetry-operator.appVersion" .) }}
+{{- printf "%s:%s" .Values.manager.image.repository (default .Chart.AppVersion .Values.manager.image.tag) }}
 {{- end }}
 
 {{- define "opentelemetry-operator.featureGatesMap" -}}


### PR DESCRIPTION
## Description

There was a change in latest chart that truncated appVersion to 63 chars: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1778. Since `"opentelemetry-operator.appVersion"` is also used to define `"opentelemetry-operator.image"`, this has an unintended side effect, where image tags were getting truncated. 

There is no max limit of tag length in OCI spec, so this can cause problems. It is also a common practice to specify digests as a part of tags like: `tag_name@sha256:digest_sha`, this gets truncated. 

This PR decouples `"opentelemetry-operator.image"` and `"opentelemetry-operator.appVersion"`.