### PR TITLE
ci: add Helm v4 to CI test matrix

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ inputs:
   helm-version:
     description: "The helm version to be used when setting up"
     required: false
-    default: "v3.9.4"
+    default: "v3.14.4"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/collector-test.yaml
+++ b/.github/workflows/collector-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   collector-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-collector

--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   demo-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,7 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.14.4"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Run chart-testing (install)
         run: "ct install --charts charts/opentelemetry-demo

--- a/.github/workflows/ebpf-test.yaml
+++ b/.github/workflows/ebpf-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   ebpf-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-ebpf

--- a/.github/workflows/kube-stack-test.yaml
+++ b/.github/workflows/kube-stack-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   opentelemetry-kube-stack-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,7 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
-          helm-version: "v3.11.3"
+          helm-version: ${{ matrix.helm-version }}
 
       # We'll need this eventually, but for now leave it commented.
       - name: Install cert-manager

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -20,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "false"
-          helm-version: "v3.14.4"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Run chart-testing (lint)
         run: "ct lint --target-branch main

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   operator-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Check CRDs
         run: make check-operator-crds
@@ -79,6 +85,11 @@ jobs:
 
   operator-test-no-certmanager:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -88,6 +99,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Check CRDs
         run: make check-operator-crds

--- a/.github/workflows/ta-test.yaml
+++ b/.github/workflows/ta-test.yaml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   ta-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-version:
+          - "v3.14.4"
+          - "v4.0.3"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +27,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           create-kind-cluster: "true"
+          helm-version: ${{ matrix.helm-version }}
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/opentelemetry-target-allocator


### PR DESCRIPTION
## Summary

Add a `helm-version` strategy matrix to all CI test and lint workflows so each chart is validated against both Helm v3 (v3.14.4) and Helm v4 (v4.0.3).

## Changes

- **collector-test.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **lint.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **demo-test.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **kube-stack-test.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **operator-test.yaml** – added helm-version matrix to both jobs (v3.14.4, v4.0.3)
- **ebpf-test.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **ta-test.yaml** – added helm-version matrix (v3.14.4, v4.0.3)
- **.github/actions/setup/action.yaml** – bumped default helm-version from v3.9.4 to v3.14.4

## Motivation

Closes #2212. Helm v4 is now available and users are reporting incompatibilities. This ensures we catch regressions against both major versions in CI.

## Testing

CI will exercise the new matrix on this PR itself (lint workflow triggers on all PRs to main).