### PR TITLE
fix(opentelemetry-collector): add rbac permissions to create tokenreviews

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.110.0
+version: 0.110.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -390,6 +390,14 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+{{ if .Values.manager.metrics.secure }}
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+{{- end }}
 
 {{ if .Values.manager.metrics.secure }}
 ---


### PR DESCRIPTION
Hi 👋 

After upgrading to `0.110.0` of the `opentelemetry-operator` chart the `opentelemetry-operator` pods started to log an error each time their `/metrics` endpoint was scraped and a 500 status code is returned:
> {"level":"ERROR","timestamp":"2026-04-20T15:37:48Z","logger":"controller-runtime.metrics","message":"Authentication failed","path":"/metrics","error":"tokenreviews.authentication.k8s.io is forbidden: User \"system:serviceaccount:opentelemetry:opentelemetry-operator\" cannot create resource \"tokenreviews\" in API group \"authentication.k8s.io\" at the cluster scope","errorCauses":[{"error":"tokenreviews.authentication.k8s.io is forbidden: User \"system:serviceaccount:opentelemetry:opentelemetry-operator\" cannot create resource \"tokenreviews\" in API group \"authentication.k8s.io\" at the cluster scope"}],"stacktrace":"sigs.k8s.io/controller-runtime/pkg/metrics/filters.WithAuthenticationAndAuthorization.func1.1\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/metrics/filters/filters.go:89\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2322\nnet/http.(*ServeMux).ServeHTTP\n\tnet/http/server.go:2861\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:3340\nnet/http.initALPNRequest.ServeHTTP\n\tnet/http/server.go:4013\nnet/http.(*http2serverConn).runHandler\n\tnet/http/h2_bundle.go:6386"}

Looking through the changelogs and PR history I think https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2153 might have removed more than intended.

As a workaround I added the following in our setup which fixed the issue:
```yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: opentelemetry-operator-tokenreview
rules:
  - apiGroups: ["authentication.k8s.io"]
    resources: ["tokenreviews"]
    verbs: ["create"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: opentelemetry-operator-tokenreview
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: opentelemetry-operator-tokenreview
subjects:
  - kind: ServiceAccount
    name: opentelemetry-operator
    namespace: opentelemetry
```

So as far as I understand the chart and the new authentication logic this PR should add the necessary permissions to allow scraping of the `/metrics` endpoint.

I see the changelog also mentions `RBAC: ClusterRole for /metrics access only created when manager.metrics.secure: true`. I think this means https://github.com/open-telemetry/opentelemetry-helm-charts/blob/c738eda8d0bfa36513acdc9601165a308d9f506b/charts/opentelemetry-operator/templates/clusterrole.yaml#L394-L409
As far as I can tell there is no `RoleBinding` or `ClusterRoleBinding` that actually uses this `ClusterRole`. During debugging I was thinking that maybe this role is supposed to solve the issue I am seeing. So as an experiment I manually created a `ClusterRoleBinding` to use this role, but it did not solve the issue.

Looking at https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2153 I don't understand how it could have worked withouth the `tokenreviews` permission for others. So I am wondering if maybe I am doing something wrong entirely?