### PR TITLE
[otel-demo] Bump Grafana to v12.2.0

### DIFF
--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-clusterrole
 rules:
   - apiGroups: [""] # "" indicates the core API group

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap-dashboard-provider.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap-dashboard-provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-config-dashboards
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
         helm.sh/chart: grafana-10.0.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "12.1.1"
+        app.kubernetes.io/version: "12.2.0"
       annotations:
         checksum/config: 3aef97dc43bb7f320b3d3f00d79efff7580bf83005ec5574a0619b42268584cf
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -164,7 +164,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:12.1.1"
+          image: "docker.io/grafana/grafana:12.2.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/role.yaml
@@ -9,5 +9,5 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-clusterrole
 rules:
   - apiGroups: [""] # "" indicates the core API group

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap-dashboard-provider.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap-dashboard-provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-config-dashboards
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
         helm.sh/chart: grafana-10.0.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "12.1.1"
+        app.kubernetes.io/version: "12.2.0"
       annotations:
         checksum/config: 3aef97dc43bb7f320b3d3f00d79efff7580bf83005ec5574a0619b42268584cf
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -164,7 +164,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:12.1.1"
+          image: "docker.io/grafana/grafana:12.2.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/role.yaml
@@ -9,5 +9,5 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-clusterrole
 rules:
   - apiGroups: [""] # "" indicates the core API group

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap-dashboard-provider.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap-dashboard-provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-config-dashboards
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
         helm.sh/chart: grafana-10.0.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "12.1.1"
+        app.kubernetes.io/version: "12.2.0"
       annotations:
         checksum/config: 3aef97dc43bb7f320b3d3f00d79efff7580bf83005ec5574a0619b42268584cf
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -164,7 +164,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:12.1.1"
+          image: "docker.io/grafana/grafana:12.2.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -9,5 +9,5 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-clusterrole
 rules:
   - apiGroups: [""] # "" indicates the core API group

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap-dashboard-provider.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap-dashboard-provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-config-dashboards
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
         helm.sh/chart: grafana-10.0.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "12.1.1"
+        app.kubernetes.io/version: "12.2.0"
       annotations:
         checksum/config: 3aef97dc43bb7f320b3d3f00d79efff7580bf83005ec5574a0619b42268584cf
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -164,7 +164,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:12.1.1"
+          image: "docker.io/grafana/grafana:12.2.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/role.yaml
@@ -9,5 +9,5 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-clusterrole
 rules:
   - apiGroups: [""] # "" indicates the core API group

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 subjects:
   - kind: ServiceAccount
     name: grafana

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap-dashboard-provider.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap-dashboard-provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana-config-dashboards
   namespace: default
 data:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 data:
   
   plugins: grafana-opensearch-datasource

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -25,7 +25,7 @@ spec:
         helm.sh/chart: grafana-10.0.0
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "12.1.1"
+        app.kubernetes.io/version: "12.2.0"
       annotations:
         checksum/config: 3aef97dc43bb7f320b3d3f00d79efff7580bf83005ec5574a0619b42268584cf
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
@@ -164,7 +164,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:12.1.1"
+          image: "docker.io/grafana/grafana:12.2.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/role.yaml
@@ -9,5 +9,5 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 rules: []

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 type: Opaque
 data:
   

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
 spec:
   type: ClusterIP
   ports:

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: grafana-10.0.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "12.1.1"
+    app.kubernetes.io/version: "12.2.0"
   name: grafana
   namespace: default

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -982,6 +982,8 @@ prometheus:
 grafana:
   enabled: true
   fullnameOverride: grafana
+  image:
+    tag: "12.2.0"
   testFramework:
     enabled: false
   grafana.ini:


### PR DESCRIPTION
Follow up on OTel Demo's Docker Compose change:
* https://github.com/open-telemetry/opentelemetry-demo/pull/2615

Fixes:
* https://github.com/open-telemetry/opentelemetry-demo/issues/2589