### PR TITLE
fix(opentelemetry-kube-stack): quote env var values in Instrumentation template

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.14.11
+version: 0.14.12
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Render a deduped list of environment variables and 'extraEnvs'
 {{- end }}
 {{- range $key, $value := $envMap }}
 - name: {{ $key }}
-  value: {{ $value }}
+  value: {{ $value | quote }}
 {{- end }}
 {{- range $key, $value := $valueFromMap }}
 - name: {{ $key }}

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -566,7 +566,7 @@
           "type": "string"
         },
         "value": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "valueFrom": {
           "$ref": "#/$defs/EnvVarSource"

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -566,7 +566,10 @@
           "type": "string"
         },
         "value": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "valueFrom": {
           "$ref": "#/$defs/EnvVarSource"


### PR DESCRIPTION
Fixes #1888

## Summary

Numeric env var values (e.g. `value: 4317`) passed to the `Instrumentation` resource caused validation errors:

```
spec.env[1].value: Invalid value: "integer": spec.env[1].value in body must be of type string
```

This is especially common when using the chart as a subchart, where YAML type coercion strips quotes from numeric strings.

## Changes

- **`templates/_helpers.tpl`**: Added `| quote` to the `value` output in the `renderenvs` helper, ensuring all values are rendered as quoted strings
- **`values.schema.json`**: Changed the `EnvVar.value` type from `"string"` to `["string", "number"]` so numeric values pass schema validation before the template quotes them
- **`Chart.yaml`**: Version bump 0.14.11 -> 0.14.12

## Testing

- [x] `helm template` with integer env var values renders them as quoted strings
- [x] `helm template` with string env var values still works correctly