### PR TITLE
Add useCanonicalNames toggle for upstream-renamed preset components

### DIFF
--- a/charts/opentelemetry-collector/ci/preset-canonical-names-values.yaml
+++ b/charts/opentelemetry-collector/ci/preset-canonical-names-values.yaml
@@ -1,0 +1,17 @@
+mode: daemonset
+image:
+  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
+presets:
+  useCanonicalNames: true
+  hostMetrics:
+    enabled: true
+  kubeletMetrics:
+    enabled: true
+  logsCollection:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+  kubernetesEvents:
+    enabled: true
+  kubernetesObjects:
+    enabled: true

--- a/charts/opentelemetry-collector/examples/using-canonical-names/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/rendered/clusterrole.yaml
@@ -1,0 +1,63 @@
+---
+# Source: opentelemetry-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.156.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get","list","watch","create","update","patch","delete"]
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/stats"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["watch", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "nodes", "services", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]

--- a/charts/opentelemetry-collector/examples/using-canonical-names/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/rendered/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+---
+# Source: opentelemetry-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.156.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-opentelemetry-collector
+subjects:
+- kind: ServiceAccount
+  name: example-opentelemetry-collector
+  namespace: default

--- a/charts/opentelemetry-collector/examples/using-canonical-names/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/rendered/configmap-agent.yaml
@@ -1,0 +1,279 @@
+---
+# Source: opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.156.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+data:
+  relay: |
+    exporters:
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_leader_elector/k8s_objects:
+        auth_type: serviceAccount
+        lease_name: k8s.objects.receiver.opentelemetry.io
+        lease_namespace: default
+    processors:
+      batch: {}
+      k8s_attributes:
+        extract:
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      file_log:
+        exclude:
+        - /var/log/pods/default_example-opentelemetry-collector*_*/opentelemetry-collector/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: container-parser
+          max_log_size: 102400
+          type: container
+        retry_on_failure:
+          enabled: true
+        start_at: end
+      host_metrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory: null
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      k8s_objects:
+        k8s_leader_elector: k8s_leader_elector/k8s_objects
+        objects:
+        - mode: pull
+          name: namespaces
+        - mode: pull
+          name: pods
+        - mode: pull
+          name: nodes
+        - mode: pull
+          name: services
+        - mode: pull
+          name: serviceaccounts
+        - group: apps
+          mode: pull
+          name: deployments
+        - group: apps
+          mode: pull
+          name: replicasets
+        - group: apps
+          mode: pull
+          name: daemonsets
+        - group: apps
+          mode: pull
+          name: statefulsets
+        - group: batch
+          mode: pull
+          name: jobs
+        - group: batch
+          mode: pull
+          name: cronjobs
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: roles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterrolebindings
+        - group: storage.k8s.io
+          mode: pull
+          name: storageclasses
+        - mode: pull
+          name: persistentvolumes
+        - mode: pull
+          name: persistentvolumeclaims
+        - group: networking.k8s.io
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          mode: pull
+          name: networkpolicies
+        - group: autoscaling
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: policy
+          mode: pull
+          name: poddisruptionbudgets
+        - group: apiextensions.k8s.io
+          mode: pull
+          name: customresourcedefinitions
+      kubelet_stats:
+        auth_type: serviceAccount
+        collection_interval: 20s
+        endpoint: ${env:K8S_NODE_IP}:10250
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - k8s_leader_elector/k8s_objects
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          processors:
+          - k8s_attributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - file_log
+          - k8s_objects
+        metrics:
+          exporters:
+          - debug
+          processors:
+          - k8s_attributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - prometheus
+          - host_metrics
+          - kubelet_stats
+        traces:
+          exporters:
+          - debug
+          processors:
+          - k8s_attributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+        resource:
+          host.name: ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/using-canonical-names/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/rendered/daemonset.yaml
@@ -1,0 +1,153 @@
+---
+# Source: opentelemetry-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.156.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: da636f169e8588a3f7101a0d0515ea9777aa28051e105dfd295cd3bf644eb818
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      
+      serviceAccountName: example-opentelemetry-collector
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-k8s
+          args:
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.152.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: example-opentelemetry-collector-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: hostfs
+          hostPath:
+            path: /
+      hostNetwork: false
+      hostPID: false

--- a/charts/opentelemetry-collector/examples/using-canonical-names/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/rendered/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.156.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: agent-collector

