### PR TITLE
feat(target-allocator): add health probes and replica count support

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.126.4
+version: 0.126.5
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"
@@ -45,6 +45,18 @@ spec:
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
               value: default
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           
       volumes:
         - name: config-volume

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"
@@ -45,6 +45,18 @@ spec:
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
               value: default
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           
       volumes:
         - name: config-volume

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"
@@ -45,6 +45,18 @@ spec:
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
               value: default
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           
       volumes:
         - name: config-volume

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.126.4
+        helm.sh/chart: opentelemetry-target-allocator-0.126.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"
@@ -45,6 +45,18 @@ spec:
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
               value: foo
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           
       volumes:
         - name: config-volume

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.126.4
+    helm.sh/chart: opentelemetry-target-allocator-0.126.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/templates/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "helper.commonLabels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "helper.selectorLabels" . | nindent 6 }}
@@ -32,6 +32,14 @@ spec:
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
               value: {{ .Values.targetAllocator.config.collector_namespace | default .Release.Namespace }}
+          {{- with .Values.targetAllocator.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.targetAllocator.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{ if .Values.targetAllocator.resources }}
           resources:
             {{- toYaml .Values.targetAllocator.resources | nindent 12 }}

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -13,6 +13,9 @@ nameOverride: ""
 # fullnameOverride completely replaces the generated name.
 fullnameOverride: ""
 
+# Number of replicas for the target allocator deployment
+replicaCount: 1
+
 targetAllocator:
   image:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
@@ -55,3 +58,21 @@ targetAllocator:
     # requests:
     #   cpu: 100m
     #   memory: 64Mi
+
+  # liveness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    httpGet:
+      path: /livez
+      port: 8080
+    initialDelaySeconds: 15
+    periodSeconds: 20
+
+  # readiness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 8080
+    initialDelaySeconds: 5
+    periodSeconds: 10


### PR DESCRIPTION
Add liveness probe, readiness probe, and configurable replica count support to target-allocator chart.

- Add replicaCount configuration with default value of 1
- Add livenessProbe configuration with default /livez endpoint
- Add readinessProbe configuration with default /readyz endpoint
- Update deployment template to support all probe configurations

All probes are enabled by default with sensible defaults, and can be fully customized including timeouts, thresholds, and intervals.