### PR TITLE
Add securityContext support for TargetAllocator

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.114.1
+version: 0.114.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -3366,6 +3366,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  SecurityContext:
+                    properties:
+                      allowPrivilegeEscalation:
+                        type: boolean
+                      capabilities:
+                        properties:
+                          add:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
                   prometheusCR:
                     properties:
                       denyFSAccessThroughSMs:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook.yaml
@@ -9047,6 +9047,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  SecurityContext:
+                    properties:
+                      allowPrivilegeEscalation:
+                        type: boolean
+                      capabilities:
+                        properties:
+                          add:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
                   prometheusCR:
                     properties:
                       denyFSAccessThroughSMs:

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -16,6 +16,7 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  minReadySeconds: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-operator
@@ -25,7 +26,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.114.1
+        helm.sh/chart: opentelemetry-operator-0.114.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.152.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook.yaml
@@ -9047,6 +9047,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  SecurityContext:
+                    properties:
+                      allowPrivilegeEscalation:
+                        type: boolean
+                      capabilities:
+                        properties:
+                          add:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
                   prometheusCR:
                     properties:
                       denyFSAccessThroughSMs:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -16,6 +16,7 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  minReadySeconds: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-operator
@@ -25,7 +26,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.114.1
+        helm.sh/chart: opentelemetry-operator-0.114.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.152.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.114.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Currently, when namespace-level privilege is not enabled, deploying TargetAllocator alongside the OpenTelemetry Collector (with `enabled=true`) fails due to PodSecurity "restricted" policy violations:

- allowPrivilegeEscalation must be set to false
- capabilities must drop ["ALL"]

This change adds support for configuring securityContext for the TargetAllocator container, enabling compliant deployments under restricted PodSecurity settings.

Test Steps and Logs
- Create an OpenTelemetryCollector with TargetAllocator enabled and securityContext configured:
```
apiVersion: opentelemetry.io/v1beta1
kind: OpenTelemetryCollector
metadata:
  name: collector-with-ta
spec:
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
      - ALL
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
  mode: statefulset
  targetAllocator:
    enabled: true
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
    podSecurityContext:
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
  config:
    receivers:
      prometheus:
        config:
          scrape_configs:
          - job_name: 'otel-collector'
            scrape_interval: 10s
            static_configs:
            - targets: [ '0.0.0.0:8888' ]
            metric_relabel_configs:
            - action: labeldrop
              regex: (id|name)
            - action: labelmap
              regex: label_(.+)
              replacement: $$1

    exporters:
      debug: {}

    service:
      pipelines:
        metrics:
          receivers: [prometheus]
          exporters: [debug]
```
- Apply the manifest
```
kubectl apply -f opentelemetry-collector-targetallocator.yml -n test1
```
- Verify the TargetAllocator pod is running:
```
kubectl get pods -n test1 |grep target
collector-with-ta-targetallocator-57986fd8f4-6l9hb   1/1     Running   0          43m
```
- Inspect the securityContext of the TargetAllocator container that it's correctly applied:
```
kubectl get pod <targetallocator-pod> -n test1 -o yaml | yq .spec.containers[].securityContext
allowPrivilegeEscalation: false
capabilities:
  drop:
    - ALL
```