--- a/charts/opentelemetry-collector/examples/using-canonical-names/values.yaml
+++ b/charts/opentelemetry-collector/examples/using-canonical-names/values.yaml
@@ -1,0 +1,22 @@
+mode: daemonset
+
+image:
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
+
+command:
+  name: "otelcol-k8s"
+
+presets:
+  useCanonicalNames: true
+  hostMetrics:
+    enabled: true
+  kubeletMetrics:
+    enabled: true
+  logsCollection:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+  kubernetesEvents:
+    enabled: true
+  kubernetesObjects:
+    enabled: true

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -162,15 +162,31 @@ Build config file for deployment OpenTelemetry Collector
 {{- tpl (toYaml $config) . }}
 {{- end }}
 
+{{- define "opentelemetry-collector.presetComponentName" -}}
+{{- $useCanonical := .Values.Values.presets.useCanonicalNames -}}
+{{- $names := dict
+      "hostMetrics"           (dict "legacy" "hostmetrics"    "canonical" "host_metrics")
+      "kubeletMetrics"        (dict "legacy" "kubeletstats"   "canonical" "kubelet_stats")
+      "logsCollection"        (dict "legacy" "filelog"        "canonical" "file_log")
+      "kubernetesAttributes"  (dict "legacy" "k8sattributes"  "canonical" "k8s_attributes")
+      "kubernetesEvents"      (dict "legacy" "k8sobjects"     "canonical" "k8s_objects")
+      "kubernetesObjects"     (dict "legacy" "k8sobjects"     "canonical" "k8s_objects")
+-}}
+{{- $entry := index $names .preset -}}
+{{- if $useCanonical -}}{{ $entry.canonical }}{{- else -}}{{ $entry.legacy }}{{- end -}}
+{{- end }}
+
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}
-{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "metrics" (dict "receivers" list)))) (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
-{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "hostmetrics" | uniq)  }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "hostMetrics" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "componentName" $name) .Values }}
+{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "metrics" (dict "receivers" list)))) (include "opentelemetry-collector.hostMetricsConfig" $ctx | fromYaml) .config }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers $name | uniq)  }}
 {{- $config | toYaml }}
 {{- end }}
 
 {{- define "opentelemetry-collector.hostMetricsConfig" -}}
 receivers:
-  hostmetrics:
+  {{ .componentName }}:
     root_path: /hostfs
     collection_interval: 10s
     scrapers:
@@ -249,22 +265,26 @@ receivers:
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}
-{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "metrics" (dict "receivers" list)))) (include "opentelemetry-collector.kubeletMetricsConfig" .Values | fromYaml) .config }}
-{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "kubeletstats" | uniq)  }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "kubeletMetrics" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "componentName" $name) .Values }}
+{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "metrics" (dict "receivers" list)))) (include "opentelemetry-collector.kubeletMetricsConfig" $ctx | fromYaml) .config }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers $name | uniq)  }}
 {{- $config | toYaml }}
 {{- end }}
 
 {{- define "opentelemetry-collector.kubeletMetricsConfig" -}}
 receivers:
-  kubeletstats:
+  {{ .componentName }}:
     collection_interval: 20s
     auth_type: "serviceAccount"
     endpoint: "${env:K8S_NODE_IP}:10250"
 {{- end }}
 
 {{- define "opentelemetry-collector.applyLogsCollectionConfig" -}}
-{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) (include "opentelemetry-collector.logsCollectionConfig" .Values | fromYaml) .config }}
-{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers "filelog" | uniq)  }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "logsCollection" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "componentName" $name) .Values }}
+{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) (include "opentelemetry-collector.logsCollectionConfig" $ctx | fromYaml) .config }}
+{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers $name | uniq)  }}
 {{- if .Values.Values.presets.logsCollection.storeCheckpoints}}
 {{- $configExtensions := mustMergeOverwrite (dict "service" (dict "extensions" list)) $config }}
 {{- $_ := set $config.service "extensions" (append $configExtensions.service.extensions "file_storage" | uniq)  }}
@@ -279,7 +299,7 @@ extensions:
     directory: /var/lib/otelcol
 {{- end }}
 receivers:
-  filelog:
+  {{ .componentName }}:
     include: [ /var/log/pods/*/*/*.log ]
     {{- if .Values.presets.logsCollection.includeCollectorLogs }}
     exclude: []
@@ -358,31 +378,33 @@ exporters:
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesAttributesConfig" -}}
-{{- $config := mustMergeOverwrite (include "opentelemetry-collector.kubernetesAttributesConfig" .Values | fromYaml) .config }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "kubernetesAttributes" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "componentName" $name) .Values }}
+{{- $config := mustMergeOverwrite (include "opentelemetry-collector.kubernetesAttributesConfig" $ctx | fromYaml) .config }}
 {{- if $config.service.pipelines.logs }}
   {{- $config = mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "processors" list)))) $config }}
