### PR TITLE
fix(OBI): Fixed network metrics config

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.9.3
+version: 0.9.4
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.9.2
+version: 0.9.3
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/UPGRADING.md
+++ b/charts/opentelemetry-ebpf-instrumentation/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrade guidelines
+
+These upgrade guidelines only contain instructions for version upgrades which require manual modifications on the user's side.
+If the version you want to upgrade to is not listed here, then there is nothing to do for you.
+Just upgrade and enjoy.
+
+## 0.9.3 to 0.9.4
+
+The `tpl` function has been added to `.Values.config.data`. If you are currently using any `{{ }}` syntax in `.Values.config.data` it will now be rendered. To escape existing instances of `{{ }}`, use ``` {{` <original content> `}} ```. For example, `{{ REDACTED_EMAIL }}` becomes ``` {{` {{ REDACTED_EMAIL }} `}} ```.

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8926ef422da030a8578200136f7c0a0bd52a0acf5b6241dda90c6197ac94707
+        checksum/config: d8c759d2b225f1a227d81fcf6d079625f6d324d25a7fa40f0f14127dc0e03e23
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d8c759d2b225f1a227d81fcf6d079625f6d324d25a7fa40f0f14127dc0e03e23
+        checksum/config: 2ace7107bf5630e1611feeacf7f776cf9a3cc509d2385ae6e19e3b6c525f8573
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8926ef422da030a8578200136f7c0a0bd52a0acf5b6241dda90c6197ac94707
+        checksum/config: d8c759d2b225f1a227d81fcf6d079625f6d324d25a7fa40f0f14127dc0e03e23
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d8c759d2b225f1a227d81fcf6d079625f6d324d25a7fa40f0f14127dc0e03e23
+        checksum/config: 2ace7107bf5630e1611feeacf7f776cf9a3cc509d2385ae6e19e3b6c525f8573
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.1
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.3
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.9.4
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.9.0"

--- a/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
@@ -145,9 +145,12 @@ Generate the configmap data based on preset and configuration values
 */}}
 {{- define "obi.configData" -}}
 {{- $config := deepCopy .Values.config.data }}
-{{- if eq .Values.preset "network" }}
-{{- if not .Values.config.data.network }}
-{{- $_ := set $config "network" (dict "enable" true) }}
+{{- if or (eq .Values.preset "network") .Values.config.data.network }}
+{{- $configMetrics := $config.metrics | default dict }}
+{{- $features := $configMetrics.features | default list }}
+{{- if not (has "network" $features) }}
+{{- $_ := set $configMetrics "features" (append $features "network") }}
+{{- $_ = set $config "metrics" $configMetrics }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.preset "application" }}
@@ -156,5 +159,5 @@ Generate the configmap data based on preset and configuration values
 {{- $_ := set $config "discovery" $discovery }}
 {{- end }}
 {{- end }}
-{{- toYaml $config }}
+{{- tpl (toYaml $config) . }}
 {{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
@@ -145,12 +145,9 @@ Generate the configmap data based on preset and configuration values
 */}}
 {{- define "obi.configData" -}}
 {{- $config := deepCopy .Values.config.data }}
-{{- if or (eq .Values.preset "network") .Values.config.data.network }}
-{{- $configMetrics := $config.metrics | default dict }}
-{{- $features := $configMetrics.features | default list }}
-{{- if not (has "network" $features) }}
-{{- $_ := set $configMetrics "features" (append $features "network") }}
-{{- $_ = set $config "metrics" $configMetrics }}
+{{- if eq .Values.preset "network" }}
+{{- if not .Values.config.data.network }}
+{{- $_ := set $config "network" (dict "enable" true) }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.preset "application" }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
@@ -33,9 +33,7 @@ spec:
       {{- if eq .Values.preset "application" }}
       hostPID: true
       {{- end }}
