### PR TITLE
fix(operator): use toYaml for VPA controlledResources

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.109.1
+version: 0.109.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
+++ b/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
@@ -16,7 +16,8 @@ spec:
     containerPolicies:
     - containerName: manager
       {{- if .Values.manager.verticalPodAutoscaler.controlledResources }}
-      controlledResources: {{ .Values.manager.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml .Values.manager.verticalPodAutoscaler.controlledResources | nindent 8 }}
       {{- end }}
       {{- if .Values.manager.verticalPodAutoscaler.maxAllowed }}
       maxAllowed:


### PR DESCRIPTION
## Summary
- `controlledResources` in the VPA template was rendered inline without `toYaml`, producing invalid YAML output (e.g. `controlledResources: [cpu memory]` instead of a proper YAML list)
- This caused the VPA controller to fail with:
  ```
  E0410 23:03:16.284497       1 types.go:131] "Cannot translate resource name" resourceName="cpu memory"
  ```
- Use `toYaml | nindent` to match the pattern used by the other fields (`recommenders`, `maxAllowed`, `minAllowed`) in the same template