### PR TITLE
fix(operator): add tokenreviews ClusterRole permission for metrics auth

### DIFF
--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -376,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -376,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews

--- a/charts/opentelemetry-operator/templates/clusterrole.yaml
+++ b/charts/opentelemetry-operator/templates/clusterrole.yaml
@@ -399,6 +399,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews


### PR DESCRIPTION
## Summary
- PR #2153 removed the `proxy` ClusterRole that granted `create` on `tokenreviews.authentication.k8s.io`, which is required by controller-runtime's built-in metrics authentication
- Add the `tokenreviews` permission to the existing `manager` ClusterRole so the operator can authenticate metrics requests
- Regenerated rendered examples

Fixes #2178

## Test plan
- [ ] `helm template` renders the `tokenreviews` rule in the manager ClusterRole
- [ ] Deploy chart and confirm `/metrics` endpoint no longer returns `tokenreviews.authentication.k8s.io is forbidden`
- [ ] `make check-examples` passes