### PR TITLE
docs: adds comment for manager.autoInstrumentationImage

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: jaronoff97
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.152.0
+appVersion: 0.152.1

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.114.1
+version: 0.114.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: jaronoff97
   - name: TylerHelmuth
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
-appVersion: 0.152.1
+appVersion: 0.152.0

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -93,7 +93,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,7 +32,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -395,7 +395,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -27,7 +27,7 @@ spec:
       labels:
         helm.sh/chart: opentelemetry-operator-0.114.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.152.0"
+        app.kubernetes.io/version: "0.152.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -52,7 +52,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.152.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.152.1"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -61,7 +61,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -93,7 +93,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -32,7 +32,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -395,7 +395,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -27,7 +27,7 @@ spec:
       labels:
         helm.sh/chart: opentelemetry-operator-0.114.1
         app.kubernetes.io/name: opentelemetry-operator
-        app.kubernetes.io/version: "0.152.0"
+        app.kubernetes.io/version: "0.152.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: opentelemetry-operator
         app.kubernetes.io/instance: example
@@ -53,7 +53,7 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.152.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.152.1"
           name: manager
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -30,7 +30,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example
@@ -61,7 +61,7 @@ metadata:
   labels:
     helm.sh/chart: opentelemetry-operator-0.114.1
     app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.152.0"
+    app.kubernetes.io/version: "0.152.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: opentelemetry-operator
     app.kubernetes.io/instance: example

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -62,6 +62,8 @@ manager:
   targetAllocatorImage:
     repository: ""
     tag: ""
+  # Provide repository and tag for auto-instrumentation images to override defaults in opentelemetry-operator
+  # Make sure both repository and tag are provided, otherwise defaults will be used
   autoInstrumentationImage:
     java:
       repository: ""


### PR DESCRIPTION
images for auto-instrumentation are passed to operator via args in deployment template.
If only tag or repository for an instrumentation image are defined in values.yaml, no args will be added to a deployment. Operator then will use default instrumentation image.