### PR TITLE
feat(opentelemetry-operator): auto detect presence of cert-manager CRDs

### DIFF
--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -1,4 +1,5 @@
-{{- if and (.Values.admissionWebhooks.create) (.Values.admissionWebhooks.certManager.enabled) }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" -}}
+{{- if or (eq .Values.admissionWebhooks.certificateSource "cert-manager") (eq .Values.admissionWebhooks.certificateSource "prefer-cert-manager") }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -234,4 +235,9 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
+{{- end }}
+{{- else -}}
+{{ if eq .Values.admissionWebhooks.certificateSource "cert-manager" }}
+{{ fail "certificateSource is set to cert-manager but cert manager APIs are not available" }}
+{{- end }}
 {{- end }}

--- a/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.admissionWebhooks.create) (not .Values.admissionWebhooks.certManager.enabled) }}
+{{- if or (ne .Values.admissionWebhooks.certificateSource "cert-manager") (and (eq .Values.admissionWebhooks.certificateSource "prefer-cert-manager") (not (.Capabilities.APIVersions.Has "cert-manager.io/v1"))) }}
 {{- $cert := fromYaml (include "opentelemetry-operator.WebhookCert" .) }}
 {{- $caCertEnc := $cert.ca }}
 {{- $certCrtEnc := $cert.crt }}

--- a/charts/opentelemetry-operator/templates/certmanager.yaml
+++ b/charts/opentelemetry-operator/templates/certmanager.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.admissionWebhooks.create .Values.admissionWebhooks.certManager.enabled }}
+{{- if and .Values.admissionWebhooks.create .Values.admissionWebhooks.certManager.enabled (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1558,6 +1558,7 @@
         "timeoutSeconds",
         "namespaceSelector",
         "objectSelector",
+        "certificateSource",
         "certManager",
         "autoGenerateCert",
         "certFile",
@@ -1661,12 +1662,21 @@
             {}
           ]
         },
+        "certificateSource": {
+          "type": "string",
+          "default": {},
+          "title": "The certificateSource Schema",
+          "required": [],
+          "properties": {},
+          "examples": [
+            {}
+          ]
+        },
         "certManager": {
           "type": "object",
           "default": {},
           "title": "The certManager Schema",
           "required": [
-            "enabled",
             "issuerRef",
             "certificateAnnotations",
             "issuerAnnotations"
@@ -1744,7 +1754,6 @@
           "default": {},
           "title": "The autoGenerateCert Schema",
           "required": [
-            "enabled",
             "recreate"
           ],
           "additionalProperties": false,

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1479,6 +1479,7 @@
         "timeoutSeconds",
         "namespaceSelector",
         "objectSelector",
+        "certificateSource",
         "certManager",
         "autoGenerateCert",
         "certFile",
@@ -1582,12 +1583,21 @@
             {}
           ]
         },
+        "certificateSource": {
+          "type": "string",
+          "default": {},
+          "title": "The certificateSource Schema",
+          "required": [],
+          "properties": {},
+          "examples": [
+            {}
+          ]
+        },
         "certManager": {
           "type": "object",
           "default": {},
           "title": "The certManager Schema",
           "required": [
-            "enabled",
             "issuerRef",
             "certificateAnnotations",
             "issuerAnnotations"
@@ -1665,7 +1675,6 @@
           "default": {},
           "title": "The autoGenerateCert Schema",
           "required": [
-            "enabled",
             "recreate"
           ],
           "additionalProperties": false,

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -291,11 +291,16 @@ admissionWebhooks:
   namespaceSelector: {}
   objectSelector: {}
 
+  ## Choose the certificate approach to take
+  ## - prefer-cert-manager (default): Uses cert manager if available, falls back to generated certificates
+  ## - cert-manager: Use cert-manager to generate certificates
+  ## - helm-generated: Generate certificates with helm
+  ## - self-signed: Provide your own certificate
+  certificateSource: 'prefer-cert-manager'
+
   ## https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/README.md#tls-certificate-requirement
   ## TLS Certificate Option 1: Use certManager to generate self-signed certificate.
-  ## certManager must be enabled. If enabled, always takes precedence over options 2 and 3.
   certManager:
-    enabled: true
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}
@@ -312,17 +317,14 @@ admissionWebhooks:
     renewBefore: ""
 
   ## TLS Certificate Option 2: Use Helm to automatically generate self-signed certificate.
-  ## certManager must be disabled and autoGenerateCert must be enabled.
-  ## If true and certManager.enabled is false, Helm will automatically create a self-signed cert and secret for you.
   autoGenerateCert:
-    enabled: true
     # If set to true, new webhook key/certificate is generated on helm upgrade.
     recreate: true
     # Cert period time in days. The default is 365 days.
     certPeriodDays: 365
 
   ## TLS Certificate Option 3: Use your own self-signed certificate.
-  ## certManager and autoGenerateCert must be disabled and certFile, keyFile, and caFile must be set.
+  ## certFile, keyFile, and caFile must be set.
   ## The chart reads the contents of the file paths with the helm .Files.Get function.
   ## Refer to this doc https://helm.sh/docs/chart_template_guide/accessing_files/ to understand
   ## limitations of file paths accessible to the chart.

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -294,11 +294,16 @@ admissionWebhooks:
   namespaceSelector: {}
   objectSelector: {}
 
+  ## Choose the certificate approach to take
+  ## - prefer-cert-manager (default): Uses cert manager if available, falls back to generated certificates
+  ## - cert-manager: Use cert-manager to generate certificates
+  ## - helm-generated: Generate certificates with helm
+  ## - self-signed: Provide your own certificate
+  certificateSource: 'prefer-cert-manager'
+
   ## https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/README.md#tls-certificate-requirement
   ## TLS Certificate Option 1: Use certManager to generate self-signed certificate.
-  ## certManager must be enabled. If enabled, always takes precedence over options 2 and 3.
   certManager:
-    enabled: true
     ## Provide the issuer kind and name to do the cert auth job.
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}
@@ -315,17 +320,14 @@ admissionWebhooks:
     renewBefore: ""
 
   ## TLS Certificate Option 2: Use Helm to automatically generate self-signed certificate.
-  ## certManager must be disabled and autoGenerateCert must be enabled.
-  ## If true and certManager.enabled is false, Helm will automatically create a self-signed cert and secret for you.
   autoGenerateCert:
-    enabled: true
     # If set to true, new webhook key/certificate is generated on helm upgrade.
     recreate: true
     # Cert period time in days. The default is 365 days.
     certPeriodDays: 365
 
   ## TLS Certificate Option 3: Use your own self-signed certificate.
-  ## certManager and autoGenerateCert must be disabled and certFile, keyFile, and caFile must be set.
+  ## certFile, keyFile, and caFile must be set.
   ## The chart reads the contents of the file paths with the helm .Files.Get function.
   ## Refer to this doc https://helm.sh/docs/chart_template_guide/accessing_files/ to understand
   ## limitations of file paths accessible to the chart.


### PR DESCRIPTION
This PR adds a check for the presence of the `cert-manager.io/v1` API in the target cluster. Using this approach, the helm chart can be installed without any customization in clusters without cert manager, simplifying the installation.