### PR TITLE
ci: fix automatic chart update workflows

### DIFF
--- a/.github/scripts/test-update-chart-app-version.sh
+++ b/.github/scripts/test-update-chart-app-version.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/.github/scripts/update-chart-app-version.sh"
+TEST_TMP_ROOT="${ROOT_DIR}/tmp/update-chart-app-version"
+
+fail() {
+	printf 'ERROR: %s\n' "$1" >&2
+	exit 1
+}
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+
+	if [[ "${expected}" != "${actual}" ]]; then
+		printf 'FAIL: %s\n' "${message}" >&2
+		printf '  expected: %s\n' "${expected}" >&2
+		printf '  actual:   %s\n' "${actual}" >&2
+		exit 1
+	fi
+}
+
+read_yaml_field() {
+	local file_path="$1"
+	local field_name="$2"
+
+	sed -n "s/^${field_name}: \\(.*\\)$/\\1/p" "${file_path}"
+}
+
+read_output_field() {
+	local output_path="$1"
+	local field_name="$2"
+
+	sed -n "s/^${field_name}=\\(.*\\)$/\\1/p" "${output_path}" | tail -n 1
+}
+
+run_case() {
+	local name="$1"
+	local fixture="$2"
+	local release_tag="$3"
+	local chart_name="$4"
+	local upstream_repository="$5"
+	local release_tag_prefix="$6"
+	local app_version_prefix="$7"
+	local branch_prefix="$8"
+	local version_policy="$9"
+	local approvers="${10}"
+	local pr_title_template="${11}"
+	local pr_body_template="${12}"
+	local expected_changed="${13}"
+	local expected_branch_name="${14}"
+	local expected_chart_version="${15}"
+	local expected_app_version="${16}"
+
+	local case_dir="${TEST_TMP_ROOT}/${name}"
+	local chart_yaml_path="${ROOT_DIR}/charts/${chart_name}/Chart.yaml"
+	local backup_path="${case_dir}/Chart.yaml.original"
+	local output_path=""
+
+	rm -rf "${case_dir}"
+	mkdir -p "${case_dir}"
+	cp "${chart_yaml_path}" "${backup_path}"
+	cp "${ROOT_DIR}/${fixture}" "${chart_yaml_path}"
+
+	output_path="$(mktemp)"
+
+	cleanup_case() {
+		cp "${backup_path}" "${chart_yaml_path}"
+		rm -f "${output_path}"
+	}
+
+	trap cleanup_case RETURN
+
+	(
+		cd "${ROOT_DIR}"
+		GITHUB_OUTPUT="${output_path}" \
+			RELEASE_TAG="${release_tag}" \
+			CHART_NAME="${chart_name}" \
+			CHART_ROOT="charts/${chart_name}" \
+			CHART_YAML="charts/${chart_name}/Chart.yaml" \
+			STAGE_PATH="charts/${chart_name}" \
+			UPSTREAM_REPOSITORY="${upstream_repository}" \
+			RELEASE_TAG_PREFIX="${release_tag_prefix}" \
+			APP_VERSION_PREFIX="${app_version_prefix}" \
+			BRANCH_PREFIX="${branch_prefix}" \
+			VERSION_POLICY="${version_policy}" \
+			APPROVERS="${approvers}" \
+			PR_TITLE_TEMPLATE="${pr_title_template}" \
+			PR_BODY_TEMPLATE="${pr_body_template}" \
+			POST_UPDATE_ACTION="none" \
+			bash "${SCRIPT_PATH}" >/dev/null
+	)
+
+	assert_equals "${expected_changed}" "$(read_output_field "${output_path}" "changed")" "${name}: changed output"
+	assert_equals "${expected_branch_name}" "$(read_output_field "${output_path}" "branch_name")" "${name}: branch_name output"
+	assert_equals "${expected_chart_version}" "$(read_yaml_field "${chart_yaml_path}" "version")" "${name}: chart version"
+	assert_equals "${expected_app_version}" "$(read_yaml_field "${chart_yaml_path}" "appVersion")" "${name}: appVersion"
+
+	cleanup_case
+	trap - RETURN
+}
+
+main() {
+	rm -rf "${TEST_TMP_ROOT}"
+	mkdir -p "${TEST_TMP_ROOT}"
+
+	run_case \
+		"obi-noop-same-app-version" \
+		".github/scripts/testdata/update-chart-app-version/obi-chart-0.8.1-app-v0.8.0.yaml" \
+		"v0.8.0" \
+		"opentelemetry-ebpf-instrumentation" \
+		"open-telemetry/opentelemetry-ebpf-instrumentation" \
+		"v" \
+		"v" \
+		"obi" \
+		"mirror-upstream-without-prefix" \
+		"@open-telemetry/ebpf-instrumentation-approvers" \
+		"Update OBI chart to use latest OBI version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"false" \
+		"otelbot/obi-0.8.1" \
+		"0.8.1" \
+		"v0.8.0"
+
+	run_case \
+		"obi-patch-bump-existing-chart-line" \
+		".github/scripts/testdata/update-chart-app-version/obi-chart-0.8.1-app-v0.8.0.yaml" \
+		"v0.8.1" \
+		"opentelemetry-ebpf-instrumentation" \
+		"open-telemetry/opentelemetry-ebpf-instrumentation" \
+		"v" \
+		"v" \
+		"obi" \
+		"mirror-upstream-without-prefix" \
+		"@open-telemetry/ebpf-instrumentation-approvers" \
+		"Update OBI chart to use latest OBI version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"true" \
+		"otelbot/obi-0.8.2" \
+		"0.8.2" \
+		"v0.8.1"
+
+	run_case \
+		"obi-initialize-to-upstream-line" \
+		".github/scripts/testdata/update-chart-app-version/obi-chart-0.7.9-app-v0.7.8.yaml" \
+		"v0.8.1" \
+		"opentelemetry-ebpf-instrumentation" \
+		"open-telemetry/opentelemetry-ebpf-instrumentation" \
+		"v" \
+		"v" \
+		"obi" \
+		"mirror-upstream-without-prefix" \
+		"@open-telemetry/ebpf-instrumentation-approvers" \
+		"Update OBI chart to use latest OBI version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"true" \
+		"otelbot/obi-0.8.1" \
+		"0.8.1" \
+		"v0.8.1"
+
+	run_case \
+		"ta-noop-same-app-version" \
+		".github/scripts/testdata/update-chart-app-version/ta-chart-0.127.2-app-0.126.0.yaml" \
+		"v0.126.0" \
+		"opentelemetry-target-allocator" \
+		"open-telemetry/opentelemetry-operator" \
+		"v" \
+		"" \
+		"ta" \
+		"patch-bump" \
+		"@atoulme" \
+		"Update target allocator chart to use latest target allocator version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"false" \
+		"otelbot/ta-0.127.2" \
+		"0.127.2" \
+		"0.126.0"
+
+	run_case \
+		"ta-patch-bump-same-minor-line" \
+		".github/scripts/testdata/update-chart-app-version/ta-chart-0.127.2-app-0.126.0.yaml" \
+		"v0.126.1" \
+		"opentelemetry-target-allocator" \
+		"open-telemetry/opentelemetry-operator" \
+		"v" \
+		"" \
+		"ta" \
+		"patch-bump" \
+		"@atoulme" \
+		"Update target allocator chart to use latest target allocator version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"true" \
+		"otelbot/ta-0.127.3" \
+		"0.127.3" \
+		"0.126.1"
+
+	run_case \
+		"ta-jump-to-higher-minor-line" \
+		".github/scripts/testdata/update-chart-app-version/ta-chart-0.127.2-app-0.126.0.yaml" \
+		"v0.150.0" \
+		"opentelemetry-target-allocator" \
+		"open-telemetry/opentelemetry-operator" \
+		"v" \
+		"" \
+		"ta" \
+		"patch-bump" \
+		"@atoulme" \
+		"Update target allocator chart to use latest target allocator version: {{ release_tag }}" \
+		$'{{ release_url }}\n\ncc {{ approvers }}' \
+		"true" \
+		"otelbot/ta-0.150.0" \
+		"0.150.0" \
+		"0.150.0"
+
+	rm -rf "${TEST_TMP_ROOT}"
+	printf 'PASS\n'
+}
+
+main "$@"

