### PR TITLE
[opentelemetry-collector]: honor schedulerName in daemonset and statefulset modes

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.159.0
+version: 0.159.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/daemonset.yaml
+++ b/charts/opentelemetry-collector/templates/daemonset.yaml
@@ -50,4 +50,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+      {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/statefulset.yaml
+++ b/charts/opentelemetry-collector/templates/statefulset.yaml
@@ -55,6 +55,9 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+      {{- end }}
       {{- $podValues := deepCopy .Values }}
       {{- $podData := dict "Values" $podValues "configmapSuffix" "-statefulset" "isAgent" false }}
       {{- include "opentelemetry-collector.pod" ($podData | mustMergeOverwrite (deepCopy .)) | nindent 6 }}


### PR DESCRIPTION
The `schedulerName` value is documented in values.yaml and wired into the Deployment pod spec, but it was never applied in `daemonset` or `statefulset` mode — setting it there had no effect.

This mirrors the existing deployment.yaml block into daemonset.yaml and statefulset.yaml so a custom scheduler is honored in all three modes.

Verified with `helm template --set schedulerName=...` for each mode (field now renders; absent by default), plus `ct lint` and `make check-examples`.