### PR TITLE
[opentelemetry-operator] Add minReadySeconds support for operator deployment

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.112.1
+version: 0.112.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -387,7 +387,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.112.1
+        helm.sh/chart: opentelemetry-operator-0.112.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.150.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -387,7 +387,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.112.1
+        helm.sh/chart: opentelemetry-operator-0.112.2
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.150.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.112.1
+    helm.sh/chart: opentelemetry-operator-0.112.2
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.150.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "opentelemetry-operator.selectorLabels" . | nindent 6 }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -48,6 +48,16 @@
         1
       ]
     },
+    "minReadySeconds": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "title": "The minReadySeconds Schema",
+      "examples": [
+        0,
+        30
+      ]
+    },
     "nameOverride": {
       "type": "string",
       "default": "",

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -11,6 +11,11 @@ replicaCount: 1
 ##
 revisionHistoryLimit: 10
 
+## Minimum number of seconds for which a newly created pod should be ready
+## without any of its container crashing, for it to be considered available.
+##
+minReadySeconds: 0
+
 ## Provide a name in place of opentelemetry-operator (includes the chart's release name).
 ##
 nameOverride: ""


### PR DESCRIPTION
Allow configuring minReadySeconds on the operator Deployment via values.yaml. Bump chart version to 0.112.2 and regenerate examples.

Tracking issue - https://github.com/open-telemetry/opentelemetry-helm-charts/issues/2103