### PR TITLE
Fix permission issue for auto-update workflows

### DIFF
--- a/.github/workflows/update-obi-chart.yaml
+++ b/.github/workflows/update-obi-chart.yaml
@@ -18,6 +18,9 @@ permissions:
 
 jobs:
   update:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-chart-app-version.yaml
     secrets: inherit
     with:

--- a/.github/workflows/update-target-allocator-chart.yaml
+++ b/.github/workflows/update-target-allocator-chart.yaml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   update:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-chart-app-version.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Fix #2149 

The auto-update workflows are currently failing:

- https://github.com/open-telemetry/opentelemetry-helm-charts/actions/runs/24337352968
- https://github.com/open-telemetry/opentelemetry-helm-charts/actions/runs/24337602845

The failure in both linked runs is a reusable-workflow permission mismatch. The caller workflows only allowed `contents: read`, while the called workflow’s update job requests `contents: write` and `pull-requests: write` so it can push a branch and open/edit a PR.

I fixed that by granting the required scopes on the calling job in `.github/workflows/update-obi-chart.yaml` and `.github/workflows/update-target-allocator-chart.yaml`. I kept the write grant scoped to the update job that invokes the reusable workflow instead of broadening workflow-wide defaults.

## Verification

- I verified the edited YAML parse cleanly and `actionlint` passes for those two callers plus `.github/workflows/update-chart-app-version.yaml`.
- Tested the OBI update action on my fork: https://github.com/MrAlias/opentelemetry-helm-charts/actions/runs/24358085839/job/71130259992
- Tested the Target Allocator update action on my fork: https://github.com/MrAlias/opentelemetry-helm-charts/actions/runs/24358131911

Note: Both action tests no longer fail on the permission issues, each run gets past `startup_failure`. Instead, they fail on not having access to the OTel bot token, which is expected.