### PR TITLE
feat(opentelemetry-operator): support custom recommender name for vpa

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.95.1
+version: 0.95.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -358,7 +358,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -377,7 +377,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.95.1
+        helm.sh/chart: opentelemetry-operator-0.95.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.134.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -358,7 +358,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -377,7 +377,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.95.1
+        helm.sh/chart: opentelemetry-operator-0.95.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.134.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.95.1
+    helm.sh/chart: opentelemetry-operator-0.95.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.134.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
+++ b/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
@@ -8,6 +8,10 @@ metadata:
     app: {{ template "opentelemetry-operator.name" . }}-operator
 {{- include "opentelemetry-operator.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.manager.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   resourcePolicy:
     containerPolicies:
     - containerName: manager

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1129,6 +1129,26 @@
                 {}
               ]
             },
+            "recommenders": {
+              "type": "array",
+              "default": [],
+              "title": "The recommenders Schema",
+              "maxItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "examples": [
+                {
+                  "name": "custom-recommender-performance"
+                }
+              ]
+            },
             "updatePolicy": {
               "type": "object",
               "default": {},

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -192,6 +192,13 @@ manager:
   # Enable vertical pod autoscaler support for the manager
   verticalPodAutoscaler:
     enabled: false
+
+    # Recommender responsible for generating recommendation for the object.
+    # List should be empty (then the default recommender will generate the recommendation)
+    # or contain exactly one recommender.
+    # recommenders:
+    # - name: custom-recommender-performance
+
     # List of resources that the vertical pod autoscaler can control. Defaults to cpu, memory and ephemeral-storage.
     controlledResources: []
 


### PR DESCRIPTION
It's possible for multiple recommenders with different configurations to be present in single cluster. This change allows VPA configuration to be updated by custom recommender if one was set, otherwise - default recommender is used.