### PR TITLE
feat(opentelemetry-demo): add KEDA-based horizontal scaling support

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.2.1
+- name: keda
+  repository: https://kedacore.github.io/charts
+  version: 2.13.0
 digest: sha256:38d05310ee527b4e9073a3538ba605c8486756a404f554875f837a81530afbac
 generated: "2025-10-22T12:00:27.354554+02:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -35,3 +35,7 @@ dependencies:
     version: 3.2.1
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
+  - name: keda
+    version: 2.13.0
+    repository: https://kedacore.github.io/charts
+    condition: keda.install.enabled

--- a/charts/opentelemetry-demo/templates/_objects.tpl
+++ b/charts/opentelemetry-demo/templates/_objects.tpl
@@ -62,7 +62,14 @@ spec:
           env:
             {{- include "otel-demo.pod.env" . | nindent 12 }}
           resources:
-            {{- .resources | toYaml | nindent 12 }}
+            {{- $mergedResources := dict }}
+            {{- if .defaultValues.resources }}
+            {{- $mergedResources = .defaultValues.resources | deepCopy }}
+            {{- end }}
+            {{- if .resources }}
+            {{- $mergedResources = mergeOverwrite $mergedResources .resources }}
+            {{- end }}
+            {{- $mergedResources | toYaml | nindent 12 }}
           {{- if or .defaultValues.securityContext .securityContext }}
           securityContext:
             {{- .securityContext | default .defaultValues.securityContext | toYaml | nindent 12 }}
@@ -107,9 +114,16 @@ spec:
           {{- end }}
           env:
             {{- include "otel-demo.pod.env" . | nindent 12 }}
+          {{- $mergedResources := dict }}
+          {{- if .defaultValues.resources }}
+          {{- $mergedResources = .defaultValues.resources | deepCopy }}
+          {{- end }}
           {{- if .resources }}
+          {{- $mergedResources = mergeOverwrite $mergedResources .resources }}
+          {{- end }}
+          {{- if or .defaultValues.resources .resources }}
           resources:
-            {{- .resources | toYaml | nindent 12 }}
+            {{- $mergedResources | toYaml | nindent 12 }}
           {{- end }}
           {{- if or .defaultValues.securityContext .securityContext }}
           securityContext:
@@ -128,6 +142,7 @@ spec:
       initContainers:
         {{- tpl (toYaml .initContainers) . | nindent 8 }}
       {{- end}}
+      {{- if or .mountedConfigMaps .mountedEmptyDirs .additionalVolumes }}
       volumes:
         {{- range .mountedConfigMaps }}
         - name: {{ .name | lower}}
@@ -145,6 +160,7 @@ spec:
         {{- if .additionalVolumes }}
         {{- tpl (toYaml .additionalVolumes) . | nindent 8 }}
         {{- end }}
