### PR TITLE
[opentelemetry-collector] Force string type for telemetry resource attributes

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.158.2
+version: 0.158.3
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aac2e41408bfa0c69888d60acd43c28c2c06eb47d15757d017835ac0ef6b7ccb
+        checksum/config: 632440025a18730dac6866d8c42ccdda3b720c3ddcf5927fbd7dc43d668360cf
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecf1dc0a67bf3c1b6fbf8e96e442155e58e6506d902910f3e6e717f6b6c7e204
+        checksum/config: a5a4a7ee42601f2dcb5210cf0f615c86dae73707306d98bd04fc0a9204a4499e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -98,9 +98,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 25bc272492d09941556aa04509d721e49ef7aba63a5ee098fb0b0431d2a3af80
+        checksum/config: f9d5552b03bfcb587cac18be760e0eb33c0b1ef559727b9576c658fa52c012da
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecf1dc0a67bf3c1b6fbf8e96e442155e58e6506d902910f3e6e717f6b6c7e204
+        checksum/config: a5a4a7ee42601f2dcb5210cf0f615c86dae73707306d98bd04fc0a9204a4499e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -109,9 +109,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8bb1d6b6819b74ae93e345a3cbb28ffd7ac575e3f15dbc1b3ab9031cd3d2ce6
+        checksum/config: cd7ec190f3226a56507a7fee0bee2ba66bd4e788fda298d0610940fa43fb16ea
         io.opentelemetry.discovery.logs/enabled: "false"
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -100,9 +100,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7b49d7d9b3b8f93beaba2e5dc5df0328e6e56f3a4224736100044df118eb7c30
+        checksum/config: 0823f88dcdbd3d4a7856878bcc9b5476fa562d94a7677b302f1ed8e12ae165aa
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -105,9 +105,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 733ebb467a259cd0ae3154cac4333193864cee7a81372775341e445c9d15ccd3
+        checksum/config: 3a17c70526edc980021598d719423c4290a8d226a01a4f12b22fa6ee8aeff745
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -138,9 +138,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e1a98e71ddd476f9cd78392d2368a0a5a51f154ff32d8ae6c338eff5be62453b
+        checksum/config: a83a4c55db5e60047623f88b6e9f53d060212321b94ef5746ddf94b633a52fa8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -162,9 +162,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 328ef73c5f44f9d40c86bc69508a106134cbd11fd90d14d0aad261e40bb52ffc
+        checksum/config: f923335f78163a88fb0dd3636364b70713f2bbe83fd9ed74b3e2709157537a9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ee45bf750fa11c3d929d1be41d29bdd2d4bf09de04fc21e4304e00bf7ffa6f3
+        checksum/config: 3c0fbe4b4918d7777e8081ec81a2b62f77988f81abc6d898203185eb246368fc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ee45bf750fa11c3d929d1be41d29bdd2d4bf09de04fc21e4304e00bf7ffa6f3
+        checksum/config: 3c0fbe4b4918d7777e8081ec81a2b62f77988f81abc6d898203185eb246368fc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -104,9 +104,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2cd8a2334ed876166c13779a0d242b998a2e490deecf75b2aa7f7e16f59a2033
+        checksum/config: 36c1a59e2097977890e54dd6593c4543e58ab19ba13816a91961fb51ac9c8cf7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -94,9 +94,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 12a78a74e93edc8f0d9a50d58f18c619536548314857da77f40db48586888afc
+        checksum/config: a0960224ec7d4c4ed9e0591a43b2f97dc507779c41664bf477a06255a3292d93
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecf1dc0a67bf3c1b6fbf8e96e442155e58e6506d902910f3e6e717f6b6c7e204
+        checksum/config: a5a4a7ee42601f2dcb5210cf0f615c86dae73707306d98bd04fc0a9204a4499e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -54,9 +54,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3b7d03c78c953cb9d8f4e1ea367b24bba8359a9ff8774c36a1150d1bb8978efb
+        checksum/config: 6fabb94da566d5c01126b40aff22c16fcc6856f5721fdd9d8f78559c056ae459
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config: 7eb70257593da06f682a3ddda54a9d260d4fc514f645237f5ca74b08f8da61a6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -89,12 +89,12 @@ data:
                   endpoint: http://localhost:4318
                   protocol: http/protobuf
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}
         traces:
           processors:
           - batch:

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a7aa59d44fc3cb4e3f240a79ac3905ae34b690b763ef4e39e74249e1daaeea02
+        checksum/config: fca2ff4bb408af4577b604487ecbad78c718d6012e6ab7094f458816c406648d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -131,9 +131,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 998fd741b061efe09c9be1de940265c61de1693061070f1e4d1206e12d9e792b
+        checksum/config: 02d52e7044cfea0ff7f5fa96e48eae1e463b4453323dc268576bf9d7fb98f295
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -99,9 +99,9 @@ data:
                     - k8s.pod.ip
                     - k8s.pod.name
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d0af51a3d35e43462c0c0c33dbbc330bf5dc46f3288c1784c6dead1cbc899291
+        checksum/config: 5d9bcaccd3ab7d8d72234d52fd93e56ead2c9912d37ee5a04fa834a2a3849e1a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -99,9 +99,9 @@ data:
                     - k8s.pod.ip
                     - k8s.pod.name
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: default
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str default
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6829f763f8028a9829743fd36d75426bb6fa2fb27b44c265efc84e5a0ecde90a
+        checksum/config: 63868febf51cd14046fc4b57406665bf15f9d49804209c800217435263e5eb18
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 75b08fae7339ff15964af5b75e3f03c19da56658137bcf2a0d983b1e5c9636fd
+        checksum/config: 0530f96221fa83cf4414682f11c96332b5054595fde0eacc0836c642bc2e77c2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 75b08fae7339ff15964af5b75e3f03c19da56658137bcf2a0d983b1e5c9636fd
+        checksum/config: 0530f96221fa83cf4414682f11c96332b5054595fde0eacc0836c642bc2e77c2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecf1dc0a67bf3c1b6fbf8e96e442155e58e6506d902910f3e6e717f6b6c7e204
+        checksum/config: a5a4a7ee42601f2dcb5210cf0f615c86dae73707306d98bd04fc0a9204a4499e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config: 7eb70257593da06f682a3ddda54a9d260d4fc514f645237f5ca74b08f8da61a6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -91,9 +91,9 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          host.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.namespace.name: !!str ${env:OTEL_K8S_NAMESPACE}
+          k8s.node.ip: !!str ${env:OTEL_K8S_NODE_IP}
+          k8s.node.name: !!str ${env:OTEL_K8S_NODE_NAME}
+          k8s.pod.ip: !!str ${env:OTEL_K8S_POD_IP}
+          k8s.pod.name: !!str ${env:OTEL_K8S_POD_NAME}

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecf1dc0a67bf3c1b6fbf8e96e442155e58e6506d902910f3e6e717f6b6c7e204
+        checksum/config: a5a4a7ee42601f2dcb5210cf0f615c86dae73707306d98bd04fc0a9204a4499e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.158.2
+    helm.sh/chart: opentelemetry-collector-0.158.3
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.153.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -86,6 +86,24 @@ logs:
 {{- end }}
 
 {{/*
+Serialize the collector config to YAML, forcing service.telemetry.resource
+attribute values to be strings. This prevents the collector from coercing
+numeric-looking values (such as an all-digit node name) to integers, which
+would fail validation for string-typed attributes like host.name.
+*/}}
+{{- define "opentelemetry-collector.serializedConfig" -}}
+{{- $config := .config }}
+{{- $resource := dig "service" "telemetry" "resource" dict $config }}
+{{- range $key, $value := $resource }}
+{{- if and (kindIs "string" $value) (ne $value "") }}
+{{- $_ := set $resource $key (printf "!!str %s" $value) }}
+{{- end }}
+{{- end }}
+{{- $rendered := tpl (toYaml $config) .ctx }}
+{{- regexReplaceAll "'(!!str [^']*)'" $rendered "${1}" }}
+{{- end }}
+
+{{/*
 Build config file for daemonset OpenTelemetry Collector
 */}}
 {{- define "opentelemetry-collector.daemonsetConfig" -}}
