### PR TITLE
[otel-kube-stack] Bump OTel Operator to v0.102.0 (OTelCollector v0.141.0)

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.lock
+++ b/charts/opentelemetry-kube-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.99.0
+  version: 0.102.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 6.3.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.48.0
-digest: sha256:9c04376f480118910fe4bb39bd64f8b6cde8ade4b76fb43fcecc2bfcbee838b3
-generated: "2025-11-05T22:11:01.225203082+01:00"
+digest: sha256:aaf420e2151c00a05ead99ff465e82ba593fa8bd555f9a5e4f0044b78a37f936
+generated: "2026-01-22T00:20:19.34647+01:00"

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.12.7
+version: 0.13.0
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -16,7 +16,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 # the appVersion stays aligned with the operator's latest version. If the collector has a patch
 # release, the collector's latest patch will be manually overridden.
-appVersion: 0.138.0
+appVersion: 0.141.0
 dependencies:
   - name: otel-crds
     version: "0.0.0"
@@ -26,7 +26,7 @@ dependencies:
     condition: crds.install,crds.installPrometheus
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.99.0
+    version: 0.102.0
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "6.3.*"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,8 +5,8 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:
@@ -24,7 +24,7 @@ spec:
     ReportsRemoteConfig: true
     ReportsStatus: true
   replicas: 1
-  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.138.0"
+  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.141.0"
   upgradeStrategy: automatic
   securityContext:
     runAsNonRoot: true

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
     opentelemetry.io/opamp-reporting: "true"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,8 +5,8 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -232,8 +232,8 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -365,8 +365,8 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -171,8 +171,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
     otel-collector-type: daemonset-example    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.12.7
-    app.kubernetes.io/version: "0.138.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.13.0
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.12.7"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.13.0"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -333,6 +333,14 @@ rules:
     - patch
     - update
   - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
       - cert-manager.io
     resources:
       - issuers
@@ -358,9 +366,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -377,9 +385,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -26,9 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.99.0
+        helm.sh/chart: opentelemetry-operator-0.102.0
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.138.0"
+        app.kubernetes.io/version: "0.141.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -41,7 +41,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.138.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.141.0
           command:
             - /manager
           env:
@@ -51,7 +51,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.141.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
@@ -92,7 +92,7 @@ spec:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -167,6 +167,7 @@ rules:
       - opentelemetrycollectors/finalizers
       - opentelemetrycollectors/status
       - targetallocators/status
+      - targetallocators/finalizers
     verbs:
       - get
       - patch

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,9 +32,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.99.0
+    helm.sh/chart: opentelemetry-operator-0.102.0
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.138.0"
+    app.kubernetes.io/version: "0.141.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example


### PR DESCRIPTION
Bump OTel Operator from [v0.99.0](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.99.0) (OTel Collector v0.138.0) to [v0.102.0](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.102.0) (OTelCollector v0.141.0)