### PR TITLE
feat(target-allocator): add namespaceOverride value

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.127.3
+version: 0.127.4
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e197860f0b6d18fd37a09dba1163efa739c4d1b2d9c9af15bda5acdc94bb10f5
+        checksum/config: 0406374d04447a8b4ab54489df3c2e3ecc2eae78bd49d187c7778bc6bb63255f
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e89de01121f615c74138107ee2c412434a7d75de2b865c76d15b3ea7ca0789b9
+        checksum/config: 9b2f57098dcb103ff3bd5482c06ce9594bb5cb1c2cb584ed12f6cfe92f5698b9
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e89de01121f615c74138107ee2c412434a7d75de2b865c76d15b3ea7ca0789b9
+        checksum/config: 9b2f57098dcb103ff3bd5482c06ce9594bb5cb1c2cb584ed12f6cfe92f5698b9
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f180270b3df463bc130587a5eee2d90112bec14c0b6b7f09a3928cbe449a13de
+        checksum/config: 95a878fcf005a5acdb6fc290dcb2b563c3d3eecd5709cf37ed28059d3dd0eba2
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.127.3
+    helm.sh/chart: opentelemetry-target-allocator-0.127.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.150.0"
@@ -28,9 +28,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e89de01121f615c74138107ee2c412434a7d75de2b865c76d15b3ea7ca0789b9
+        checksum/config: 9b2f57098dcb103ff3bd5482c06ce9594bb5cb1c2cb584ed12f6cfe92f5698b9
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.127.3
+        helm.sh/chart: opentelemetry-target-allocator-0.127.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.150.0"

--- a/charts/opentelemetry-target-allocator/templates/_helpers.tpl
+++ b/charts/opentelemetry-target-allocator/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Helper used to define a namspace.
 - If namespaceOverride value is filled in it will replace the namespace
 */}}
 {{- define "helper.namespace" -}}
-  {{- default .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+  {{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/opentelemetry-target-allocator/values.schema.json
+++ b/charts/opentelemetry-target-allocator/values.schema.json
@@ -15,6 +15,10 @@
     "nameOverride": {
       "type": "string"
     },
+    "namespaceOverride": {
+      "description": "Name of the namespace to deploy the resources into.",
+      "type": "string"
+    },
     "mode": {
       "description": "Valid values are 'deployment' and 'statefulset'.",
       "type": "string",

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -15,6 +15,10 @@ mode: "deployment"
 nameOverride: ""
 # fullnameOverride completely replaces the generated name.
 fullnameOverride: ""
+# Specify which namespace should be used to deploy the resources into.
+# Useful when running this chart as a subchart whose resources need to live
+# in a namespace different from the parent's release namespace.
+namespaceOverride: ""
 
 # Number of replicas for the target allocator
 replicaCount: 1

--- a/charts/opentelemetry-target-allocator/values.yaml
+++ b/charts/opentelemetry-target-allocator/values.yaml
@@ -16,8 +16,6 @@ nameOverride: ""
 # fullnameOverride completely replaces the generated name.
 fullnameOverride: ""
 # Specify which namespace should be used to deploy the resources into.
-# Useful when running this chart as a subchart whose resources need to live
-# in a namespace different from the parent's release namespace.
 namespaceOverride: ""
 
 # Number of replicas for the target allocator


### PR DESCRIPTION
## Summary

- Adds a top-level `namespaceOverride` value to the `opentelemetry-target-allocator` chart, mirroring the existing parameter in the `opentelemetry-collector` chart.
- When set, `helper.namespace` uses it in place of `.Release.Namespace`, so every namespaced resource the chart renders (`ServiceAccount`, `ConfigMap`, `Service`, `Deployment` / `StatefulSet`, and the `ClusterRoleBinding` subject namespace) lands in the configured namespace.
- Default value is `""`, which preserves current behavior (`.Release.Namespace` is used). No existing example renders change beyond the chart version label.

## Motivation

The Target Allocator chart is increasingly consumed as a Helm subchart (alongside `opentelemetry-collector` or as part of larger umbrella charts). In that scenario the parent chart often deploys into a release namespace that differs from where the TA's resources should actually live (for example, the parent installs into the user's app namespace, but the operator-style components — including the TA — belong in a dedicated `observability` / `monitoring` namespace).

Today the only way to relocate the TA's resources is to install it as its own release. That breaks the "single Helm install" UX. Adding `namespaceOverride` makes the umbrella-chart use case work out of the box:

```yaml
# Parent values.yaml
opentelemetry-target-allocator:
  namespaceOverride: observability
```

This is the same pattern `opentelemetry-collector` already exposes (`namespaceOverride: ""` at the top level of its values.yaml), so behavior is consistent across the two charts when they are composed together.

## Changes

- `values.yaml`: new `namespaceOverride: ""` field with comment.
- `values.schema.json`: new `namespaceOverride` string property.
- `templates/_helpers.tpl`: `helper.namespace` now resolves to `.Values.namespaceOverride` when non-empty, else `.Release.Namespace`.
- `Chart.yaml`: minor version bump `0.127.3` → `0.128.0`.
- `examples/*/rendered/*`: regenerated via `make generate-examples CHARTS=opentelemetry-target-allocator` — the only diff is the chart-version label.

## Test plan

- [x] `make generate-examples CHARTS=opentelemetry-target-allocator` regenerates cleanly.
- [x] `make check-examples CHARTS=opentelemetry-target-allocator` passes for all 7 examples (provide-custom-volumes, statefulset-with-pvc, consistent-hashing, existing-configmap, existing-service-account, collector-fleet, prometheus-scrape-config).
- [x] `helm template t charts/opentelemetry-target-allocator --namespace default --set namespaceOverride=observability` — every resource's `metadata.namespace` and the `ClusterRoleBinding` subject namespace render as `observability`. `collector_namespace` in the TA ConfigMap is intentionally left bound to `.Release.Namespace` (it controls where the TA *looks for collectors*, not where its own resources are deployed — overriding it would be a behavior change unrelated to this PR).
- [x] `helm template t charts/opentelemetry-target-allocator --namespace mynamespace` (no override) — unchanged: every resource renders into `mynamespace`.
- [x] Verified as a subchart: created a parent chart with `opentelemetry-target-allocator` as a dependency and set `<alias>.namespaceOverride: observability` in the parent's `values.yaml`; all TA resources rendered into `observability` while the parent's release namespace remained `default`.