### PR TITLE
fix(collector): inject K8S_NODE_NAME for annotationDiscovery in daemonset mode

### DIFF
--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -300,7 +300,9 @@ receivers:
 extensions:
   k8s_observer:
     auth_type: serviceAccount
+    {{- if eq .Values.mode "daemonset" }}
     node: ${env:K8S_NODE_NAME}
+    {{- end }}
 
 receivers:
   {{- if .Values.presets.annotationDiscovery.logs.enabled }}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -52,7 +52,17 @@ containers:
           fieldRef:
             apiVersion: v1
             fieldPath: status.podIP
-      {{- if or .Values.presets.kubeletMetrics.enabled (and .Values.presets.kubernetesAttributes.enabled (eq .Values.mode "daemonset")) }}
+      {{- if or
+      .Values.presets.kubeletMetrics.enabled
+      (and .Values.presets.kubernetesAttributes.enabled (eq .Values.mode "daemonset"))
+      (and
+        (or
+          .Values.presets.annotationDiscovery.logs.enabled
+          .Values.presets.annotationDiscovery.metrics.enabled
+        )
+        (eq .Values.mode "daemonset")
+      )
+      }}
       - name: K8S_NODE_NAME
         valueFrom:
           fieldRef:


### PR DESCRIPTION
### What this PR does
- Injects `K8S_NODE_NAME` and `K8S_NODE_IP` env vars when annotationDiscovery is enabled in daemonset mode
- Avoids setting `k8s_observer.node` and node-scoped env vars in deployment mode

### Why
When `presets.annotationDiscovery.(logs|metrics)` is enabled, the collector config references
`${env:K8S_NODE_NAME}`, but the env var was not injected by default, causing runtime failures.

This change ensures the env vars and config are aligned with the installation mode.

### Verification
- `helm template` tested for:
  - daemonset + annotationDiscovery enabled
  - deployment + annotationDiscovery enabled

Fixes #2067