### PR TITLE
fix(opentelemetry-ebpf-instrumentation): add rollingUpdate fields to schema

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.7.0
+version: 0.7.1
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/values.schema.json
+++ b/charts/opentelemetry-ebpf-instrumentation/values.schema.json
@@ -835,6 +835,48 @@
             "OnDelete"
           ],
           "example": "RollingUpdate"
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "title": "Rolling Update Configuration",
+          "description": "Rolling update configuration for the DaemonSet. Only applies when type is 'RollingUpdate'.",
+          "additionalProperties": false,
+          "properties": {
+            "maxUnavailable": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "title": "Max Unavailable - Integer",
+                  "description": "The maximum number of DaemonSet pods that can be unavailable during the update as an absolute number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "title": "Max Unavailable - Percentage",
+                  "description": "The maximum number of DaemonSet pods that can be unavailable during the update as a percentage (e.g., '10%')",
+                  "pattern": "^[0-9]+%$"
+                }
+              ],
+              "example": 1
+            },
+            "maxSurge": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "title": "Max Surge - Integer",
+                  "description": "The maximum number of DaemonSet pods that can be created over the desired number during the update as an absolute number",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "title": "Max Surge - Percentage",
+                  "description": "The maximum number of DaemonSet pods that can be created over the desired number during the update as a percentage (e.g., '10%')",
+                  "pattern": "^[0-9]+%$"
+                }
+              ],
+              "example": "10%"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
This PR adds support for `rollingUpdate` fields `maxUnavailable` and `maxSurge`. Without it, validation fails even though the chart itself supports it.