--- a/.github/scripts/testdata/update-chart-app-version/obi-chart-0.7.9-app-v0.7.8.yaml
+++ b/.github/scripts/testdata/update-chart-app-version/obi-chart-0.7.9-app-v0.7.8.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: opentelemetry-ebpf-instrumentation
+version: 0.7.9
+description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
+type: application
+home: https://opentelemetry.io/
+sources:
+  - https://github.com/coralogix/opentelemetry-helm-charts
+  - https://github.com/open-telemetry/opentelemetry-helm-charts
+icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
+maintainers:
+  - name: dmitryax
+  - name: jaronoff97
+  - name: TylerHelmuth
+  - name: nimrodavni78
+appVersion: v0.7.8

--- a/.github/scripts/testdata/update-chart-app-version/obi-chart-0.8.1-app-v0.8.0.yaml
+++ b/.github/scripts/testdata/update-chart-app-version/obi-chart-0.8.1-app-v0.8.0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: opentelemetry-ebpf-instrumentation
+version: 0.8.1
+description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
+type: application
+home: https://opentelemetry.io/
+sources:
+  - https://github.com/coralogix/opentelemetry-helm-charts
+  - https://github.com/open-telemetry/opentelemetry-helm-charts
+icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
+maintainers:
+  - name: dmitryax
+  - name: jaronoff97
+  - name: TylerHelmuth
+  - name: nimrodavni78
+appVersion: v0.8.0

