### PR TITLE
Bump OTel Demo sub charts

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.117.1
+  version: 0.130.1
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
-  version: 3.4.0
+  version: 3.4.1
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 27.4.0
+  version: 27.29.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 8.10.1
+  version: 9.3.1
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
   version: 2.31.0
-digest: sha256:2061f81bda153f1616ae989ce4eb75e6f2eca876de1f31d45267d396a22380dc
-generated: "2025-02-25T22:21:05.393113-05:00"
+digest: sha256:75640502e3538c126fd43640dfb08ee65f58a6cba76a63883e98b4f6a3b75dfc
+generated: "2025-08-07T15:43:15.795918+02:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -15,19 +15,19 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: 2.0.2
 dependencies:
   - name: opentelemetry-collector
-    version: 0.117.1
+    version: 0.130.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
   - name: jaeger
-    version: 3.4.0
+    version: 3.4.1
     repository: https://jaegertracing.github.io/helm-charts
     condition: jaeger.enabled
   - name: prometheus
-    version: 27.4.0
+    version: 27.29.1
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
   - name: grafana
-    version: 8.10.1
+    version: 9.3.1
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: opensearch

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,10 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.10.1
+        helm.sh/chart: grafana-9.3.1
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "11.5.2"
+        app.kubernetes.io/version: "12.1.0"
       annotations:
         checksum/config: 99cca986c6d5f6511900d815ee5a70d0c284aeb70af56fb96108c7bf456eff87
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.5.2"
+          image: "docker.io/grafana/grafana:12.1.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 rules:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 roleRef:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 data:
@@ -159,7 +159,6 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
           level: detailed
           readers:
           - periodic:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,13 +6,14 @@ metadata:
   name: otel-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 spec:
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-collector
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9b4a65e93ade8654d3602b026145ddf8244ed93f2cc4aa81d58df111908c12d7
+        checksum/config: 96b7047e4e12219c3f29d3c1cbba1e3a0a26f454e91c6bdfdbe8e3f1c190fe45
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:
@@ -34,6 +35,7 @@ spec:
     spec:
       
       serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -42,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.120.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
@@ -28,7 +28,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/deploy.yaml
@@ -7,12 +7,15 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default
 spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/component: server
@@ -20,17 +23,14 @@ spec:
       app.kubernetes.io/instance: example
   replicas: 1
   revisionHistoryLimit: 10
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v3.1.0
-        helm.sh/chart: prometheus-27.4.0
+        app.kubernetes.io/version: v3.5.0
+        helm.sh/chart: prometheus-27.29.1
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v3.1.0"
+          image: "quay.io/prometheus/prometheus:v3.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,10 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.10.1
+        helm.sh/chart: grafana-9.3.1
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "11.5.2"
+        app.kubernetes.io/version: "12.1.0"
       annotations:
         checksum/config: 99cca986c6d5f6511900d815ee5a70d0c284aeb70af56fb96108c7bf456eff87
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.5.2"
+          image: "docker.io/grafana/grafana:12.1.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 rules:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 roleRef:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 data:
@@ -166,7 +166,6 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
           level: detailed
           readers:
           - periodic:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 62985ab6fdce0c9c82b48d4654a8cc73ebd555652464ccb6547236d216163d26
+        checksum/config: cc38c5239abdecefccac8f64bc65ae585475f547deb871bfa7d0aab016150846
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:
@@ -36,6 +36,7 @@ spec:
     spec:
       
       serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -44,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.120.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
@@ -28,7 +28,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/deploy.yaml
@@ -7,12 +7,15 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default
 spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/component: server
@@ -20,17 +23,14 @@ spec:
       app.kubernetes.io/instance: example
   replicas: 1
   revisionHistoryLimit: 10
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v3.1.0
-        helm.sh/chart: prometheus-27.4.0
+        app.kubernetes.io/version: v3.5.0
+        helm.sh/chart: prometheus-27.29.1
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v3.1.0"
+          image: "quay.io/prometheus/prometheus:v3.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,10 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.10.1
+        helm.sh/chart: grafana-9.3.1
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "11.5.2"
+        app.kubernetes.io/version: "12.1.0"
       annotations:
         checksum/config: 99cca986c6d5f6511900d815ee5a70d0c284aeb70af56fb96108c7bf456eff87
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.5.2"
+          image: "docker.io/grafana/grafana:12.1.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 rules:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 roleRef:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 data:
@@ -157,7 +157,6 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
           level: detailed
           readers:
           - periodic:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 926b9ff95e3c843878db38a0f0ee9d894dca81a2332acab49a01bab5b60021d1
+        checksum/config: 20aff486daf7d8ffd6f24703bb895929eae8f9258ec36f227c48925f51209623
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:
@@ -36,6 +36,7 @@ spec:
     spec:
       
       serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -44,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.120.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
@@ -28,7 +28,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/deploy.yaml
@@ -7,12 +7,15 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default
 spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/component: server