-  {{- if not (has "k8sattributes" $config.service.pipelines.logs.processors) }}
-    {{- $_ := set $config.service.pipelines.logs "processors" (prepend $config.service.pipelines.logs.processors "k8sattributes" | uniq)  }}
+  {{- if not (has $name $config.service.pipelines.logs.processors) }}
+    {{- $_ := set $config.service.pipelines.logs "processors" (prepend $config.service.pipelines.logs.processors $name | uniq)  }}
   {{- end }}
 {{- end }}
 {{- if and $config.service.pipelines.metrics }}
   {{- $config = mustMergeOverwrite (dict "service" (dict "pipelines" (dict "metrics" (dict "processors" list)))) $config }}
-  {{- if not (has "k8sattributes" $config.service.pipelines.metrics.processors) }}
-    {{- $_ := set $config.service.pipelines.metrics "processors" (prepend $config.service.pipelines.metrics.processors "k8sattributes" | uniq)  }}
+  {{- if not (has $name $config.service.pipelines.metrics.processors) }}
+    {{- $_ := set $config.service.pipelines.metrics "processors" (prepend $config.service.pipelines.metrics.processors $name | uniq)  }}
   {{- end }}
 {{- end }}
 {{- if and $config.service.pipelines.traces }}
   {{- $config = mustMergeOverwrite (dict "service" (dict "pipelines" (dict "traces" (dict "processors" list)))) $config }}
-  {{- if not (has "k8sattributes" $config.service.pipelines.traces.processors) }}
-    {{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "k8sattributes" | uniq)  }}
+  {{- if not (has $name $config.service.pipelines.traces.processors) }}
+    {{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors $name | uniq)  }}
   {{- end }}
 {{- end }}
 {{- if $config.service.pipelines.profiles }}
   {{- $config = mustMergeOverwrite (dict "service" (dict "pipelines" (dict "profiles" (dict "processors" list)))) $config }}
-  {{- if not (has "k8sattributes" $config.service.pipelines.profiles.processors) }}
-    {{- $_ := set $config.service.pipelines.profiles "processors" (prepend $config.service.pipelines.profiles.processors "k8sattributes" | uniq)  }}
+  {{- if not (has $name $config.service.pipelines.profiles.processors) }}
+    {{- $_ := set $config.service.pipelines.profiles "processors" (prepend $config.service.pipelines.profiles.processors $name | uniq)  }}
   {{- end }}
-  {{- $podAssoc := $config.processors.k8sattributes.pod_association }}
+  {{- $podAssoc := (index $config.processors $name).pod_association }}
   {{- $containerIdSource := dict "sources" (list (dict "from" "resource_attribute" "name" "container.id")) }}
   {{- $hasContainerId := false }}
   {{- range $podAssoc }}
@@ -393,7 +415,7 @@ exporters:
     {{- end }}
   {{- end }}
   {{- if not $hasContainerId }}
-    {{- $_ := set $config.processors.k8sattributes "pod_association" (prepend $podAssoc $containerIdSource) }}
+    {{- $_ := set (index $config.processors $name) "pod_association" (prepend $podAssoc $containerIdSource) }}
   {{- end }}
 {{- end }}
 {{- $config | toYaml }}
@@ -401,7 +423,7 @@ exporters:
 
 {{- define "opentelemetry-collector.kubernetesAttributesConfig" -}}
 processors:
-  k8sattributes:
+  {{ .componentName }}:
   {{- if eq .Values.mode "daemonset" }}
     filter:
       node_from_env_var: K8S_NODE_NAME
@@ -491,14 +513,16 @@ processors:
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesEventsConfig" -}}
-{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) (include "opentelemetry-collector.kubernetesEventsConfig" .Values | fromYaml) .config }}
-{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers "k8sobjects" | uniq)  }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "kubernetesEvents" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "componentName" $name) .Values }}
+{{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) (include "opentelemetry-collector.kubernetesEventsConfig" $ctx | fromYaml) .config }}
+{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers $name | uniq)  }}
 {{- $config | toYaml }}
 {{- end }}
 
 {{- define "opentelemetry-collector.kubernetesEventsConfig" -}}
 receivers:
-  k8sobjects:
+  {{ .componentName }}:
     objects:
       - name: events
         mode: "watch"
@@ -515,25 +539,26 @@ receivers:
 {{- end -}}
 {{- $useLeaderElection := and (eq $vals.mode "daemonset") (not $disableLeaderElection) -}}
 {{- $electorName := "k8s_objects" }}
