### PR TITLE
fix(kube-stack): fix Quantity schema type to accept string and number values

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.14.4
+version: 0.14.5
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -2235,15 +2235,13 @@
       ]
     },
     "Quantity": {
-      "properties": {
-        "Format": {
+      "oneOf": [
+        {
           "type": "string"
+        },
+        {
+          "type": "number"
         }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "Format"
       ]
     },
     "QuobyteVolumeSource": {


### PR DESCRIPTION
## Summary

The `Quantity` type definition in `values.schema.json` was derived from the Go `resource.Quantity` struct, producing an object type with a required `Format` field:

```json
"Quantity": {
  "type": "object",
  "required": ["Format"],
  "properties": { "Format": { "type": "string" } },
  "additionalProperties": false
}
```

This does not match how Kubernetes quantities are represented in YAML/JSON — they are plain strings (e.g., `"50Mi"`, `"1Gi"`, `"500m"`) or numbers. Helm schema validation rejects standard Kubernetes quantity values with:

```
Invalid type. Expected: object, given: string
```

### Affected fields

| Field | Use case |
|-------|----------|
| `EmptyDirVolumeSource.sizeLimit` | Volume size limits |
| `MetricTarget.value` | HPA metric target values |
| `MetricTarget.averageValue` | HPA average metric target values |
| `ResourceFieldSelector.divisor` | Downward API resource field selectors |
| `ResourceList` (additionalProperties) | Resource requests and limits |

### Fix

Changes the `Quantity` definition to match the [Kubernetes OpenAPI specification](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L404-L416) — `oneOf` string or number:

```json
"Quantity": {
  "oneOf": [
    { "type": "string" },
    { "type": "number" }
  ]
}
```

This matches the canonical Kubernetes definition from `apimachinery/pkg/api/resource/quantity.go`:

```go
func (Quantity) OpenAPIV3OneOfTypes() []string { return []string{"string", "number"} }
```

And the [yannh/kubernetes-json-schema](https://github.com/yannh/kubernetes-json-schema/blob/master/master-standalone-strict/quantity.json) reference:

```json
{ "oneOf": [{ "type": "string" }, { "type": "number" }] }
```

### Cross-chart comparison

| Chart | How Quantity is handled |
|-------|----------------------|
| **kube-prometheus-stack** | No `values.schema.json` at all |
| **prometheus** | `sizeLimit: {"type": "string"}`, resources: `{"type": "object"}` (open) |
| **cert-manager** | Resources: `{"type": "object"}` (open), no Quantity type |
| **ingress-nginx** | No `values.schema.json` |
| **OTel Collector** (sibling chart) | cpu: `["string", "integer"]`, memory: `"string"` — no Quantity ref |
| **OTel Kube-Stack** (this chart) | `Quantity` as Go struct object — **the only chart with this pattern** |
| **Kubernetes canonical** | `oneOf: ["string", "number"]` |

The `opentelemetry-kube-stack` chart is the only Helm chart that defines `Quantity` as a Go struct object type. Every other chart either uses plain strings, open objects, or doesn't validate at all.

### Note on `ResourceRequirements`

The `ResourceRequirements` definition in this chart was already manually fixed (cpu: `["string", "integer"]`, memory: `"string"`) — it does not reference `Quantity`. This is why `resources.limits.cpu: "250m"` in the default `values.yaml` works today. Only the remaining 5 `$ref: Quantity` fields (listed above) are broken.

### Backward compatibility

- **No breaking change.** Zero instances of the old object format (`{Format: "BinarySI"}`) exist in the chart's values, examples, or rendered output
- All default values and examples already use string quantities (`"64Mi"`, `"250m"`, etc.)
- The fix is purely additive — it makes previously-failing string values pass validation

### Reproduction

```yaml
# values.yaml — fails schema validation on 0.12.6 through current main
collectors:
  daemon:
    volumes:
      - name: my-volume
        emptyDir:
          sizeLimit: 50Mi  # Error: Expected: object, given: string
```

```bash
helm template test open-telemetry/opentelemetry-kube-stack -f values.yaml
# Error: values don't meet the specifications of the schema(s)
# collectors.daemon.volumes.0.emptyDir.sizeLimit: Invalid type. Expected: object, given: string
```

### Testing

- Verified `values.schema.json` remains valid JSON after the change
- All 5 `$ref` to `Quantity` resolve correctly
- String values (`"50Mi"`, `"1Gi"`) and number values pass validation
- Object values are correctly rejected
- Chart version bumped 0.14.4 → 0.14.5