### PR TITLE
docs: adds comment for manager.autoInstrumentationImage

### DIFF
--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -63,6 +63,8 @@ manager:
     repository: ""
     tag: ""
   autoInstrumentationImage:
+  ## Provide repository and tag for auto-instrumentation images to override defaults in opentelemetry-operator
+  # Make sure both repository and tag are provided, otherwise defaults will be used
     java:
       repository: ""
       tag: ""


### PR DESCRIPTION
images for auto-instrumentation are passed to operator via args in deployment template.
If only tag or repository for an instrumentation image are defined in values.yaml, no args will be added to a deployment. Operator then will use default instrumentation image.