### PR TITLE
fix(opentelemetry-ebpf-instrumentation): update servicemonitor endpoint

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.7.1
+version: 0.7.2
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     - port: {{ .Values.service.portName }}
       path: {{ .Values.config.data.prometheus_export.path }}
       scheme: http
-      {{- with .Values.serviceMonitor.endpoint }}
+      {{- with .Values.serviceMonitor.metrics.endpoint }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
The helm chart references `.Values.serviceMonitor.endpoint`, but `values.yaml` and `values.schema.json` use `.Values.serviceMonitor.metrics.endpoint` instead.