### PR TITLE
[opentelemetry-collector] Add namespace exclusion for logs collection

### DIFF
--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -129,6 +129,20 @@ config:
         - /var/log/pods/example-namespace_*/*/*.log
 ```
 
+Alternatively, you can exclude logs from specific namespaces using the `excludeNamespaces` property:
+
+```yaml
+mode: daemonset
+
+presets:
+  logsCollection:
+    enabled: true
+    excludeNamespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+```
+
 The container logs pipeline uses the `debug` exporter by default.
 Paired with the default `filelog` receiver that receives all containers' console output,
 it is easy to accidentally feed the exported logs back into the receiver.

--- a/charts/opentelemetry-collector/ci/logscollection-exclude-namespaces-values.yaml
+++ b/charts/opentelemetry-collector/ci/logscollection-exclude-namespaces-values.yaml
@@ -1,0 +1,18 @@
+mode: daemonset
+
+image:
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
+
+command:
+  name: "otelcol-k8s"
+
+presets:
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false
+    # Exclude logs from system namespaces
+    excludeNamespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+

--- a/charts/opentelemetry-collector/examples/README.md
+++ b/charts/opentelemetry-collector/examples/README.md
@@ -6,6 +6,7 @@ Here is a collection of common configurations for the OpenTelemetry collector. E
 - [Deployment only](deployment-only)
 - [Daemonset and deployment](daemonset-and-deployment)
 - [Log collection, including collector logs](daemonset-collector-logs)
+- [Log collection, excluding logs by namespace](daemonset-logs-exclude-namespaces)
 - [Add component (hostmetrics)](daemonset-hostmetrics)
 
 The manifests are rendered using the `helm template` command and the specific example folder's values.yaml.

--- a/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/configmap-agent.yaml
@@ -1,0 +1,110 @@
+---
+# Source: opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.139.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.139.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+data:
+  relay: |
+    exporters:
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      filelog:
+        exclude:
+        - /var/log/pods/kube-system_*/*/*.log
+        - /var/log/pods/kube-public_*/*/*.log
+        - /var/log/pods/kube-node-lease_*/*/*.log
+        - /var/log/pods/default_example-opentelemetry-collector*_*/opentelemetry-collector/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: container-parser
+          max_log_size: 102400
+          type: container
+        retry_on_failure:
+          enabled: true
+        start_at: end
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - filelog
+        metrics:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - prometheus
+        traces:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888

--- a/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/daemonset.yaml
@@ -1,0 +1,113 @@
+---
+# Source: opentelemetry-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.139.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.139.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 9a503baeaa5be57f6314b9556430323f285e810b592d469e6481c95b259be3f0
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      
+      serviceAccountName: example-opentelemetry-collector
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-k8s
+          args:
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.139.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: example-opentelemetry-collector-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+      hostNetwork: false

--- a/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/rendered/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.139.0
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.139.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/values.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-logs-exclude-namespaces/values.yaml
@@ -1,0 +1,20 @@
+mode: daemonset
+
+image:
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
+
+command:
+  name: "otelcol-k8s"
+
+presets:
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false
+    # Exclude logs from specific namespaces
+    # This is useful for excluding system namespaces or other namespaces 
+    # where you don't want to collect logs
+    excludeNamespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -67,6 +67,13 @@
             "maxRecombineLogSize": {
               "description": "Specifies the max recombine log size.",
               "type": "integer"
+            },
+            "excludeNamespaces": {
+              "description": "List of Kubernetes namespaces to exclude from log collection.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -35,6 +35,11 @@ presets:
     # The maximum bytes size of the recombined field.
     # Once the size exceeds the limit, all received entries of the source will be combined and flushed.
     maxRecombineLogSize: 102400
+    # List of namespaces to exclude from log collection.
+    # The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
+    excludeNamespaces: []
+    # - kube-system
+    # - kube-public
   # Configures the collector to collect host metrics.
   # Adds the hostmetrics receiver to the metrics pipeline
   # and adds the necessary volumes and volume mounts.


### PR DESCRIPTION
## Description

This PR adds the ability to exclude logs from specific Kubernetes namespaces when using the `logsCollection` preset. This feature provides a more convenient way to filter out logs from unwanted namespaces.

## Motivation

Currently, users **cannot** easily exclude logs from certain namespaces (like `kube-system`, `kube-public`, etc.). This makes it difficult to filter out logs that are not needed for observability.

Many observability tools charge based on the volume of logs ingested. Without an easy way to exclude logs from system namespaces or other non-critical sources, users may face unexpected and unwanted charges for collecting logs they don't actually need. This PR introduces a simple `excludeNamespaces` list that makes it easy to control which logs are collected, helping users **Reduce costs** by excluding logs from namespaces that don't provide business value

## Usage Example

```yaml
mode: daemonset

presets:
  logsCollection:
    enabled: true
    excludeNamespaces:
      - kube-system
      - kube-public
      - kube-node-lease
```

This generates the following exclude patterns in the filelog receiver:
```yaml
exclude:
  - /var/log/pods/kube-system_*/*/*.log
  - /var/log/pods/kube-public_*/*/*.log
  - /var/log/pods/kube-node-lease_*/*/*.log
  - /var/log/pods/default_example-opentelemetry-collector*_*/opentelemetry-collector/*.log
```
