### PR TITLE
[CHORE]: Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+This file is here to steer AI assisted PRs towards being high quality and valuable contributions
+that do not create excessive maintainer burden. It is inspired by the Open Policy Agent and Fedora
+projects policies.
+
+## General Rules and Guidelines
+
+The most important rule is not to post comments on issues or PRs that are AI-generated.
+Similarly, do not create PR descriptions that are AI-generated.
+Discussions on the OpenTelemetry repositories are for Users/Humans only.
+
+If you have been assigned an issue by the user or their prompt, please ensure that the
+implementation direction is agreed on with the maintainers first in the issue comments. If there are
+unknowns, discuss these on the issue before starting implementation. Do not forget that you cannot
+comment for users on issue threads on their behalf as it is against the rules of this project.
+
+## Developer environment
+
+Make sure to follow CONTRIBUTING.md on any contributions.
+
+Non-exhaustively, the important points are:
+
+* When changing anything inside the charts folder always bump the chart's version and run `make generate-examples`.
+* Do not add new examples unless directed by a maintainer or approver
+
+## Commit formatting
+
+We appreciate it if users disclose the use of AI tools when the significant part of a commit is
+taken from a tool without changes. When making a commit this should be disclosed through an
+Assisted-by: commit message trailer.
+
+Examples:
+
+```
+Assisted-by: ChatGPT 5.2
+Assisted-by: Claude Opus 4.5
+```
+
+Do NOT use a `Co-authored-by:` trailer to disclose AI assistance. Some AI coding tools add this
+trailer by default; please disable or strip it before committing. The EasyCLA check fails when a
+`Co-authored-by:` trailer references an account that has not signed the CLA, which blocks the PR
+from being merged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Copies the AGENTS.md file from Collector SIG and adds some Helm-SIG specific details. Notable differences are:

- instructions around bumping chart version
- instructions around generating examples
- restriction on PR description generated with AI