### PR TITLE
feat(target-allocator): add ServiceMonitor support

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.126.4
+version: 0.126.5
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-target-allocator/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.targetAllocator.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "helper.fullname" . }}-ta
+  namespace: {{ template "helper.namespace" . }}
+  labels:
+    {{- include "helper.commonLabels" . | nindent 4 }}
+    {{- range $key, $value := .Values.targetAllocator.serviceMonitor.extraLabels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.targetAllocator.serviceMonitor.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.targetAllocator.serviceMonitor.annotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "helper.selectorLabels" . | nindent 6 }}
+  endpoints:
+  {{- toYaml .Values.targetAllocator.serviceMonitor.metricsEndpoints | nindent 4 }}
+      {{- with .Values.targetAllocator.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.targetAllocator.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "helper.namespace" . }}
+{{- end }}

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -55,3 +55,17 @@ targetAllocator:
     # requests:
     #   cpu: 100m
     #   memory: 64Mi
+
+  ## Enable ServiceMonitor for Prometheus metrics scrape
+  serviceMonitor:
+    enabled: false
+    # additional labels on the ServiceMonitor
+    extraLabels: {}
+    # add annotations on the ServiceMonitor
+    annotations: {}
+    metricsEndpoints:
+      - port: http-port
+    # Used to set relabeling and metricRelabeling configs on the ServiceMonitor
+    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    relabelings: []
+    metricRelabelings: []


### PR DESCRIPTION
Add ServiceMonitor resource support to target-allocator chart.

- Add serviceMonitor configuration section to values.yaml
- Create servicemonitor.yaml template with full feature support
- Support extraLabels, annotations, relabelings, and metricRelabelings
