### PR TITLE
[kube-stack] Bump operator chart to 0.113.1

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.lock
+++ b/charts/opentelemetry-kube-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.0.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.105.1
+  version: 0.113.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 6.3.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.48.0
-digest: sha256:2ec77416b3a4f1ed3c0cd19512e929b8911fc64e31f5fb909fc50ac61e9c8256
-generated: "2026-02-12T15:44:34.531542519+11:00"
+digest: sha256:0bc649ea2dff6ba5885f295a74847cb477ed71374f15daa40f68d87b01ec82b6
+generated: "2026-05-18T12:13:31.924545+02:00"

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.14.13
+version: 0.15.0
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.
@@ -16,7 +16,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 # the appVersion stays aligned with the operator's latest version. If the collector has a patch
 # release, the collector's latest patch will be manually overridden.
-appVersion: 0.144.0
+appVersion: 0.151.0
 dependencies:
   - name: otel-crds
     version: "0.0.0"
@@ -26,7 +26,7 @@ dependencies:
     condition: crds.install,crds.installPrometheus
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.105.1
+    version: 0.113.1
     condition: opentelemetry-operator.enabled
   - name: kube-state-metrics
     version: "6.3.*"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,8 +5,8 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:
@@ -24,7 +24,7 @@ spec:
     ReportsRemoteConfig: true
     ReportsStatus: true
   replicas: 1
-  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.144.0"
+  image: "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.151.0"
   upgradeStrategy: automatic
   securityContext:
     runAsNonRoot: true

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
     opentelemetry.io/opamp-reporting: "true"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,8 +5,8 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
 spec:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -232,8 +232,8 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -365,8 +365,8 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:
@@ -173,8 +173,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
     otel-collector-type: daemonset-example    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
   namespace: kube-system

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
-    app.kubernetes.io/version: "0.144.0"
+    helm.sh/chart: opentelemetry-kube-stack-0.15.0
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
 spec:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.15.0"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -91,9 +91,9 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/certmanager.yaml
@@ -4,9 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,9 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrole.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -193,11 +193,32 @@ rules:
       - list
       - update
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - monitoring.coreos.com
@@ -355,6 +376,12 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
       - authorization.k8s.io
     resources:
       - subjectaccessreviews
@@ -366,9 +393,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -379,24 +406,3 @@ rules:
       - /metrics
     verbs:
       - get
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -16,28 +16,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: example-opentelemetry-operator-manager
-subjects:
-  - kind: ServiceAccount
-    name: opentelemetry-operator
-    namespace: default
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: opentelemetry-operator
-    app.kubernetes.io/instance: example
-    app.kubernetes.io/component: controller-manager
-  name: example-opentelemetry-operator-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: example-opentelemetry-operator-proxy
 subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/deployment.yaml
@@ -4,9 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -25,9 +25,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.105.1
+        helm.sh/chart: opentelemetry-operator-0.113.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.144.0"
+        app.kubernetes.io/version: "0.151.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -37,11 +37,12 @@ spec:
       hostNetwork: false
       containers:
         - args:
-            - --metrics-addr=0.0.0.0:8080
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-k8s:0.144.0
+            - --collector-image=otel/opentelemetry-collector-k8s:0.151.0
           command:
             - /manager
           env:
@@ -51,11 +52,11 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
               name: metrics
               protocol: TCP
             - containerPort: 9443
@@ -79,25 +80,6 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
-          securityContext: 
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --v=0
-          image: "quay.io/brancz/kube-rbac-proxy:v0.20.0"
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
           securityContext: 
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/rolebinding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/service.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -15,12 +15,8 @@ metadata:
   namespace: default
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
     - name: metrics
-      port: 8080
+      port: 8443
       protocol: TCP
       targetPort: metrics
   selector:
@@ -32,9 +28,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -7,9 +7,9 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -6,9 +6,9 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -59,9 +59,9 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.105.1
+    helm.sh/chart: opentelemetry-operator-0.113.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.144.0"
+    app.kubernetes.io/version: "0.151.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example


### PR DESCRIPTION
[kube-stack] Bump operator chart to 0.113.1
  - Operator binary: 0.151.0 (appVersion)
  - Default managed collector image: 0.151.0 (manager.collectorImage.tag)