### PR TITLE
feat(target-allocator): add configMap.existingPath for checksum-based pod restart

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.127.2
+version: 0.128.0
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 560bad05205d0110fe38bf11b872ec7179cd4a36f33819e8cd92e5fc11d0d42b
+        checksum/config: 5b1a6a30d3cb2cc3517ba6d414710cc20571f7ae6a11fcb143e0fa53e6174a8e
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
+        checksum/config: 90ec1b8ea030d3641ce8725b5fddb22a6c913916bebe9540c8f7092218a9c66d
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
+        checksum/config: 90ec1b8ea030d3641ce8725b5fddb22a6c913916bebe9540c8f7092218a9c66d
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e40374c4889a2362d64c337ccec8739cda24ac2ae9ead87b2a759d3a86f52295
+        checksum/config: 02271dbf230528ee4afde04b7893287910f9e1677910aab7862d5980e904b2c9
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.2
+    helm.sh/chart: opentelemetry-target-allocator-0.128.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.126.0"
@@ -28,9 +28,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a96ec7dbe251d28b583e9cb9fdcfe32032d49aa405bb47f68ef4cf31b89d8bdb
+        checksum/config: 90ec1b8ea030d3641ce8725b5fddb22a6c913916bebe9540c8f7092218a9c66d
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.2
+        helm.sh/chart: opentelemetry-target-allocator-0.128.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.126.0"

--- a/charts/opentelemetry-target-allocator/templates/NOTES.txt
+++ b/charts/opentelemetry-target-allocator/templates/NOTES.txt
@@ -2,6 +2,10 @@
 {{ fail "[ERROR] 'mode' must be set to one of: deployment, statefulset." }}
 {{ end }}
 
+{{- if and .Values.configMap.create .Values.configMap.existingPath }}
+{{ fail "[ERROR] Cannot set configMap.existingPath when configMap.create is true" }}
+{{ end }}
+
 {{- if not .Values.targetAllocator.resources }}
 [WARNING] No resource limits or requests were set. Consider setting resource requests and limits for your target allocator via the `targetAllocator.resources` field.
 {{ end }}

--- a/charts/opentelemetry-target-allocator/templates/_helpers.tpl
+++ b/charts/opentelemetry-target-allocator/templates/_helpers.tpl
@@ -98,8 +98,12 @@ Create the target allocator docker image name.
 {{- end -}}
 
 {{/*
-Create ConfigMap checksum annotation
+Create ConfigMap checksum annotation if configMap.existingPath is defined, otherwise use default template
 */}}
 {{- define "helper.configTemplateChecksumAnnotation" -}}
-checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+  {{- if .Values.configMap.existingPath -}}
+  checksum/config: {{ include (print $.Template.BasePath "/" .Values.configMap.existingPath) . | sha256sum }}
+  {{- else -}}
+  checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+  {{- end }}
 {{- end -}}

--- a/charts/opentelemetry-target-allocator/values.schema.json
+++ b/charts/opentelemetry-target-allocator/values.schema.json
@@ -34,6 +34,10 @@
         },
         "existingKey": {
           "type": "string"
+        },
+        "existingPath": {
+          "description": "Relative path to the template file used to generate a custom configMap. Needed for pod restart on custom config change.",
+          "type": "string"
         }
       }
     },

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -27,6 +27,9 @@ configMap:
   existingName: ""
   # If the key in your provided configmap does not match 'targetallocator.yaml' you can set here the custom one
   # existingKey: demo-key
+  # Specifies the relative path to a custom ConfigMap template file. This option SHOULD be used when bundling a custom
+  # ConfigMap template, as it enables pod restart via a template checksum annotation.
+  # existingPath: ""
   # You can also set create: false and dont specify a existing one, but than you have to provide custom config volume mount via the mounts below and mount it to /conf/targetallocator.yaml, otherwhise the pod wont start
 
 targetAllocator:


### PR DESCRIPTION
## Description

Add `configMap.existingPath` to the target-allocator chart, mirroring the mechanism already present in the collector chart (`charts/opentelemetry-collector/templates/_helpers.tpl#L235-L250`). When set, the deployment/statefulset checksum annotation is computed from the rendered output of the user-supplied template at that path, so the pod rolls when the bundled config changes.

## Motivation

The `helper.configTemplateChecksumAnnotation` helper hashes `templates/configmap.yaml`, but that template is gated by `{{- if and (.Values.configMap.create) (not .Values.configMap.existingName) -}}`. So when a user mounts a ConfigMap via `configMap.existingName` (or supplies their own template), the included content is empty and the checksum is permanently `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (sha256 of the empty string). You can see this baked into the existing rendered example at `examples/existing-configmap/rendered/deployment.yaml`.

The result: changes to externally-managed config never trigger a pod restart.

The collector chart solved this with `configMap.existingPath`, letting users bundle a ConfigMap template via a parent chart and tell the helper where to find it for hashing. This PR ports that same pattern to the target-allocator chart.

## Changes

- `templates/_helpers.tpl`: extend `helper.configTemplateChecksumAnnotation` with an `existingPath` branch.
- `templates/NOTES.txt`: fail-fast guard rejecting `configMap.create: true` combined with `configMap.existingPath`.
- `values.yaml`: documented (commented) `existingPath` example.
- `values.schema.json`: add `existingPath` string property under `configMap`.
- `Chart.yaml`: bump `version` 0.127.2 → 0.128.0 (minor, new feature).
- `examples/*/rendered/*.yaml`: regenerated via `make generate-examples CHARTS=opentelemetry-target-allocator` to pick up the new chart-version label.

Backwards compatible — when `existingPath` is unset, the helper falls through to the original `configmap.yaml`-based checksum.

## Validation

- `helm lint charts/opentelemetry-target-allocator` passes.
- `make check-examples CHARTS=opentelemetry-target-allocator` passes for all 7 existing examples.
- `pre-commit run` passes for the touched files.
- Synthetic check: `helm template ... --set configMap.create=false --set configMap.existingPath=service.yaml` produces a non-empty checksum, confirming the new branch is wired up.