### PR TITLE
fix(opentelemetry-demo): Add missing ENVOY_ADDR env variable to frontend-proxy

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.38.3
+version: 0.38.4
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -533,7 +533,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -601,7 +601,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -679,7 +679,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -768,7 +768,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -832,7 +832,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -900,7 +900,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1102,7 +1102,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1198,7 +1198,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1242,6 +1242,8 @@ spec:
               value: my-otel-collector.opentelemetry-ns
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1298,7 +1300,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1362,7 +1364,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1522,7 +1524,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1592,7 +1594,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1656,7 +1658,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1731,7 +1733,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1801,7 +1803,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1873,7 +1875,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1937,7 +1939,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -533,7 +533,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -601,7 +601,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -679,7 +679,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -768,7 +768,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -832,7 +832,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -900,7 +900,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1102,7 +1102,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1198,7 +1198,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1242,6 +1242,8 @@ spec:
               value: $(OTEL_K8S_NODE_NAME)
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1298,7 +1300,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1362,7 +1364,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1522,7 +1524,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1592,7 +1594,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1656,7 +1658,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1731,7 +1733,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1801,7 +1803,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1873,7 +1875,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1937,7 +1939,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -2539,7 +2539,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -3743,7 +3743,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -4219,7 +4219,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -7065,7 +7065,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -13400,7 +13400,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -14891,7 +14891,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -15942,7 +15942,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/collector-as-daemonset/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -535,7 +535,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -605,7 +605,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -685,7 +685,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -776,7 +776,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -842,7 +842,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -912,7 +912,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1041,7 +1041,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1116,7 +1116,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1258,6 +1258,8 @@ spec:
               value: otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1314,7 +1316,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1378,7 +1380,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1454,7 +1456,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1540,7 +1542,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1612,7 +1614,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1676,7 +1678,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1753,7 +1755,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1825,7 +1827,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1899,7 +1901,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1965,7 +1967,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -2539,7 +2539,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -3743,7 +3743,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -4219,7 +4219,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -7065,7 +7065,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -13400,7 +13400,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -14891,7 +14891,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -15942,7 +15942,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -533,7 +533,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -601,7 +601,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -679,7 +679,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -768,7 +768,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -832,7 +832,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -900,7 +900,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1102,7 +1102,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1198,7 +1198,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1242,6 +1242,8 @@ spec:
               value: otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1298,7 +1300,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1362,7 +1364,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1522,7 +1524,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1592,7 +1594,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1656,7 +1658,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1731,7 +1733,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1801,7 +1803,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1873,7 +1875,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1937,7 +1939,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -2539,7 +2539,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -3743,7 +3743,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -4219,7 +4219,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -7065,7 +7065,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -13400,7 +13400,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -14891,7 +14891,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -15942,7 +15942,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -533,7 +533,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -601,7 +601,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -679,7 +679,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -768,7 +768,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -832,7 +832,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -900,7 +900,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1102,7 +1102,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1198,7 +1198,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1242,6 +1242,8 @@ spec:
               value: otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1298,7 +1300,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1362,7 +1364,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1522,7 +1524,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1592,7 +1594,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1656,7 +1658,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1731,7 +1733,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1801,7 +1803,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1873,7 +1875,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1937,7 +1939,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -2539,7 +2539,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -3743,7 +3743,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -4219,7 +4219,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -7065,7 +7065,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -13400,7 +13400,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -14891,7 +14891,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -15942,7 +15942,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -55,7 +55,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +80,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -105,7 +105,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -130,7 +130,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +161,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +186,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +211,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +236,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +264,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -289,7 +289,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -314,7 +314,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -339,7 +339,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -364,7 +364,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -414,7 +414,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -439,7 +439,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -464,7 +464,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: accounting
     
@@ -533,7 +533,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: ad
     
@@ -601,7 +601,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: cart
     
@@ -679,7 +679,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: checkout
     
@@ -768,7 +768,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: currency
     
@@ -832,7 +832,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: email
     
@@ -900,7 +900,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: flagd
     
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: fraud-detection
     
@@ -1102,7 +1102,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend
     
@@ -1198,7 +1198,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1242,6 +1242,8 @@ spec:
               value: otel-collector
             - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
               value: cumulative
+            - name: ENVOY_ADDR
+              value: 0.0.0.0
             - name: ENVOY_PORT
               value: "8080"
             - name: ENVOY_ADMIN_PORT
@@ -1298,7 +1300,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: image-provider
     
@@ -1362,7 +1364,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: kafka
     
@@ -1438,7 +1440,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: load-generator
     
@@ -1522,7 +1524,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: payment
     
@@ -1592,7 +1594,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: postgresql
     
@@ -1656,7 +1658,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: product-catalog
     
@@ -1731,7 +1733,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: quote
     
@@ -1801,7 +1803,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: recommendation
     
@@ -1873,7 +1875,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: shipping
     
@@ -1937,7 +1939,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: valkey-cart
     
@@ -1999,7 +2001,7 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     opentelemetry.io/name: frontend-proxy
     

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -2539,7 +2539,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -3743,7 +3743,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -4219,7 +4219,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -7065,7 +7065,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -13400,7 +13400,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -14891,7 +14891,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"
@@ -15942,7 +15942,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/product-catalog-products.yaml
@@ -6,7 +6,7 @@ metadata:
   name: product-catalog-products
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.38.3
+    helm.sh/chart: opentelemetry-demo-0.38.4
     
     
     app.kubernetes.io/version: "2.1.3"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -393,6 +393,8 @@ components:
     service:
       port: 8080
     env:
+      - name: ENVOY_ADDR
+        value: "0.0.0.0"
       - name: ENVOY_PORT
         value: "8080"
       - name: ENVOY_ADMIN_PORT


### PR DESCRIPTION
[This PR](https://github.com/open-telemetry/opentelemetry-demo/pull/2594/files) introduced a new environment variable, ENVOY_ADDR. It was added to the .env file used for Docker deployments, but it’s missing from the Helm chart.