--- a/.github/scripts/testdata/update-chart-app-version/ta-chart-0.127.2-app-0.126.0.yaml
+++ b/.github/scripts/testdata/update-chart-app-version/ta-chart-0.127.2-app-0.126.0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: opentelemetry-target-allocator
+version: 0.127.2
+description: OpenTelemetry Target Allocator Helm chart for Kubernetes
+type: application
+home: https://opentelemetry.io/
+sources:
+  - https://github.com/open-telemetry/opentelemetry-operator
+maintainers:
+  - name: atoulme
+icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
+appVersion: 0.126.0

--- a/.github/scripts/update-chart-app-version.sh
+++ b/.github/scripts/update-chart-app-version.sh
@@ -215,6 +215,7 @@ run_post_update_action() {
 }
 
 set_default_outputs() {
+  local next_chart_version="$1"
   local pr_title=""
   local pr_body=""
   local branch_name=""
@@ -222,8 +223,10 @@ set_default_outputs() {
   pr_title="$(render_template "${PR_TITLE_TEMPLATE}")"
   pr_body="$(render_template "${PR_BODY_TEMPLATE}")"
   # Auto-update branches must live under otelbot/ to bypass the repo EasyCLA
-  # branch rule while still allowing the follow-up PR workflows to run.
-  branch_name="otelbot/${BRANCH_PREFIX}-${RESOLVED_RELEASE_TAG}"
+  # branch rule while still allowing the follow-up PR workflows to run. Use
+  # the next chart version so branch identity tracks the chart revision rather
+  # than only the upstream app/image tag.
+  branch_name="otelbot/${BRANCH_PREFIX}-${next_chart_version}"
 
   set_output "changed" "false"
   set_output "release_tag" "${RESOLVED_RELEASE_TAG}"
@@ -278,7 +281,7 @@ main() {
   next_app_version="$(desired_app_version)"
   next_chart_version="$(desired_chart_version "${current_app_version}" "${current_chart_version}" "${next_app_version}")"
 
-  set_default_outputs
+  set_default_outputs "${next_chart_version}"
 
   if [[ "${current_chart_version}" == "${next_chart_version}" && "${current_app_version}" == "${next_app_version}" ]]; then
     log "Chart already points at ${RESOLVED_RELEASE_TAG}; nothing to do."

--- a/.github/scripts/update-chart-app-version.sh
+++ b/.github/scripts/update-chart-app-version.sh
@@ -182,6 +182,32 @@ semver_gte() {
   [[ ${left_patch} -ge ${right_patch} ]]
 }
 
+semver_major_minor_gt() {
+  local left="$1"
+  local right="$2"
+  local left_major=""
+  local left_minor=""
+  local left_patch=""
+  local right_major=""
+  local right_minor=""
+  local right_patch=""
+
+  IFS='.' read -r left_major left_minor left_patch <<< "${left}"
+  IFS='.' read -r right_major right_minor right_patch <<< "${right}"
+
+  [[ -n "${left_major}" && -n "${left_minor}" && -n "${left_patch}" ]] \
+    || fail "Invalid semver value for comparison: ${left}"
+  [[ -n "${right_major}" && -n "${right_minor}" && -n "${right_patch}" ]] \
+    || fail "Invalid semver value for comparison: ${right}"
+
+  if (( left_major != right_major )); then
+    [[ ${left_major} -gt ${right_major} ]]
+    return $?
+  fi
+
+  [[ ${left_minor} -gt ${right_minor} ]]
+}
+
 desired_app_version() {
   if [[ -n "${APP_VERSION_PREFIX}" ]]; then
     printf '%s%s\n' "${APP_VERSION_PREFIX}" "${NORMALIZED_RELEASE_VERSION}"
@@ -213,6 +239,11 @@ desired_chart_version() {
     patch-bump)
       if [[ "${current_app_version}" == "${next_app_version}" ]]; then
         printf '%s\n' "${current_chart_version}"
+        return 0
+      fi
+
+      if semver_major_minor_gt "${NORMALIZED_RELEASE_VERSION}" "${current_chart_version}"; then
+        printf '%s\n' "${NORMALIZED_RELEASE_VERSION}"
         return 0
       fi
 

--- a/.github/scripts/update-chart-app-version.sh
+++ b/.github/scripts/update-chart-app-version.sh
@@ -151,6 +151,37 @@ increment_patch_version() {
   printf '%s.%s.%s\n' "${major}" "${minor}" "$((patch + 1))"
 }
 
+semver_gte() {
+  local left="$1"
+  local right="$2"
+  local left_major=""
+  local left_minor=""
+  local left_patch=""
+  local right_major=""
+  local right_minor=""
+  local right_patch=""
+
+  IFS='.' read -r left_major left_minor left_patch <<< "${left}"
+  IFS='.' read -r right_major right_minor right_patch <<< "${right}"
+
+  [[ -n "${left_major}" && -n "${left_minor}" && -n "${left_patch}" ]] \
+    || fail "Invalid semver value for comparison: ${left}"
+  [[ -n "${right_major}" && -n "${right_minor}" && -n "${right_patch}" ]] \
+    || fail "Invalid semver value for comparison: ${right}"
+
+  if (( left_major != right_major )); then
+    [[ ${left_major} -gt ${right_major} ]]
+    return $?
+  fi
+
+  if (( left_minor != right_minor )); then
+    [[ ${left_minor} -gt ${right_minor} ]]
+    return $?
+  fi
+
+  [[ ${left_patch} -ge ${right_patch} ]]
+}
+
 desired_app_version() {
   if [[ -n "${APP_VERSION_PREFIX}" ]]; then
     printf '%s%s\n' "${APP_VERSION_PREFIX}" "${NORMALIZED_RELEASE_VERSION}"
@@ -169,6 +200,11 @@ desired_chart_version() {
     mirror-upstream-without-prefix)
       if [[ "${current_app_version}" == "${next_app_version}" ]]; then
         printf '%s\n' "${current_chart_version}"
+        return 0
+      fi
+
+      if semver_gte "${current_chart_version}" "${NORMALIZED_RELEASE_VERSION}"; then
+        increment_patch_version "${current_chart_version}"
         return 0
       fi
 

--- a/.github/scripts/update-chart-app-version.sh
+++ b/.github/scripts/update-chart-app-version.sh
@@ -167,6 +167,11 @@ desired_chart_version() {
 
   case "${VERSION_POLICY}" in
     mirror-upstream-without-prefix)
+      if [[ "${current_app_version}" == "${next_app_version}" ]]; then
+        printf '%s\n' "${current_chart_version}"
+        return 0
+      fi
+
       printf '%s\n' "${NORMALIZED_RELEASE_VERSION}"
       ;;
     patch-bump)

--- a/.github/scripts/update-chart-app-version.sh
+++ b/.github/scripts/update-chart-app-version.sh
@@ -217,13 +217,17 @@ run_post_update_action() {
 set_default_outputs() {
   local pr_title=""
   local pr_body=""
+  local branch_name=""
 
   pr_title="$(render_template "${PR_TITLE_TEMPLATE}")"
   pr_body="$(render_template "${PR_BODY_TEMPLATE}")"
+  # Auto-update branches must live under otelbot/ to bypass the repo EasyCLA
+  # branch rule while still allowing the follow-up PR workflows to run.
+  branch_name="otelbot/${BRANCH_PREFIX}-${RESOLVED_RELEASE_TAG}"
 
   set_output "changed" "false"
   set_output "release_tag" "${RESOLVED_RELEASE_TAG}"
-  set_output "branch_name" "${BRANCH_PREFIX}-${RESOLVED_RELEASE_TAG}"
+  set_output "branch_name" "${branch_name}"
   set_output "commit_message" "${pr_title}"
   set_output "stage_path" "${STAGE_PATH}"
   set_output "pr_title" "${pr_title}"


### PR DESCRIPTION
Fixes #2149 

## Summary
Fix the shared chart auto-update workflow so automatic target allocator and OBI updates behave correctly under the current repository rules and versioning expectations.

## What changed
- route auto-update branches under `otelbot/` so the EasyCLA branch ruleset exclusion applies
- key auto-update branch names off the computed chart version instead of only the upstream release tag
- prevent `mirror-upstream-without-prefix` charts from downgrading chart versions when `appVersion` is unchanged
- make chart versioning monotonic for app updates:
  - if `appVersion` is unchanged, keep the current chart version
  - if the upstream app release moves to a higher major/minor than the current chart version, move the chart version to that upstream semver
  - otherwise patch-bump the chart version
- add a checked-in test harness and fixtures for the shared updater script

## Validation
- reproduced the failing May 6, 2026 target allocator and OBI workflow behavior from the referenced Actions runs
- ran `bash .github/scripts/test-update-chart-app-version.sh`