@@ -119,7 +137,7 @@ Build config file for daemonset OpenTelemetry Collector
 {{- if and .Values.presets.resourceDetection.enabled (or .Values.presets.resourceDetection.env.enabled .Values.presets.resourceDetection.k8snode.enabled .Values.presets.resourceDetection.eks.enabled .Values.presets.resourceDetection.aks.enabled .Values.presets.resourceDetection.gcp.enabled) }}
 {{- $config = (include "opentelemetry-collector.applyResourceDetectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
-{{- tpl (toYaml $config) . }}
+{{- include "opentelemetry-collector.serializedConfig" (dict "config" $config "ctx" .) }}
 {{- end }}
 
 {{/*
@@ -159,7 +177,7 @@ Build config file for deployment OpenTelemetry Collector
 {{- if and .Values.presets.resourceDetection.enabled (or .Values.presets.resourceDetection.env.enabled .Values.presets.resourceDetection.k8snode.enabled .Values.presets.resourceDetection.eks.enabled .Values.presets.resourceDetection.aks.enabled .Values.presets.resourceDetection.gcp.enabled) }}
 {{- $config = (include "opentelemetry-collector.applyResourceDetectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
-{{- tpl (toYaml $config) . }}
+{{- include "opentelemetry-collector.serializedConfig" (dict "config" $config "ctx" .) }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}


### PR DESCRIPTION
#### Description
The collector resolves `${env:...}` placeholders after parsing the config and infers the type of the substituted value. When a node's name is all digits, `host.name` and `k8s.node.name` get coerced to integers, so the collector fails to start with:
```service::telemetry::resource: legacy resource attribute "host.name" must be string or null```
This renders `service.telemetry.resource` attribute values with an explicit `!!str` YAML tag so the collector always treats them as strings, regardless of the node name. Non-string values (e.g. `null`) are left untouched, so the existing `null` workaround still works.

Bumped the chart version and regenerated the examples.
#### Link to tracking issue
Fixes #2250 

#### Authorship

- [X] I, a human, wrote this pull request description myself.