-      {{- $netFeats := dig "metrics" "features" (list) .Values.config.data }}
-      {{- if not (kindIs "slice" $netFeats) }}{{- fail "config.data.metrics.features must be a YAML list (sequence), not a scalar" }}{{- end }}
-      {{- $networkEnabled := or (eq .Values.preset "network") (has "network" $netFeats) (has "network_flow_packets" $netFeats) (has "network_inter_zone" $netFeats) .Values.config.data.network }}
+      {{- $networkEnabled := or (eq .Values.preset "network") .Values.config.data.network }}
       {{- if $networkEnabled }}
       hostNetwork: true
       dnsPolicy: {{ .Values.dnsPolicy }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
@@ -33,7 +33,10 @@ spec:
       {{- if eq .Values.preset "application" }}
       hostPID: true
       {{- end }}
-      {{- if or (eq .Values.preset "network") .Values.config.data.network }}
+      {{- $netFeats := dig "metrics" "features" (list) .Values.config.data }}
+      {{- if not (kindIs "slice" $netFeats) }}{{- fail "config.data.metrics.features must be a YAML list (sequence), not a scalar" }}{{- end }}
+      {{- $networkEnabled := or (eq .Values.preset "network") (has "network" $netFeats) (has "network_flow_packets" $netFeats) (has "network_inter_zone" $netFeats) .Values.config.data.network }}
+      {{- if $networkEnabled }}
       hostNetwork: true
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
@@ -61,6 +64,9 @@ spec:
                 - BPF
                 - SYS_PTRACE
                 - NET_RAW
+                {{- if $networkEnabled }}
+                - NET_ADMIN
+                {{- end }}
                 - CHECKPOINT_RESTORE
                 - DAC_READ_SEARCH
                 - PERFMON
@@ -118,6 +124,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/ebpf-instrument/config
               name: ebpf-instrument-config
+            {{- if $networkEnabled }}
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+              readOnly: true
+            {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -141,6 +152,12 @@ spec:
         - name: ebpf-instrument-config
           configMap:
             name: {{ default (include "obi.fullname" .) .Values.config.name }}
+        {{- if $networkEnabled }}
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -195,10 +195,8 @@ config:
   ## If empty, default configuration below is used.
   name: ""
   # -- default value of Opentelemetry eBPF Instrumentation configuration
-  # Supports Go template expressions (e.g. {{ .Release.Name }}). BREAKING: values that contain
-  # literal {{ }} are now interpreted as template expressions. Escape them as {{` {{ }} `}}.
-  # Do not use non-idempotent functions (e.g. randAlphaNum) — config.data is rendered
-  # separately for the ConfigMap and the DaemonSet checksum/config annotation.
+  # Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
+  # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
   data:
     # profile_port: 6060
     # open_port: 8443

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -175,7 +175,7 @@ podLabels: {}
 
 ## https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 # -- Determines how DNS resolution is handled for that pod.
-# If `.Values.preset` is set to `network` or `.Values.config.data.metrics.features` includes a network feature, Opentelemetry eBPF Instrumentation requires `hostNetwork` access, causing cluster service DNS resolution to fail.
+# If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Opentelemetry eBPF Instrumentation requires `hostNetwork` access, causing cluster service DNS resolution to fail.
 # It is recommended not to change this if Opentelemetry eBPF Instrumentation sends traces and metrics to Grafana components via k8s service.
 dnsPolicy: ClusterFirstWithHostNet
 

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -225,9 +225,8 @@ config:
         k8s_src_owner_name:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
     ## to enable network metrics
-    # metrics:
-    #   features:
-    #     - network
+    # network:
+    #   enable: true
     prometheus_export:
       port: 9090
       path: /metrics

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -175,7 +175,7 @@ podLabels: {}
 
 ## https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 # -- Determines how DNS resolution is handled for that pod.
-# If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Opentelemetry eBPF Instrumentation requires `hostNetwork` access, causing cluster service DNS resolution to fail.
+# If `.Values.preset` is set to `network` or `.Values.config.data.metrics.features` includes a network feature, Opentelemetry eBPF Instrumentation requires `hostNetwork` access, causing cluster service DNS resolution to fail.
 # It is recommended not to change this if Opentelemetry eBPF Instrumentation sends traces and metrics to Grafana components via k8s service.
 dnsPolicy: ClusterFirstWithHostNet
 
@@ -195,6 +195,10 @@ config:
   ## If empty, default configuration below is used.
   name: ""
   # -- default value of Opentelemetry eBPF Instrumentation configuration
+  # Supports Go template expressions (e.g. {{ .Release.Name }}). BREAKING: values that contain
+  # literal {{ }} are now interpreted as template expressions. Escape them as {{` {{ }} `}}.
+  # Do not use non-idempotent functions (e.g. randAlphaNum) — config.data is rendered
+  # separately for the ConfigMap and the DaemonSet checksum/config annotation.
   data:
     # profile_port: 6060
     # open_port: 8443
@@ -221,8 +225,9 @@ config:
         k8s_src_owner_name:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
     ## to enable network metrics
-    # network:
-    #   enable: true
+    # metrics:
+    #   features:
+    #     - network
     prometheus_export:
       port: 9090
       path: /metrics


### PR DESCRIPTION
#### Description
1. The chart now has all the stuff mentioned in [opentelemetry.io](https://opentelemetry.io/docs/zero-code/obi/distributed-traces/#kubernetes-configuration) as needed (NET_ADMIN when not privileged & mount /sys/fs/cgroup when network feature is in use).

2. The config now allows for templating (tpl) similarly to how it is in the otel collector chart.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
