### PR TITLE
[opentelemetry-operator]: sync feature gates and add a drift check

### DIFF
--- a/.github/scripts/check-operator-feature-gates.sh
+++ b/.github/scripts/check-operator-feature-gates.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Fails when the operator feature gates exposed by this chart through
+# manager.featureGatesMap drift from the gates the operator actually registers
+# at the chart's appVersion. A new operator release that adds or drops a gate
+# should not be able to land here without the schema being updated to match.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+CHART_YAML="${CHART_YAML:-charts/opentelemetry-operator/Chart.yaml}"
+SCHEMA_FILE="${SCHEMA_FILE:-charts/opentelemetry-operator/values.schema.json}"
+# Set FEATUREGATE_FILE to read the operator gates from a local file instead of
+# downloading them; the tests use it to run offline.
+FEATUREGATE_FILE="${FEATUREGATE_FILE:-}"
+
+fail() {
+  printf 'check-operator-feature-gates: %s\n' "$1" >&2
+  exit 1
+}
+
+operator_version() {
+  if [[ -n "${OPERATOR_APP_VERSION:-}" ]]; then
+    printf '%s\n' "${OPERATOR_APP_VERSION}"
+    return
+  fi
+
+  local version
+  version="$(sed -n 's/^appVersion: //p' "${CHART_YAML}")"
+  [[ -n "${version}" ]] || fail "could not read appVersion from ${CHART_YAML}"
+  printf '%s\n' "${version}"
+}
+
+operator_source() {
+  local version="$1"
+
+  if [[ -n "${FEATUREGATE_FILE}" ]]; then
+    cat "${FEATUREGATE_FILE}"
+    return
+  fi
+
+  local url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v${version}/pkg/featuregate/featuregate.go"
+  curl -sSfL "${url}" || fail "could not download ${url}"
+}
+
+# Users can only toggle alpha and beta gates; stable gates are locked on and are
+# removed from the operator, so the chart only tracks alpha and beta ones.
+registered_gates() {
+  awk '
+    /MustRegister\(/ { in_block = 1; gate_id = ""; stage = ""; next }
+    in_block && gate_id == "" && /"/ {
+      if (match($0, /"[^"]+"/)) { gate_id = substr($0, RSTART + 1, RLENGTH - 2) }
+      next
+    }
+    in_block && /featuregate\.Stage/ {
+      if (match($0, /Stage[A-Za-z]+/)) { stage = substr($0, RSTART + 5, RLENGTH - 5) }
+    }
+    in_block && gate_id != "" && stage != "" {
+      if (stage == "Alpha" || stage == "Beta") { print gate_id }
+      in_block = 0
+    }
+  ' | sort -u
+}
+
+schema_gates() {
+  jq -r '.properties.manager.properties.featureGatesMap.properties | keys[]' "${SCHEMA_FILE}" | sort -u
+}
+
+main() {
+  local version
+  version="$(operator_version)"
+
+  local operator_gates chart_gates
+  operator_gates="$(operator_source "${version}" | registered_gates)"
+  chart_gates="$(schema_gates)"
+
+  [[ -n "${operator_gates}" ]] || fail "found no feature gates in the operator source for v${version}; the upstream file or its format may have changed"
+
+  local missing extra
+  missing="$(comm -23 <(printf '%s\n' "${operator_gates}") <(printf '%s\n' "${chart_gates}"))"
+  extra="$(comm -13 <(printf '%s\n' "${operator_gates}") <(printf '%s\n' "${chart_gates}"))"
+
+  if [[ -z "${missing}" && -z "${extra}" ]]; then
+    printf 'feature gates are in sync with operator v%s\n' "${version}"
+    return 0
+  fi
+
+  printf 'feature gates are out of sync with operator v%s:\n' "${version}" >&2
+  if [[ -n "${missing}" ]]; then
+    printf '  missing from values.schema.json: %s\n' "$(printf '%s ' ${missing})" >&2
+  fi
+  if [[ -n "${extra}" ]]; then
+    printf '  no longer registered by the operator: %s\n' "$(printf '%s ' ${extra})" >&2
+  fi
+  exit 1
+}
+
+main "$@"

--- a/.github/scripts/test-check-operator-feature-gates.sh
+++ b/.github/scripts/test-check-operator-feature-gates.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="${ROOT_DIR}/.github/scripts/check-operator-feature-gates.sh"
+DATA_DIR="${ROOT_DIR}/.github/scripts/testdata/check-operator-feature-gates"
+
+passed=0
+
+run_checker() {
+  local featuregate_file="$1"
+  local schema_file="$2"
+
+  FEATUREGATE_FILE="${featuregate_file}" \
+  SCHEMA_FILE="${schema_file}" \
+  OPERATOR_APP_VERSION="0.0.0" \
+    bash "${CHECKER}"
+}
+
+expect_in_sync() {
+  local description="$1"
+  local featuregate_file="$2"
+  local schema_file="$3"
+
+  if run_checker "${featuregate_file}" "${schema_file}" >/dev/null 2>&1; then
+    printf 'ok   - %s\n' "${description}"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL - %s (expected the checker to pass)\n' "${description}" >&2
+    exit 1
+  fi
+}
+
+expect_drift() {
+  local description="$1"
+  local featuregate_file="$2"
+  local schema_file="$3"
+
+  if run_checker "${featuregate_file}" "${schema_file}" >/dev/null 2>&1; then
+    printf 'FAIL - %s (expected the checker to report drift)\n' "${description}" >&2
+    exit 1
+  else
+    printf 'ok   - %s\n' "${description}"
+    passed=$((passed + 1))
+  fi
+}
+
+main() {
+  local work_dir
+  work_dir="$(mktemp -d)"
+  trap "rm -rf '${work_dir}'" EXIT
+
+  local schema_in_sync="${DATA_DIR}/schema-insync.json"
+  local gates_path='.properties.manager.properties.featureGatesMap.properties'
+
+  expect_in_sync "alpha and beta gates match the schema" \
+    "${DATA_DIR}/featuregate-insync.go" "${schema_in_sync}"
+
+  local schema_missing="${work_dir}/schema-missing.json"
+  jq "del(${gates_path}[\"demo.beta.one\"])" "${schema_in_sync}" > "${schema_missing}"
+  expect_drift "schema is missing a gate the operator registers" \
+    "${DATA_DIR}/featuregate-insync.go" "${schema_missing}"
+
+  local schema_extra="${work_dir}/schema-extra.json"
+  jq "${gates_path}[\"demo.removed.one\"] = {\"type\":\"boolean\",\"default\":false}" \
+    "${schema_in_sync}" > "${schema_extra}"
+  expect_drift "schema keeps a gate the operator dropped" \
+    "${DATA_DIR}/featuregate-insync.go" "${schema_extra}"
+
+  expect_drift "operator source parses to no gates" \
+    "${DATA_DIR}/featuregate-empty.go" "${schema_in_sync}"
+
+  printf '\n%d checks passed\n' "${passed}"
+}
+
+main "$@"

--- a/.github/scripts/testdata/check-operator-feature-gates/featuregate-empty.go
+++ b/.github/scripts/testdata/check-operator-feature-gates/featuregate-empty.go
@@ -1,0 +1,4 @@
+// A source file with no gate registrations. The checker must treat an empty
+// parse result as a failure rather than reporting "in sync", since it usually
+// means the upstream file moved or its format changed.
+package featuregate

--- a/.github/scripts/testdata/check-operator-feature-gates/featuregate-insync.go
+++ b/.github/scripts/testdata/check-operator-feature-gates/featuregate-insync.go
@@ -1,0 +1,24 @@
+// Trimmed-down copy of the operator's pkg/featuregate/featuregate.go, used to
+// exercise the parser in check-operator-feature-gates.sh without hitting the
+// network. Only the registration shape matters here, not the surrounding code.
+package featuregate
+
+var (
+	DemoAlphaOne = featuregate.GlobalRegistry().MustRegister(
+		"demo.alpha.one",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("an alpha gate users can toggle"),
+	)
+
+	DemoBetaOne = featuregate.GlobalRegistry().MustRegister(
+		"demo.beta.one",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("a beta gate users can toggle"),
+	)
+
+	DemoStableOne = featuregate.GlobalRegistry().MustRegister(
+		"demo.stable.one",
+		featuregate.StageStable,
+		featuregate.WithRegisterDescription("a stable gate that is locked on and must not appear in the chart"),
+	)
+)

--- a/.github/scripts/testdata/check-operator-feature-gates/schema-insync.json
+++ b/.github/scripts/testdata/check-operator-feature-gates/schema-insync.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "manager": {
+      "properties": {
+        "featureGatesMap": {
+          "additionalProperties": false,
+          "properties": {
+            "demo.alpha.one": {
+              "type": "boolean",
+              "default": false
+            },
+            "demo.beta.one": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Check CRDs
         run: make check-operator-crds
 
+      - name: Check feature gates
+        run: make check-operator-feature-gates
+
       - name: Install Openshift route crd
         run: kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deploy/route_crd.yaml
 
@@ -115,6 +118,9 @@ jobs:
 
       - name: Check CRDs
         run: make check-operator-crds
+
+      - name: Check feature gates
+        run: make check-operator-feature-gates
 
       - name: Install Openshift route crd
         run: kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deploy/route_crd.yaml

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ check-operator-crds:
 		exit 1; \
 	fi; \
 
+.PHONY: check-operator-feature-gates
+check-operator-feature-gates:
+	.github/scripts/check-operator-feature-gates.sh
+
 define get-crd
 @curl -s -o $(1) $(2)
 @sed -i '\#path: /convert#a {{ if .caBundle }}{{ cat "caBundle:" .caBundle | indent 8 }}{{ end }}' $(1)

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.114.1
+version: 0.115.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,23 @@
 # Upgrade guidelines
 
+## 0.114.x to 0.115.0
+
+### Removal of graduated feature gates
+
+The `operator.collector.targetallocatorcr` and `operator.collector.default.config` feature gates have graduated to stable in the operator and were then removed, so they can no longer be configured. The operator now applies both behaviors by default.
+
+If you set either gate under `manager.featureGatesMap`, remove it before upgrading, otherwise the chart will fail schema validation:
+
+```yaml
+# No longer valid, remove these entries
+manager:
+  featureGatesMap:
+    operator.collector.targetallocatorcr: true
+    operator.collector.default.config: true
+```
+
+This release also exposes the `operator.networkpolicy`, `operand.networkpolicy`, `operator.clusterobservability` and `operator.collector.usedefaulttelemetryshape` gates that the operator added but the chart did not yet support.
+
 ## 0.109.x to 0.110.0
 
 ### Migration from kube-rbac-proxy to controller-runtime metrics

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.114.1
+        helm.sh/chart: opentelemetry-operator-0.115.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.152.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.114.1
+        helm.sh/chart: opentelemetry-operator-0.115.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.152.0"
         app.kubernetes.io/managed-by: Helm
@@ -43,7 +43,7 @@ spec:
             - --health-probe-addr=:8081
             - --webhook-port=9443
             - --collector-image=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.152.1
-            - --feature-gates=-operator.collector.targetallocatorcr,operator.targetallocator.mtls
+            - --feature-gates=-operator.clusterobservability,operator.targetallocator.mtls
           command:
             - /manager
           env:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.114.1
+    helm.sh/chart: opentelemetry-operator-0.115.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.152.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/values.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/values.yaml
@@ -3,4 +3,4 @@ manager:
     repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s"
   featureGatesMap:
     operator.targetallocator.mtls: true
-    operator.collector.targetallocatorcr: false
+    operator.clusterobservability: false

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -646,14 +646,6 @@
                 false
               ]
             },
-            "operator.collector.targetallocatorcr": {
-              "type": "boolean",
-              "default": false,
-              "title": "Whether to create TargetAllocator custom resource",
-              "examples": [
-                false
-              ]
-            },
             "operator.golang.flags": {
               "type": "boolean",
               "default": false,
@@ -662,10 +654,34 @@
                 false
               ]
             },
-            "operator.collector.default.config": {
+            "operator.networkpolicy": {
               "type": "boolean",
               "default": false,
-              "title": "Set default endpoints for known components",
+              "title": "Whether the operator manages NetworkPolicies for itself",
+              "examples": [
+                false
+              ]
+            },
+            "operand.networkpolicy": {
+              "type": "boolean",
+              "default": false,
+              "title": "Whether the operator manages NetworkPolicies for collectors and target allocators",
+              "examples": [
+                false
+              ]
+            },
+            "operator.clusterobservability": {
+              "type": "boolean",
+              "default": false,
+              "title": "Whether to enable the ClusterObservability controller",
+              "examples": [
+                false
+              ]
+            },
+            "operator.collector.usedefaulttelemetryshape": {
+              "type": "boolean",
+              "default": false,
+              "title": "Use collector defaults for injected Prometheus telemetry metric names",
               "examples": [
                 false
               ]


### PR DESCRIPTION
## TL;DR

Bring the operator chart's `manager.featureGatesMap` back in sync with the feature gates the operator registers, and add a CI check so future appVersion bumps cannot drift again.

## Problem

`values.schema.json` lists the allowed `featureGatesMap` keys with `additionalProperties: false`. When a new operator release adds a gate, it cannot be set through the chart until the schema is updated by hand; when the operator drops a gate, it lingers in the schema. Operator bump PRs only change `appVersion`, so the two drift apart over time. #2240 is one instance, where `operator.clusterobservability` was unreachable.

## Changes

Sync with operator v0.152.0:

- Add `operator.networkpolicy`, `operand.networkpolicy`, `operator.clusterobservability` and `operator.collector.usedefaulttelemetryshape`.
- Remove `operator.collector.targetallocatorcr` and `operator.collector.default.config`, which graduated to stable and were then removed from the operator.

Enforce going forward:

- Add `make check-operator-feature-gates`, wired into the operator CI next to the CRD check. It compares the alpha and beta gates the operator registers at the chart's `appVersion` against the schema keys and fails on any mismatch. A small test with fixtures covers the in-sync, missing, extra and empty-parse cases.

## Notes

- Removing the two graduated gates is a breaking change for anyone still setting them. Chart bumped 0.114.1 -> 0.115.0 (MINOR) and documented in `UPGRADING.md`.
- Examples regenerated with `make generate-examples`.

Closes #2240
Addresses #2248
