### PR TITLE
fix: opentelemetry-helm-chart tests to include ImagePullSecrets

### DIFF
--- a/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
@@ -35,6 +35,10 @@ spec:
       {{- with .Values.testFramework.resources }}
       resources: {{ toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
   {{- with .Values.affinity }}
   affinity: {{ toYaml . | nindent 4 }}

--- a/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
@@ -36,6 +36,10 @@ spec:
       {{- with .Values.testFramework.resources }}
       resources: {{ toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
   {{- with .Values.affinity }}
   affinity: {{ toYaml . | nindent 4 }}
@@ -86,6 +90,10 @@ spec:
       {{- with .Values.testFramework.resources }}
       resources: {{ toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
   {{- with .Values.affinity }}
   affinity: {{ toYaml . | nindent 4 }}


### PR DESCRIPTION
Hello all 👋 

Fixes: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1825

I also tested it with this simple values file (my-values.yaml) and running `helm template`

```yaml
# Values to test private testFramework image with imagePullSecrets

imagePullSecrets:
  - name: myregistry-cred

testFramework:
  image:
    repository: registry.example.com/private/busybox
    tag: latest
```

` helm template myrel opentelemetry-helm-charts/charts/opentelemetry-operator -f my-values.yaml`

```yaml
...
# Source: opentelemetry-operator/templates/tests/test-service-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "myrel-opentelemetry-operator-webhook"
  namespace: default
  labels:
    helm.sh/chart: opentelemetry-operator-0.93.1
    app.kubernetes.io/name: opentelemetry-operator
    app.kubernetes.io/version: "0.131.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: opentelemetry-operator
    app.kubernetes.io/instance: myrel
    app.kubernetes.io/component: controller-manager
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: "registry.example.com/private/busybox:latest"
      env:
        - name: WEBHOOK_SERVICE_CLUSTERIP
          value: "myrel-opentelemetry-operator-webhook"
        - name: WEBHOOK_SERVICE_PORT
          value: "443"
      command:
        - sh
        - -c
        # The following shell script tests if the webhook service is up. If the service is up, when we try
        # to wget its exposed port, we will get an HTTP error 400.
        - |
          wget_output=$(wget -q "$WEBHOOK_SERVICE_CLUSTERIP:$WEBHOOK_SERVICE_PORT")
          if wget_output=="wget: server returned error: HTTP/1.0 400 Bad Request"
          then exit 0
          else exit 1
          fi
      securityContext: 
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault
  imagePullSecrets:
    - name: myregistry-cred
...
```
To confirm it renders it correctly.

Cheers!