### PR TITLE
add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,98 @@
+# syntax=docker/dockerfile:1
+
+# renovate: datasource=github-releases packageName=helm/chart-testing
+ARG CHART_TESTING_VERSION='3.14.0'
+# renovate: datasource=github-releases packageName=helm/helm
+ARG HELM_VERSION='3.19.2'
+# renovate: datasource=github-releases packageName=kubernetes-sigs/kind
+ARG KIND_VERSION='0.30.0'
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl extractVersion=^kubernetes-(?<version>.+)$
+ARG KUBECTL_VERSION='1.34.2'
+# renovate: datasource=github-releases packageName=aquasecurity/trivy
+ARG TRIVY_VERSION='0.68.1'
+# renovate: datasource=github-releases packageName=git-lfs/git-lfs
+ARG GIT_LFS_VERSION='3.7.1'
+
+FROM mcr.microsoft.com/devcontainers/python:3.14-bookworm AS base
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+ARG TARGETPLATFORM
+
+RUN <<EOT
+	if [ "${TARGETPLATFORM}" != 'linux/amd64' ] && [ "${TARGETPLATFORM}" != 'linux/arm64' ]; then
+		echo "Platform ${TARGETPLATFORM} currently not supported!" >&2
+		exit 2
+	fi
+	mkdir -p /tmp/output-bin/
+EOT
+
+FROM base AS tools-misc
+ARG TARGETARCH
+ARG TRIVY_VERSION GIT_LFS_VERSION
+
+RUN <<EOF
+
+	arch="$(echo "${TARGETARCH}" | sed s/arm64/ARM/ | sed s/amd64/64bit/)"
+	curl -fsSL -o /tmp/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${arch}.tar.gz"
+	tar -xzf /tmp/trivy.tar.gz -C /tmp/output-bin/ --no-same-owner trivy
+	rm -f /tmp/trivy.tar.gz
+	/tmp/output-bin/trivy --version
+
+	wget -qO /tmp/git-lfs.tar.gz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz"
+	tar -xzf /tmp/git-lfs.tar.gz -C /tmp/output-bin/ --no-same-owner "git-lfs-${GIT_LFS_VERSION}/git-lfs" --strip-components=1
+	rm -f /tmp/git-lfs.tar.gz
+	/tmp/output-bin/git-lfs version
+EOF
+
+FROM base AS tools-k8s
+ARG KUBECTL_VERSION KIND_VERSION HELM_VERSION CHART_TESTING_VERSION
+ARG TARGETARCH
+
+RUN <<EOF
+	mkdir -p /tmp/output-bin/
+	wget -qO /tmp/output-bin/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl"
+	chmod +x /tmp/output-bin/kubectl
+	/tmp/output-bin/kubectl version --client
+
+	wget -qO /tmp/helm.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz"
+	tar -xzf /tmp/helm.tar.gz -C /tmp/output-bin/ "linux-${TARGETARCH}/helm" --strip-components=1
+	rm /tmp/helm.tar.gz
+	/tmp/output-bin/helm version
+
+	wget -qO /tmp/output-bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-${TARGETARCH}"
+	chmod +x /tmp/output-bin/kind
+	/tmp/output-bin/kind version
+
+	wget -qO /tmp/chart-testing.tar.gz "https://github.com/helm/chart-testing/releases/download/v${CHART_TESTING_VERSION}/chart-testing_${CHART_TESTING_VERSION}_linux_${TARGETARCH}.tar.gz"
+	tar -xzf /tmp/chart-testing.tar.gz -C /tmp/output-bin/ --no-same-owner ct
+	rm -f /tmp/chart-testing.tar.gz
+	/tmp/output-bin/ct version
+EOF
+
+FROM base AS development-base
+
+RUN <<EOF
+	packages=(
+		# General
+		file
+		iputils-ping
+		dnsutils
+		# IntelliJ requirements
+		libxtst6
+		libxrender1
+		libfontconfig1
+		libxi6
+		libgtk-3-0
+	)
+	apt-get update
+	apt-get install -y --no-install-recommends "${packages[@]}"
+	apt-get clean
+	rm -rf /var/lib/apt/lists/*
+
+	pip install pre-commit
+	pre-commit -V
+EOF
+
+FROM development-base AS development
+
+COPY --from=tools-k8s /tmp/output-bin /usr/local/bin/
+COPY --from=tools-misc /tmp/output-bin /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+{
+    "name": "otel helm charts",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "target": "development",
+    },
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "4gb",
+        "storage": "8gb"
+    },
+    "features": {
+        // Don't add more features as they are very slow to build, use the Dockerfile instead.
+        // Only dind feature makes sense to install as it is non trivial to setup manually.
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    },
+    "forwardPorts": [
+    ],
+    "portsAttributes": {},
+    "otherPortsAttributes": {
+        "onAutoForward" : "ignore"
+    },
+    "mounts": [
+        {
+            "source": "vscode-home-${devcontainerId}",
+            "target": "/home/vscode/",
+            "type": "volume"
+        }
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "docker.docker",
+                "exiasr.hadolint",
+                "github.vscode-github-actions",
+                "aquasecurityofficial.trivy-vulnerability-scanner",
+
+                "eamodio.gitlens",
+                "mutantdino.resourcemonitor",
+                "shd101wyy.markdown-preview-enhanced",
+                "streetsidesoftware.code-spell-checker",
+            ],
+            "settings": {
+                "resmon.show.battery": false,
+                "resmon.show.cpufreq": false,
+                "telemetry.enableTelemetry": false,
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                // Prefer .vscode/settings.json over putting settings here.
+            }
+        }
+    }
+}

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,9 @@
+misconfigurations:
+  - id: AVD-DS-0026
+    statement: No healthcheck instruction is not applicable for devcontainer.
+    paths:
+      - .devcontainer/Dockerfile
+  - id: AVD-DS-0002
+    statement: Image user should not be root is not applicable for devcontainer.
+    paths:
+      - .devcontainer/Dockerfile


### PR DESCRIPTION
A devcontainer definition containing all the devtools to contribute to this repository (works on CDEs like codespaces/coder/gitpod, on windows 11 with docker desktop, may work on MacOS too (arm64), and works on linux via docker engine.

The maintenance is easy, just bump the tooling version and everyone using it will be up to date. It can be automated by enabling the renovate bot on the repo.