### PR TITLE
feat(target-allocator): add extraEnvs support

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.127.1
+version: 0.127.2
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: 560bad05205d0110fe38bf11b872ec7179cd4a36f33819e8cd92e5fc11d0d42b
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e40374c4889a2362d64c337ccec8739cda24ac2ae9ead87b2a759d3a86f52295
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.1
+    helm.sh/chart: opentelemetry-target-allocator-0.127.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -30,7 +30,7 @@ spec:
       annotations:
         checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.1
+        helm.sh/chart: opentelemetry-target-allocator-0.127.2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/templates/_pod.tpl
+++ b/charts/opentelemetry-target-allocator/templates/_pod.tpl
@@ -37,6 +37,9 @@ containers:
     env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
       - name: OTELCOL_NAMESPACE
         value: {{ .Values.targetAllocator.config.collector_namespace | default .Release.Namespace }}
+      {{- with .Values.targetAllocator.extraEnvs }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
     {{- with .Values.targetAllocator.livenessProbe }}
     livenessProbe:
       {{- toYaml . | nindent 6 }}

--- a/charts/opentelemetry-target-allocator/values.schema.json
+++ b/charts/opentelemetry-target-allocator/values.schema.json
@@ -99,6 +99,12 @@
         "imagePullSecrets": {
           "type": "array"
         },
+        "extraEnvs": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "resources": {
           "type": "object"
         },

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -95,6 +95,18 @@ targetAllocator:
   # Pod labels to add to the target allocator pod
   podLabels: {}
 
+  # Extra environment variables to set in the target allocator container.
+  # Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: MY_VAR
+  #     value: "my-value"
+  #   - name: MY_SECRET_VAR
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: my-secret
+  #         key: my-key
+
 affinity: {}
 tolerations: []
 nodeSelector: {}


### PR DESCRIPTION
## Summary

Adds `extraEnvs` support to the target-allocator Helm chart, allowing users to set arbitrary environment variables in the target allocator container. This follows the same pattern already established in the `opentelemetry-collector` chart.

## Changes

- Added `targetAllocator.extraEnvs: []` field to `values.yaml` with examples
- Updated `_pod.tpl` template to render `extraEnvs` after built-in `OTELCOL_NAMESPACE` env var
- Added `extraEnvs` to `values.schema.json` for validation
- Bumped chart version to 0.127.2 per contribution guidelines

## Use Case

Users can now set environment variables like `GOMEMLIMIT` for memory management:

```yaml
targetAllocator:
  extraEnvs:
    - name: GOMEMLIMIT
      value: "128MiB"
```

Or inject from secrets:

```yaml
targetAllocator:
  extraEnvs:
    - name: API_KEY
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: api-key
```

## Testing

- Helm lint passes
- Chart templates render correctly with extraEnvs
- Schema validation includes new field

## Related

Closes #2098