### PR TITLE
Fix example block for featureGates

### DIFF
--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -573,7 +573,9 @@
           "type": "string",
           "default": "",
           "title": "The featureGates to enable",
-          "examples": ""
+          "examples": [
+            ""
+          ]
         },
         "featureGatesMap": {
           "type": "object",


### PR DESCRIPTION
Helm v3.18.5 is more strict about validating the `values.schema.json` in a Helm chart. When providing examples (plural), the data must be in an array. This updates the `examples` for the `featureGates` property to correctly be an array, matching the other properties that also use array for examples.