### PR TITLE
add  --enable-go-instrumentation flag opention to opentelemetry-operator

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.93.0
+version: 0.93.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -1,4 +1,9 @@
+{{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag (not .Values.manager.autoInstrumentation.go.enabled) }}
+{{- fail "[ERROR] manager.autoInstrumentation.go.enabled must be true when providing manager.autoInstrumentationImage.go.repository and manager.autoInstrumentationImage.go.tag" }}
+{{- end }}
+
 {{- $explicitMount := not .Values.automountServiceAccountToken }}
+{{- $enableGoInstrumentation := or (and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag) .Values.manager.autoInstrumentation.go.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,6 +76,9 @@ spec:
             {{- if and .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag }}
             - --auto-instrumentation-dotnet-image={{ .Values.manager.autoInstrumentationImage.dotnet.repository }}:{{ .Values.manager.autoInstrumentationImage.dotnet.tag }}
             {{- end }}
+            {{- if $enableGoInstrumentation }}
+            - --enable-go-instrumentation
+            {{- end }}
             {{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag }}
             - --auto-instrumentation-go-image={{ .Values.manager.autoInstrumentationImage.go.repository }}:{{ .Values.manager.autoInstrumentationImage.go.tag }}
             {{- end }}
@@ -84,6 +92,9 @@ spec:
             - --feature-gates={{ include "opentelemetry-operator.featureGatesMap" . }}
             {{- else if ne .Values.manager.featureGates "" }}
             - --feature-gates={{ .Values.manager.featureGates }}
+            {{- end }}
+            {{- if .Values.manager.leaderElection.enabled }}
+            - --enable-leader-election
             {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -173,7 +173,8 @@
         "verticalPodAutoscaler",
         "rolling",
         "securityContext",
-        "ignoreMissingCollectorCRDs"
+        "ignoreMissingCollectorCRDs",
+        "autoInstrumentation"
       ],
       "additionalProperties": false,
       "properties": {
@@ -1200,6 +1201,24 @@
           "examples": [
             false
           ]
+        },
+        "autoInstrumentation": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "go": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable Go auto-instrumentation"
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          }
         }
       },
       "examples": [

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -73,11 +73,16 @@ manager:
     apacheHttpd:
       repository: ""
       tag: ""
-    # The Go instrumentation support in the operator is disabled by default.
-    # To enable it, use the operator.autoinstrumentation.go feature gate.
+    # To enable Go instrumentation, manager.autoInstrumentation.go.enabled must be set to true
     go:
       repository: ""
       tag: ""
+
+  # The Go instrumentation support in the operator is disabled by default.
+  autoInstrumentation:
+    go:
+      enabled: false
+
   # If ignoreMissingCollectorCRDs is set to true, the manager will not raise errors
   # if the collector CRDs are not present.
   ignoreMissingCollectorCRDs: false


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1781
Follow the suggestions from https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1782

A fail condition has been added to `deployment.yaml` because  `.Values.manager.autoInstrumentationImage.go.repository` and `.Values.manager.autoInstrumentationImage.go.tag` without the `.Values.manager.autoInstrumentation.go.enabled` flag will not make go auto instrumentation work. 
```
{{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag (not .Values.manager.autoInstrumentation.go.enabled) }}
{{- fail "[ERROR] manager.autoInstrumentation.go.enabled must be true when providing manager.autoInstrumentationImage.go.repository and manager.autoInstrumentationImage.go.tag" }}
{{- end }}
```

If there is a more elegant way to make this work, please let me know. 

Thanks