@@ -20,17 +23,14 @@ spec:
       app.kubernetes.io/instance: example
   replicas: 1
   revisionHistoryLimit: 10
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v3.1.0
-        helm.sh/chart: prometheus-27.4.0
+        app.kubernetes.io/version: v3.5.0
+        helm.sh/chart: prometheus-27.29.1
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v3.1.0"
+          image: "quay.io/prometheus/prometheus:v3.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,10 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.10.1
+        helm.sh/chart: grafana-9.3.1
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "11.5.2"
+        app.kubernetes.io/version: "12.1.0"
       annotations:
         checksum/config: 99cca986c6d5f6511900d815ee5a70d0c284aeb70af56fb96108c7bf456eff87
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.5.2"
+          image: "docker.io/grafana/grafana:12.1.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 rules:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 roleRef:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 data:
@@ -230,7 +230,6 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
           level: detailed
           readers:
           - periodic:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/daemonset.yaml
@@ -6,13 +6,14 @@ metadata:
   name: otel-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector
 spec:
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-collector
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 774748bc8a0fa5248b8b10b95213e8c18f5bde5c672e0283260d2a35f410ee63
+        checksum/config: 5883a6251271995dac3f28684719b9bcb9b2cdfb0677e1d77f0918bd271562f6
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:
@@ -34,6 +35,7 @@ spec:
     spec:
       
       serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -43,7 +45,7 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
-          image: "otel/opentelemetry-collector-contrib:0.120.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
@@ -28,7 +28,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/deploy.yaml
@@ -7,12 +7,15 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default
 spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/component: server
@@ -20,17 +23,14 @@ spec:
       app.kubernetes.io/instance: example
   replicas: 1
   revisionHistoryLimit: 10
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v3.1.0
-        helm.sh/chart: prometheus-27.4.0
+        app.kubernetes.io/version: v3.5.0
+        helm.sh/chart: prometheus-27.29.1
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v3.1.0"
+          image: "quay.io/prometheus/prometheus:v3.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -4,9 +4,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -22,10 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: grafana-8.10.1
+        helm.sh/chart: grafana-9.3.1
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "11.5.2"
+        app.kubernetes.io/version: "12.1.0"
       annotations:
         checksum/config: 99cca986c6d5f6511900d815ee5a70d0c284aeb70af56fb96108c7bf456eff87
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:11.5.2"
+          image: "docker.io/grafana/grafana:12.1.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -6,8 +6,8 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -5,9 +5,9 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:
-    helm.sh/chart: grafana-8.10.1
+    helm.sh/chart: grafana-9.3.1
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "11.5.2"
+    app.kubernetes.io/version: "12.1.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-agent-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-agent
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-collector-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-collector
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-deploy.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-query-svc.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: jaeger-query
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/jaeger/allinone-sa.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: jaeger
   labels:
-    helm.sh/chart: jaeger-3.4.0
+    helm.sh/chart: jaeger-3.4.1
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.53.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 rules:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otel-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 roleRef:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 data:
@@ -157,7 +157,6 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
           level: detailed
           readers:
           - periodic:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 926b9ff95e3c843878db38a0f0ee9d894dca81a2332acab49a01bab5b60021d1
+        checksum/config: 20aff486daf7d8ffd6f24703bb895929eae8f9258ec36f227c48925f51209623
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:
@@ -36,6 +36,7 @@ spec:
     spec:
       
       serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -44,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.120.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector
     component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.117.1
+    helm.sh/chart: opentelemetry-collector-0.130.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.120.0"
+    app.kubernetes.io/version: "0.131.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: standalone-collector

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrole.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
@@ -28,7 +28,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/clusterrolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/deploy.yaml
@@ -7,12 +7,15 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default
 spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/component: server
@@ -20,17 +23,14 @@ spec:
       app.kubernetes.io/instance: example
   replicas: 1
   revisionHistoryLimit: 10
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: v3.1.0
-        helm.sh/chart: prometheus-27.4.0
+        app.kubernetes.io/version: v3.5.0
+        helm.sh/chart: prometheus-27.29.1
         app.kubernetes.io/part-of: prometheus
     spec:
       enableServiceLinks: true
@@ -38,7 +38,7 @@ spec:
       containers:
 
         - name: prometheus-server
-          image: "quay.io/prometheus/prometheus:v3.1.0"
+          image: "quay.io/prometheus/prometheus:v3.5.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/serviceaccount.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: v3.1.0
-    helm.sh/chart: prometheus-27.4.0
+    app.kubernetes.io/version: v3.5.0
+    helm.sh/chart: prometheus-27.29.1
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: default


### PR DESCRIPTION
Just bump the following sub charts: opentelemetry collector, jaeger, Prometheus, and Grafana.
I didn't bump opensearch as I am not knowledgeable enough on this database.

I just bumped the sub chart versions in `Chart.yaml` then run `make`