### PR TITLE
Add trivy scan IaC

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,0 +1,35 @@
+name: Scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-iac-scan:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Trivy IaC Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in IaC mode
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: 'config'
+          hide-progress: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,1 @@
+ignorefile: .trivyignore.yaml # experimental so the doc say we must specify it explicitly


### PR DESCRIPTION
- Closes #930
  - Generate IaC misconfigs using trivy
  - Feed trivy output to github security tab for issue management (https://github.com/open-telemetry/opentelemetry-helm-charts/security ) 
 

Trivy reports +4000 issues in the security tabs. (https://github.com/ggjulio/opentelemetry-helm-charts/security/code-scanning)
But the scan can still be merged without breaking anything, later on issues can either be fixed, ignored (.trivyconfig) or closed in the security tab.

<img width="1092" height="508" alt="image" src="https://github.com/user-attachments/assets/b58e200f-3d76-4701-bb62-4e1876231af4" />

<img width="1794" height="742" alt="image" src="https://github.com/user-attachments/assets/7008f966-dcfe-4458-84e7-808fe893ef6d" />

<img width="1386" height="839" alt="image" src="https://github.com/user-attachments/assets/5f5fb6c7-c6a1-4172-bb72-81530918ccec" />


