### PR TITLE
ci: use OTelBot token to push update branches

### DIFF
--- a/.github/workflows/update-chart-app-version.yaml
+++ b/.github/workflows/update-chart-app-version.yaml
@@ -102,10 +102,22 @@ jobs:
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
+      - name: Create OTelBot token
+        if: steps.update.outputs.changed == 'true'
+        id: otelbot-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Push update branch if needed
         if: steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           BRANCH_NAME: ${{ steps.update.outputs.branch_name }}
           COMMIT_MESSAGE: ${{ steps.update.outputs.commit_message }}
           STAGE_PATH: ${{ steps.update.outputs.stage_path }}
@@ -117,17 +129,6 @@ jobs:
           git commit -m "${COMMIT_MESSAGE}"
           git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
             push --force-with-lease --set-upstream origin "${BRANCH_NAME}"
-
-      - name: Create OTelBot token
-        if: steps.update.outputs.changed == 'true'
-        id: otelbot-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-pull-requests: write
 
       - name: Create pull request if needed
         if: steps.update.outputs.changed == 'true'


### PR DESCRIPTION
## Description
This PR fixes the automated `update-chart-app-version` workflow, which is currently failing to push new branches due to repository ruleset violations (`GH013`).

Fixes #2149 

**The Problem:**
Currently, the workflow attempts to push the new feature branch using the default `secrets.GITHUB_TOKEN`. Because of repository rules enforcing the `EasyCLA` status check on all branch pushes, GitHub rejects the push. The `OTelBot` app token is generated *after* the push fails, meaning it's only being used to open the PR, not to push the branch.

**The Fix:**
1. Moved the `Create OTelBot token` step to run **before** the git push.
2. Granted the OTelBot token `permission-contents: write` so it can push code.
3. Updated the `Push update branch if needed` step to use the `OTelBot` token for authentication instead of the default Actions token.

Because OTelBot is a configured GitHub App/Bot account, using its token for the `git push` satisfies the repository rules/CLA checks and allows the automated workflow to successfully create branches and open PRs again.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update