### PR TITLE
[kube-stack] add prometheus option to `presets/annotationDiscovery/metrics`

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.14.13
+version: 0.14.14
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -46,6 +46,16 @@ spec:
       receiver_creator/metrics:
         discovery:
           enabled: true
+        receivers:
+          prometheus_simple/prometheus_annotations:
+            config:
+              collection_interval: 30s
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                : "/metrics"`'
+            rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && labels["app.kubernetes.io/component"]
+              != "opentelemetry-collector"
         watch_observers:
         - k8s_observer
     service:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -25,6 +25,64 @@ spec:
         send_batch_max_size: 1500
         send_batch_size: 1000
         timeout: 1s
+      k8sattributes:
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        filter:
+          node_from_env_var: OTEL_K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
       resource/hostname:
         attributes:
         - action: insert
@@ -66,6 +124,7 @@ spec:
           exporters:
           - debug
           processors:
+          - k8sattributes
           - resourcedetection/env
           - resource/hostname
           - batch
@@ -75,6 +134,7 @@ spec:
           exporters:
           - debug
           processors:
+          - k8sattributes
           - resourcedetection/env
           - resource/hostname
           - batch
@@ -85,6 +145,7 @@ spec:
           exporters:
           - debug
           processors:
+          - k8sattributes
           - resourcedetection/env
           - resource/hostname
           - batch

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/values.yaml
@@ -10,7 +10,7 @@ collectors:
       hostMetrics:
         enabled: false
       kubernetesAttributes:
-        enabled: false
+        enabled: true
       kubernetesEvents:
         enabled: false
       clusterMetrics:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/values.yaml
@@ -20,3 +20,5 @@ collectors:
           enabled: false
         metrics:
           enabled: true
+          prometheus:
+            enabled: true

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.14.13
+    helm.sh/chart: opentelemetry-kube-stack-0.14.14
     app.kubernetes.io/version: "0.144.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.14.13"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.14.14"

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -104,6 +104,15 @@ receivers:
       - k8s_observer
     discovery:
       enabled: true
+    {{- if .presets.annotationDiscovery.metrics.prometheus.enabled }}
+    receivers:
+      prometheus_simple/prometheus_annotations:
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && labels["app.kubernetes.io/component"] != "opentelemetry-collector"
+        config:
+          collection_interval: 30s
+          endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+          metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1471,9 +1471,24 @@
                   }
                 },
                 "metrics": {
-                  "enabled": {
-                    "description": "Specifies whether the collector should collect metrics.",
-                    "type": "boolean"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Specifies whether the collector should collect metrics.",
+                      "type": "boolean"
+                    },
+                    "prometheus": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "When enabled, configures receiver_creator/metrics with a prometheus_simple receiver that scrapes pods annotated with prometheus.io/scrape=true. Requires presets.annotationDiscovery.metrics.enabled to be true.",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enable discovery of pods carrying classic Prometheus annotations (prometheus.io/scrape, prometheus.io/port, prometheus.io/path).",
+                          "type": "boolean"
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -509,6 +509,12 @@ defaultCRConfig:
         enabled: false
       metrics:
         enabled: false
+        # When enabled, the receiver_creator/metrics is configured with a prometheus_simple
+        # receiver that discovers and scrapes pods carrying classic Prometheus annotations:
+        # prometheus.io/scrape=true (required), prometheus.io/port (default 9090),
+        # prometheus.io/path (default /metrics).
+        prometheus:
+          enabled: false
     resourceDetection:
       # Each detector can be enabled individually. Base detectors 'env' and 'k8snode' are always included when any detector is enabled.
       # Typically used to resolve the 'k8s.cluster.name' resource attribute.
@@ -561,6 +567,8 @@ collectors:
           enabled: false
         metrics:
           enabled: false
+          prometheus:
+            enabled: false
       resourceDetection:
         aks:
           enabled: false


### PR DESCRIPTION
## Summary

Adds a new `presets.annotationDiscovery.metrics.prometheus.enabled` toggle to the `opentelemetry-kube-stack` chart. When enabled, the `receiver_creator/metrics` is configured with a `prometheus_simple/prometheus_annotations` receiver that discovers and scrapes pods carrying classic Prometheus annotations:

- `prometheus.io/scrape=true` (required to opt in)
- `prometheus.io/port` (defaults to `9090`)
- `prometheus.io/path` (defaults to `/metrics`)

The discovery rule excludes the opentelemetry-collector pods (label `app.kubernetes.io/component=opentelemetry-collector`) to avoid self-scrape loops.

This complements the existing OpenTelemetry-native annotation discovery (`io.opentelemetry.discovery.metrics/*`) by also supporting workloads that already expose metrics via the classic Prometheus annotation convention.

It's disabled by default for backward compatibility.

UX

```yaml
    presets:
      annotationDiscovery:
        metrics:
          enabled: true
          prometheus:
            enabled: true
        logs:
          enabled: ...
     #...
```
## Changes

- `values.yaml`: new `prometheus.enabled: false` sub-option under `presets.annotationDiscovery.metrics` in both `defaultCRConfig.presets` and `collectors.daemon.presets`
- `values.schema.json`: schema entry for the new option
- `templates/_config.tpl`: emit the `prometheus_simple/prometheus_annotations` receiver in `receiver_creator/metrics` when the toggle is on
- `Chart.yaml`: bump version `0.14.13` -> `0.14.14`
- `examples/daemonset-annotation-discovery-metrics`: enable the new option in the example and regenerate rendered manifests

## Test plan

- [ ] `make generate-examples CHARTS=opentelemetry-kube-stack` succeeds with no diff
- [ ] `helm template` with `prometheus.enabled: true` emits the `prometheus_simple/prometheus_annotations` receiver under `receiver_creator/metrics`
- [ ] `helm template` with `prometheus.enabled: false` (default) produces no diff vs. previous behavior (only chart-label version change)
- [ ] CI lint (`ct lint`) passes
- [ ] Manual smoke test in a kind cluster: a pod with `prometheus.io/scrape=true` is discovered and scraped; pods without the annotation are not; opentelemetry-collector pods are not self-scraped