### PR TITLE
Fix VPA updateMode YAML parsing by adding quotes

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.112.0
+version: 0.112.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -387,7 +387,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.112.0
+        helm.sh/chart: opentelemetry-operator-0.112.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.150.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -387,7 +387,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.112.0
+        helm.sh/chart: opentelemetry-operator-0.112.1
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.150.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.0
+    helm.sh/chart: opentelemetry-operator-0.112.1
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
+++ b/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
@@ -34,7 +34,7 @@ spec:
   {{- if .Values.manager.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
-    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode }}
+    updateMode: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.updateMode | quote }}
     {{- end }}
     {{- if .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}
     minReplicas: {{ .Values.manager.verticalPodAutoscaler.updatePolicy.minReplicas }}


### PR DESCRIPTION
The VPA templates render updateMode without quotes, causing it to be interpreted as a boolean in YAML 1.1. This breaks deployments on clusters with strict VPA webhook validation (like GKE) with the error:

`admission webhook "gke-vpa.k8s.io" denied the request: json: cannot unmarshal bool into Go struct field PodUpdatePolicy.spec.updatePolicy.updateMode of type v1.UpdateMode`                              
                                                                                                                                                                                                        
The issue occurs when users set `updateMode: "Off"` in values - it gets rendered as unquoted `updateMode: Off`, which YAML interprets as the boolean `false`. The VPA API expects a string enum value.
                                                                                                                                                                                                    
This fix adds the `| quote` Helm filter to ensure the value is always rendered as a properly quoted string.
                                                                                                                                                                                                    