-{{- $ctx := mustMerge (dict "namespace" (include "opentelemetry-collector.namespace" .Values) "useLeaderElection" $useLeaderElection "electorName" $electorName) .Values }}
+{{- $name := include "opentelemetry-collector.presetComponentName" (dict "preset" "kubernetesObjects" "Values" .Values) }}
+{{- $ctx := mustMerge (dict "namespace" (include "opentelemetry-collector.namespace" .Values) "useLeaderElection" $useLeaderElection "electorName" $electorName "componentName" $name) .Values }}
 {{- $objectsYaml := include "opentelemetry-collector.kubernetesObjectsConfig" $ctx | fromYaml }}
-{{- $newObjects := (index $objectsYaml.receivers "k8sobjects").objects }}
+{{- $newObjects := (index $objectsYaml.receivers $name).objects }}
 {{- $existingObjects := list }}
 {{- if .config.receivers }}
-{{- if index .config.receivers "k8sobjects" }}
-{{- if (index .config.receivers "k8sobjects").objects }}
-{{- $existingObjects = (index .config.receivers "k8sobjects").objects }}
+{{- if index .config.receivers $name }}
+{{- if (index .config.receivers $name).objects }}
+{{- $existingObjects = (index .config.receivers $name).objects }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- $allObjects := concat $newObjects $existingObjects }}
 {{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) $objectsYaml .config }}
-{{- $_ := set (index $config.receivers "k8sobjects") "objects" $allObjects }}
+{{- $_ := set (index $config.receivers $name) "objects" $allObjects }}
 {{- if $useLeaderElection }}
 {{- $configExtensions := mustMergeOverwrite (dict "service" (dict "extensions" list)) $config }}
 {{- $_ := set $config.service "extensions" (append $configExtensions.service.extensions (printf "k8s_leader_elector/%s" $electorName) | uniq) }}
 {{- end }}
-{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers "k8sobjects" | uniq) }}
+{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers $name | uniq) }}
 {{- $config | toYaml }}
 {{- end }}
 
@@ -543,7 +568,7 @@ receivers:
 {{- include "opentelemetry-collector.leaderElectionConfig" (dict "name" .electorName "leaseName" "k8s.objects.receiver.opentelemetry.io" "leaseNamespace" .namespace) }}
 {{- end }}
 receivers:
-  k8sobjects:
+  {{ .componentName }}:
     {{- if .useLeaderElection }}
     k8s_leader_elector: k8s_leader_elector/{{ .electorName }}
     {{- end }}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -321,6 +321,10 @@
               "type": "boolean"
             }
           }
+        },
+        "useCanonicalNames": {
+          "description": "When true, preset components are injected under their canonical upstream names instead of the deprecated camelCase aliases.",
+          "type": "boolean"
         }
       }
     },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -24,6 +24,10 @@ namespaceOverride: ""
 # .Values.config and use the other fields supplied in the
 # values.yaml to configure k8s as necessary.
 presets:
+  # Inject preset components under their upstream canonical names
+  # (e.g. host_metrics) instead of the chart's legacy aliases (e.g. hostmetrics).
+  useCanonicalNames: false
+
   # Configures the collector to collect logs.
   # Adds the filelog receiver to the logs pipeline
   # and adds the necessary volumes and volume mounts.


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339 has been renaming several components from their camelCase aliases to snake_case canonical names:
* hostmetrics: host_metrics
* kubeletstats: kubelet_stats
* filelog: file_log
* k8sattributes: k8s_attributes
* k8sobjects: k8s_objects.

The chart's presets still inject these under the deprecated aliases. So a user who enables a preset and references the canonical name in their own config,  expecting it to override or extend the preset:
```
  presets:
    hostMetrics:
      enabled: true
  config:
    receivers:
      host_metrics:
        collection_interval: 30s
```
  …ends up with two separate receiver instances in the rendered collector config:
```
  receivers:
    host_metrics:          # user's override
      collection_interval: 30s
    hostmetrics:           # injected by preset
      collection_interval: 10s
  service:
    pipelines:
      metrics:
        receivers:
        - host_metrics
        - otlp
        - hostmetrics      # both names in the pipeline
```

Both receivers run,  telemetry is silently doubled. The user's "override" doesn't override anything because the names don't match.

This PR adds an opt-in toggle:

```
  presets:
    useCanonicalNames: true   # default false
    hostMetrics:
      enabled: true
```

Default false and existing users unaffected. With true, the affected presets inject under the canonical name, so .Values.config overrides line up and emit a single instance instead of two.
