### PR TITLE
[opentelemetry-operator]: remove deprecated manager.featureGates

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.115.1
+version: 0.116.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/UPGRADING.md
+++ b/charts/opentelemetry-operator/UPGRADING.md
@@ -1,5 +1,22 @@
 # Upgrade guidelines
 
+## 0.115.x to 0.116.0
+
+The deprecated `manager.featureGates` value has been removed. It was replaced by `manager.featureGatesMap` back in 0.72.1, and setting it now fails schema validation.
+
+If you still rely on `manager.featureGates`, move each gate into `manager.featureGatesMap` before upgrading:
+
+```yaml
+# before
+manager:
+  featureGates: "operator.golang.flags"
+
+# after
+manager:
+  featureGatesMap:
+    operator.golang.flags: true
+```
+
 ## 0.109.x to 0.110.0
 
 ### Migration from kube-rbac-proxy to controller-runtime metrics

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.115.1
+        helm.sh/chart: opentelemetry-operator-0.116.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.153.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.115.1
+        helm.sh/chart: opentelemetry-operator-0.116.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.153.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -393,7 +393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ spec:
         checksum/config: 0da985a5e8e6c8d2ffbbcdbd02b166f0c8b47a193418632712111fcc71a431d5
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.115.1
+        helm.sh/chart: opentelemetry-operator-0.116.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.153.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm
@@ -59,7 +59,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.115.1
+    helm.sh/chart: opentelemetry-operator-0.116.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.153.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/NOTES.txt
+++ b/charts/opentelemetry-operator/templates/NOTES.txt
@@ -1,12 +1,6 @@
 {{- if and (not .Values.manager.collectorImage.repository) .Values.manager.ignoreMissingCollectorCRDs }}
 {{ fail "[ERROR] 'manager.collectorImage.repository' must be set. See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md for instructions." }}
 {{ end }}
-{{- if and .Values.manager.featureGates .Values.manager.featureGatesMap }}
-{{ fail "[ERROR] only one of 'manager.featureGates' and 'manager.featureGatesMap' can be set at a time" }}
-{{ end }}
-{{- if .Values.manager.featureGates }}
-The 'manager.featureGates' value is deprecated. Please migrate to use the 'manager.featureGatesMap' value.
-{{ end }}
 
 {{- if not .Values.manager.resources }}
 [WARNING] No resource limits or requests were set. Consider setter resource requests and limits via the `resources` field.

--- a/charts/opentelemetry-operator/templates/deployment.yaml
+++ b/charts/opentelemetry-operator/templates/deployment.yaml
@@ -104,8 +104,6 @@ spec:
             {{- end }}
             {{- if .Values.manager.featureGatesMap }}
             - --feature-gates={{ include "opentelemetry-operator.featureGatesMap" . }}
-            {{- else if ne .Values.manager.featureGates "" }}
-            - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}
             {{-  if .Values.manager.extraArgs  }}
             {{- .Values.manager.extraArgs | toYaml | nindent 12 }}

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -166,7 +166,6 @@
         "opampBridgeImage",
         "targetAllocatorImage",
         "autoInstrumentationImage",
-        "featureGates",
         "ports",
         "env",
         "extraEnvs",
@@ -619,11 +618,6 @@
               }
             }
           ]
-        },
-        "featureGates": {
-          "type": "string",
-          "default": "",
-          "title": "The featureGates to enable"
         },
         "featureGatesMap": {
           "type": "object",
@@ -1408,7 +1402,6 @@
               "tag": ""
             }
           },
-          "featureGates": "",
           "ports": {
             "metricsPort": 8443,
             "webhookPort": 9443,
@@ -2101,7 +2094,6 @@
             "tag": ""
           }
         },
-        "featureGates": "",
         "ports": {
           "metricsPort": 8443,
           "webhookPort": 9443,

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -106,14 +106,8 @@ manager:
   # See https://github.com/open-telemetry/opentelemetry-operator/blob/main/internal/config/config.go
   # for the list of supported configuration fields.
   config: {}
-  # Feature Gates are a comma-delimited list of feature gate identifiers.
-  # Prefix a gate with '-' to disable support.
-  # Prefixing a gate with '+' or no prefix will enable support.
-  # A full list of valid identifiers can be found here: https://github.com/open-telemetry/opentelemetry-operator/blob/main/pkg/featuregate/featuregate.go
-  # NOTE: the featureGates value is deprecated and will be replaced by featureGatesMap in the future.
-  featureGates: ""
   # The featureGatesMap will enable or disable specific feature gates in the operator as well as deploy any prerequisites for the feature gate.
-  # If this property is not an empty map, the featureGates property will be ignored.
+  # A full list of valid identifiers can be found here: https://github.com/open-telemetry/opentelemetry-operator/blob/main/pkg/featuregate/featuregate.go
   featureGatesMap: {}
   # operator.clusterobservability: false
   # operator.targetallocator.fallbackstrategy: false


### PR DESCRIPTION
#### Description

This removes the deprecated string-based `manager.featureGates` value from the operator chart and keeps `manager.featureGatesMap` as the supported way to configure operator feature gates. This is a preparatory cleanup for the feature-gate sync work discussed in #2248, so the chart has a single feature-gate configuration path before adding drift checks and missing gates. Users still setting `manager.featureGates` will now fail schema validation and should migrate to `manager.featureGatesMap`; upgrade notes are included in `UPGRADING.md`.

#### Link to tracking issue

Related to #2248

#### Authorship

- [x] I, a human, wrote this pull request description myself.