+      {{- end }}
 {{- end }}
 
 {{/*
@@ -297,3 +313,48 @@ spec:
 {{- end}}
 {{- end}}
 {{- end}}
+
+
+{{/*
+Demo component KEDA ScaledObject template
+*/}}
+{{- define "otel-demo.scaledobject" -}}
+{{- $componentKeda := .keda | default dict -}}
+{{- $defaultKeda := .defaultValues.keda | default dict -}}
+
+{{- if or ($defaultKeda.enabled | default false) ($componentKeda.enabled | default false) }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "otel-demo.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ .name }}
+  pollingInterval: {{ $componentKeda.pollingInterval | default $defaultKeda.pollingInterval | default 5 }}
+  cooldownPeriod: {{ $componentKeda.cooldownPeriod | default $defaultKeda.cooldownPeriod | default 30 }}
+  minReplicaCount: {{ $componentKeda.minReplicas | default $defaultKeda.minReplicas | default 1 }}
+  maxReplicaCount: {{ $componentKeda.maxReplicas | default $defaultKeda.maxReplicas | default 5 }}
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://prometheus.{{ .Release.Namespace }}.svc.cluster.local:9090
+      metricName: {{ include "otel-demo.name" . }}-{{ .name }}-cpu-utilization
+      # This query calculates the total CPU usage in cores across all pods.
+      query: |
+        sum(rate(container_cpu_usage_seconds_total{container!="", pod=~"^{{ .name }}-[^-]+-[^-]+$"}[25s]))
+      threshold: '{{ divf ($componentKeda.targetCPUMillicores | default $defaultKeda.targetCPUMillicores | default 100.0) 1000.0 }}'
+  {{- /* Merge advanced settings - component-specific takes precedence over default */ -}}
+  {{- $mergedAdvanced := $defaultKeda.advanced }}
+  {{- if $componentKeda.advanced }}
+  {{- $mergedAdvanced = mergeOverwrite $defaultKeda.advanced $componentKeda.advanced }}
+  {{- end }}
+  {{- if $mergedAdvanced }}
+  advanced:
+    {{- $mergedAdvanced | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/opentelemetry-demo/templates/component.yaml
+++ b/charts/opentelemetry-demo/templates/component.yaml
@@ -13,6 +13,7 @@
         {{- include "otel-demo.service" $config -}}
         {{- include "otel-demo.ingress" $config -}}
         {{- include "otel-demo.configmap" $config -}}
+        {{- include "otel-demo.scaledobject" $config -}}
     {{ end }}
 
 {{- end }}

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -49,6 +49,9 @@
     },
     "opensearch": {
       "type": "object"
+    },
+    "keda": {
+      "type": "object"
     }
   },
   "required": [
@@ -224,6 +227,9 @@
         },
         "additionalVolumes": {
           "type": "array"
+        },
+        "keda": {
+          "$ref": "#/definitions/KedaConfig"
         }
       },
       "required": [
@@ -302,6 +308,12 @@
         },
         "podSecurityContext": {
           "type": "object"
+        },
+        "resources": {
+          "$ref": "#/definitions/ContainerResources"
+        },
+        "keda": {
+          "$ref": "#/definitions/KedaConfig"
         }
       },
       "required": [
@@ -310,6 +322,19 @@
         "securityContext"
       ],
       "title": "Default"
+    },
+    "KedaConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "pollingInterval": {"type": "number"},
+        "cooldownPeriod": {"type": "number"},
+        "minReplicas": {"type": "number"},
+        "maxReplicas": {"type": "number"},
+        "targetCPUMillicores": {"type": "number"},
+        "advanced": {"type": "object"}
+      },
+      "title": "KedaConfig"
     },
     "ConfigMapKeyRef": {
       "type": "object",

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -35,6 +35,27 @@ default:
     tolerations: []
   # Default securityContext for all components
   securityContext: {}
+  resources:
+    requests:
+      cpu: 100m
+  keda:
+    enabled: false
+    pollingInterval: 5
+    cooldownPeriod: 30
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUMillicores: 80
+    # Advanced KEDA configuration - any valid ScaledObject spec fields
+    # These will be merged into the ScaledObject spec
+    advanced: {}
+
+keda:
+  install:
+    enabled: true
+    # Values to pass to the KEDA subchart can be placed here.
+    # For example:
+    # extraArgs:
+    #   v: "1"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -460,6 +481,10 @@ components:
     enabled: true
     useDefault:
       env: true
+    keda:
+      # Users should consider scaling Locust _vertically_ using an env LOCUST_PROCESSES. Doing that 
+      # allows Locust to generate aggregate statistics and respect the configured total users and spawn rate.
+      maxReplicas: 1 # Disable horizontal scaling for Locust
     service:
       port: 8089
     env:
@@ -977,7 +1002,7 @@ prometheus:
       servicePort: 9090
     resources:
       limits:
-        memory: 300Mi
+        memory: 1000Mi
 
 grafana:
   enabled: true


### PR DESCRIPTION
this adds KEDA scale-up support to the opentelemetry-demo, so it can stress a large system.

The Unvariance collector uses this to run its benchmark on a 96-core m7i.metal-24xl and reach high transactions per second count (multiple hundreds) and high CPU utilization, e.g., https://unvariance.github.io/collector/benchmarks/workload_performance.png