### PR TITLE
feat(operator): support extraObjects

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.109.0
+version: 0.109.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -373,7 +373,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -392,7 +392,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.109.0
+        helm.sh/chart: opentelemetry-operator-0.109.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.148.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -373,7 +373,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -392,7 +392,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.109.0
+        helm.sh/chart: opentelemetry-operator-0.109.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.148.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.109.0
+    helm.sh/chart: opentelemetry-operator-0.109.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.148.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/extramanifests.yaml
+++ b/charts/opentelemetry-operator/templates/extramanifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -2137,6 +2137,14 @@
       "examples": [
         false
       ]
+    },
+    "extraObjects": {
+      "type": "array",
+      "default": [],
+      "title": "Extra manifests to deploy as an array",
+      "items": {
+        "type": "object"
+      }
     }
   },
   "examples": [

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -416,3 +416,13 @@ testFramework:
   #   requests:
   #     cpu: 10m
   #     memory: 64Mi
+
+## Extra manifests to deploy as an array
+## Supports tpl syntax for templating
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: '{{ include "opentelemetry-operator.fullname" . }}-extra'
+  #   data:
+  #     key: value


### PR DESCRIPTION
Add extraObjects to the opentelemetry-operator chart, allowing users to deploy additional Kubernetes manifests alongside the operator in a single Helm release.

This is useful for managing custom resources such as Instrumentation or OpenTelemetryCollector directly within the operator chart, without requiring a separate release.

Consistent with the existing pattern in opentelemetry-kube-stack and opentelemetry-target-allocator charts.

<details>
<summary>Test results</summary>

With extraObjects values:

```console
$ helm template test charts/opentelemetry-operator/ \
    --set 'extraObjects[0].apiVersion=v1' \
    --set 'extraObjects[0].kind=ConfigMap' \
    --set 'extraObjects[0].metadata.name=test-extra' \
    --set 'extraObjects[0].data.key=value'
...
kind: ConfigMap
metadata:
  name: test-extra
---
```

Default (empty extraObjects) renders without errors:

```console
$ helm template test charts/opentelemetry-operator/
---
# Source: opentelemetry-operator/templates/serviceaccount.yaml
apiVersion: v1
...
```

</details>