### PR TITLE
[otel-demo] Fix and update prometheus config

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.37.5
+version: 0.37.6
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -572,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -650,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -737,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -801,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -865,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -986,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1055,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1147,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1245,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1309,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1379,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1461,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1604,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1672,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1744,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1808,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -572,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -650,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -737,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -801,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -865,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -986,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1055,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1147,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1245,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1309,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1379,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1461,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1604,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1672,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1744,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1808,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/prometheus/cm.yaml
@@ -20,12 +20,39 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     storage:
       tsdb:
         out_of_order_time_window: 30m
+    otlp:
+        keep_identifying_resource_attributes: true
+        promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        - host.name
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -506,7 +506,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -576,7 +576,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -656,7 +656,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -745,7 +745,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -811,7 +811,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -877,7 +877,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -998,7 +998,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1069,7 +1069,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1163,7 +1163,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1261,7 +1261,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1325,7 +1325,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1395,7 +1395,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1479,7 +1479,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1551,7 +1551,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1626,7 +1626,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1696,7 +1696,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1770,7 +1770,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1836,7 +1836,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/prometheus/cm.yaml
@@ -20,12 +20,39 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     storage:
       tsdb:
         out_of_order_time_window: 30m
+    otlp:
+        keep_identifying_resource_attributes: true
+        promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        - host.name
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -572,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -650,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -737,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -801,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -865,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -986,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1055,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1147,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1245,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1309,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1379,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1461,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1604,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1672,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1744,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1808,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/cm.yaml
@@ -20,12 +20,39 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     storage:
       tsdb:
         out_of_order_time_window: 30m
+    otlp:
+        keep_identifying_resource_attributes: true
+        promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        - host.name
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -572,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -650,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -737,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -801,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -865,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -986,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1055,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1147,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1245,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1309,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1379,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1461,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1604,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1672,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1744,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1808,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/prometheus/cm.yaml
@@ -20,12 +20,39 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     storage:
       tsdb:
         out_of_order_time_window: 30m
+    otlp:
+        keep_identifying_resource_attributes: true
+        promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        - host.name
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -439,7 +439,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: accounting
     
@@ -504,7 +504,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: ad
     
@@ -572,7 +572,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: cart
     
@@ -650,7 +650,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: checkout
     
@@ -737,7 +737,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: currency
     
@@ -801,7 +801,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: email
     
@@ -865,7 +865,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: flagd
     
@@ -986,7 +986,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: fraud-detection
     
@@ -1055,7 +1055,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend
     
@@ -1147,7 +1147,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1245,7 +1245,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: image-provider
     
@@ -1309,7 +1309,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: kafka
     
@@ -1379,7 +1379,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: load-generator
     
@@ -1461,7 +1461,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: payment
     
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: product-catalog
     
@@ -1604,7 +1604,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: quote
     
@@ -1672,7 +1672,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: recommendation
     
@@ -1744,7 +1744,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: shipping
     
@@ -1808,7 +1808,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: valkey-cart
     
@@ -1870,7 +1870,7 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     opentelemetry.io/name: frontend-proxy
     

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-dashboards.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-dashboards
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/prometheus/cm.yaml
@@ -20,12 +20,39 @@ data:
     {}
   prometheus.yml: |
     global:
-      evaluation_interval: 30s
-      scrape_interval: 5s
-      scrape_timeout: 3s
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
     storage:
       tsdb:
         out_of_order_time_window: 30m
+    otlp:
+        keep_identifying_resource_attributes: true
+        promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        - host.name
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.37.5
+    helm.sh/chart: opentelemetry-demo-0.37.6
     
     
     app.kubernetes.io/version: "2.0.2"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -832,34 +832,43 @@ prometheus:
     extraFlags:
       - "enable-feature=exemplar-storage"
       - "web.enable-otlp-receiver"
-    global:
-      scrape_interval: 5s
-      scrape_timeout: 3s
-      evaluation_interval: 30s
     tsdb:
       out_of_order_time_window: 30m
-    prometheus.yml:
-      otlp:
-        keep_identifying_resource_attributes: true
-        # Recommended attributes to be promoted to labels.
-        promote_resource_attributes:
-          - service.instance.id
-          - service.name
-          - service.namespace
-          - cloud.availability_zone
-          - cloud.region
-          - container.name
-          - deployment.environment.name
-          - k8s.cluster.name
-          - k8s.container.name
-          - k8s.cronjob.name
-          - k8s.daemonset.name
-          - k8s.deployment.name
-          - k8s.job.name
-          - k8s.namespace.name
-          - k8s.pod.name
-          - k8s.replicaset.name
-          - k8s.statefulset.name
+    otlp:
+      keep_identifying_resource_attributes: true
+      # Recommended attributes to be promoted to labels.
+      promote_resource_attributes:
+        - service.instance.id
+        - service.name
+        - service.namespace
+        - service.version
+        - cloud.availability_zone
+        - cloud.region
+        - deployment.environment.name
+        # When deploying on Kubernetes, resource attributes used to identify the
+        # kubernetes resources in dashboards and alerts.
+        - k8s.cluster.name
+        - k8s.container.name
+        - k8s.cronjob.name
+        - k8s.daemonset.name
+        - k8s.deployment.name
+        - k8s.job.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.name
+        - k8s.replicaset.name
+        - k8s.statefulset.name
+        - container.name
+        # When deploying on VMs, resource attributes used to identify
+        # the host in dashboards and alerts.
+        - host.name
+        # PostgreSQL resource attributes produced by the OTel Collector PostgreSQL receiver
+        # and used in dashboards and alerts.
+        # See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/postgresqlreceiver/metadata.yaml
+        - postgresql.database.name
+        - postgresql.schema.name
+        - postgresql.table.name
+        - postgresql.index.name
     persistentVolume:
       enabled: false
     service:


### PR DESCRIPTION
Depend on:
- https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1791

Fix Prometheus config: the `otlp` block was in the wrong place and ignored.
Update Prometheus OTLP resource attribute promotion to cover more use cases and get parity with the otel-demo Docker compose.