### PR TITLE
fix(target-allocator): use Downward API for OTELCOL_NAMESPACE so namespaceOverride works

### DIFF
--- a/charts/opentelemetry-target-allocator/Chart.yaml
+++ b/charts/opentelemetry-target-allocator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-target-allocator
-version: 0.128.0
+version: 0.128.1
 description: OpenTelemetry Target Allocator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca42eb9ade6782b3d97ee14bb416001699f2fc9df0fe7011f079ee92f49a20ac
+        checksum/config: e37d0d540bfe4adb49aa51d7b7d4c5c028e1480520238a474d7a0afb3c18e874
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/collector-fleet/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ff48203ed298ab5d9f8e4fc7724236d2b89b2445b3b05759f15588cd745af51
+        checksum/config: ca96982a57560c47f4f5666899beba95eabf7a0dfa218d4e7d7ea53586813531
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"
@@ -46,7 +46,9 @@ spec:
               readOnly: true
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
-              value: default
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/consistent-hashing/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"
@@ -46,7 +46,9 @@ spec:
               readOnly: true
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
-              value: default
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-configmap/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/existing-service-account/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ff48203ed298ab5d9f8e4fc7724236d2b89b2445b3b05759f15588cd745af51
+        checksum/config: ca96982a57560c47f4f5666899beba95eabf7a0dfa218d4e7d7ea53586813531
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"
@@ -46,7 +46,9 @@ spec:
               readOnly: true
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
-              value: default
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31949ef62b311b5af3212350e049e21d65267974273816c6f206b1de0aabc8bd
+        checksum/config: 94a49df4fade2b8fc39aa04cc320babe3889835b775cf961e9faf26847d40b5e
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/prometheus-scrape-config/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"
@@ -46,7 +46,9 @@ spec:
               name: custom-ta-configmap
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
-              value: default
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/provide-custom-volumes/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta-clusterRole
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-opentelemetry-target-allocator-ta-clusterRoleBinding
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta-configmap
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-opentelemetry-target-allocator-ta
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-target-allocator/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   name: example-opentelemetry-target-allocator-ta
   labels:
-    helm.sh/chart: opentelemetry-target-allocator-0.151.0
+    helm.sh/chart: opentelemetry-target-allocator-0.128.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-target-allocator
     app.kubernetes.io/version: "0.151.0"
@@ -28,9 +28,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ff48203ed298ab5d9f8e4fc7724236d2b89b2445b3b05759f15588cd745af51
+        checksum/config: ca96982a57560c47f4f5666899beba95eabf7a0dfa218d4e7d7ea53586813531
       labels:
-        helm.sh/chart: opentelemetry-target-allocator-0.151.0
+        helm.sh/chart: opentelemetry-target-allocator-0.128.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-target-allocator
         app.kubernetes.io/version: "0.151.0"
@@ -53,7 +53,9 @@ spec:
               readOnly: true
           env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
             - name: OTELCOL_NAMESPACE
-              value: default
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /livez

--- a/charts/opentelemetry-target-allocator/templates/_pod.tpl
+++ b/charts/opentelemetry-target-allocator/templates/_pod.tpl
@@ -36,7 +36,13 @@ containers:
       {{- end }}
     env: # Workaround for https://github.com/open-telemetry/opentelemetry-operator/pull/3976
       - name: OTELCOL_NAMESPACE
-        value: {{ .Values.targetAllocator.config.collector_namespace | default .Release.Namespace }}
+        {{- with .Values.targetAllocator.config.collector_namespace }}
+        value: {{ . }}
+        {{- else }}
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+        {{- end }}
       {{- with .Values.targetAllocator.extraEnvs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
## Problem

The target-allocator subchart sets the pod's `OTELCOL_NAMESPACE` env from `.Release.Namespace` (or the optional `targetAllocator.config.collector_namespace` value):

```yaml
# charts/opentelemetry-target-allocator/templates/_pod.tpl
env:
  - name: OTELCOL_NAMESPACE
    value: {{ .Values.targetAllocator.config.collector_namespace | default .Release.Namespace }}
```

When the chart is consumed as a subchart and installed into a different namespace via `namespaceOverride` (added in #2194), every other resource (Deployment, Service, ConfigMap, ServiceAccount, ClusterRoleBinding subject) honours the override via `helper.namespace`, but the pod itself is still told to watch `.Release.Namespace`.

## What this causes

`OTELCOL_NAMESPACE` is read into `Config.CollectorNamespace` (`cmd/otel-allocator/internal/config/config.go`) and used to scope the TA's collector pod informer. When that env points at a namespace where no collectors are running, the watcher returns zero pods regardless of `collector_selector`. As a result, on installs that use `namespaceOverride`:

- `opentelemetry_allocator_collectors_discovered` and `opentelemetry_allocator_collectors_allocatable` stay at 0
- `/jobs/<job>/targets?collector_id=<pod>` returns `[]` for every collector
- targets get discovered but never assigned

Setting `targetAllocator.config.collector_namespace` to the same value as `namespaceOverride` works around it, but nothing in the chart docs flags the dependency, so it's easy to miss.

## Fix

Source the env from the Downward API instead of templating a literal:

```yaml
env:
  - name: OTELCOL_NAMESPACE
    {{- with .Values.targetAllocator.config.collector_namespace }}
    value: {{ . }}
    {{- else }}
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace
    {{- end }}
```

A pod always knows what namespace it landed in, regardless of install method (`helm install`, subchart, `helm template | kustomize`, plain `kubectl apply -n <ns>`, or ArgoCD with destination override). `targetAllocator.config.collector_namespace` is preserved as an explicit escape hatch that wins over the fieldRef, so deployments that intentionally watch a different namespace from their own are unaffected.

This matches the precedent already set by `open-telemetry/opentelemetry-operator`:
- TA reconciler: `internal/manifests/targetallocator/container.go`
- Standalone manifest: `config/target-allocator/deployment.yaml`

## Why #2194 missed it

#2194 only touched `_helpers.tpl` to make `helper.namespace` honour `namespaceOverride`. The `_pod.tpl` env block was not modified, and the rendered-example fixtures don't exercise `namespaceOverride` and render with `--namespace default`, so the buggy line happens to produce the right value in CI. It only surfaces on installs with a non-default `.Release.Namespace` or `namespaceOverride`.

## Changes

- `charts/opentelemetry-target-allocator/templates/_pod.tpl`: switch `OTELCOL_NAMESPACE` to `valueFrom.fieldRef: metadata.namespace`, keeping `collector_namespace` as an explicit override.
- `charts/opentelemetry-target-allocator/Chart.yaml`: bump to `0.128.1`.
- Regenerated examples via `make generate-examples CHARTS=opentelemetry-target-allocator`.

## Verification

- `make check-examples CHARTS=opentelemetry-target-allocator` passes.
- `helm lint charts/opentelemetry-target-allocator` clean.
- `helm template t charts/opentelemetry-target-allocator --namespace default --set namespaceOverride=foo` now renders the fieldRef form.
- `helm template t charts/opentelemetry-target-allocator --set targetAllocator.config.collector_namespace=watch-this-ns` still renders the explicit value (escape hatch preserved).