### PR TITLE
Fix formatting of Helm repo add command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-$ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 ```
 
 ## Helm Charts


### PR DESCRIPTION
remove `$` from command to make it copiable