### PR TITLE
feat(opentelemetry-collector): migrate default service.telemetry.resource to attributes array

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.159.1
+version: 0.160.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/UPGRADING.md
+++ b/charts/opentelemetry-collector/UPGRADING.md
@@ -4,6 +4,24 @@ These upgrade guidelines only contain instructions for version upgrades which re
 If the version you want to upgrade to is not listed here, then there is nothing to do for you.
 Just upgrade and enjoy.
 
+## 0.159.1 to 0.160.0
+
+The default `config.service.telemetry.resource` now uses the Collector's `resource.attributes` array format instead of the deprecated inline map. This clears the deprecation warning the Collector logs on startup (appVersion 0.153.0+).
+
+If you override `config.service.telemetry.resource` in your `values.yaml` using the legacy inline map (for example `k8s.namespace.name: "..."`), migrate it to the array form:
+
+```yaml
+config:
+  service:
+    telemetry:
+      resource:
+        attributes:
+          - name: k8s.namespace.name
+            value: "${env:OTEL_K8S_NAMESPACE}"
+```
+
+The legacy inline map cannot be combined with `attributes`; the Collector rejects a `resource` block that contains both.
+
 ## 0.157.0 to 0.157.1
 
 The OpenTelemetry Collector renamed the `k8sattributes` processor to `k8s_attributes` in v0.146.0. The old name still works as an alias but is deprecated.

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3efecfb6fe0bc8addf535eec06e24fb381077eba4fe3291b4fc898e7dd72feb1
+        checksum/config: 171bfbac7eb9560d7015c8d0e64ea74186e122da0bebc8f0b427670f17da9879
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 46b0b1adfa45c78a6de93a91da4e04aca8d2b38620edbadbf7c7049630cf241a
+        checksum/config: ff20e5d1a75553983f999b88007ff90e78cfb174484c897caf85c6a95c274c04
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -98,9 +98,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c17e8e154ed7429046a1bea770e4a267aeddc625a0b21c381801641c4b77d036
+        checksum/config: a87d3c45ec59d64f236b04e4f6dd7704c6b1744cb100c06b0046b6aa10680ae0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 46b0b1adfa45c78a6de93a91da4e04aca8d2b38620edbadbf7c7049630cf241a
+        checksum/config: ff20e5d1a75553983f999b88007ff90e78cfb174484c897caf85c6a95c274c04
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -109,9 +109,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 76c784eae625bac63decf83e3420cea39f1c2a41fd2fb5f33851b91995fbd759
+        checksum/config: fb72dfb5e8eb9c3d30f9b5ff506948de15200c73fb2d1789a5e50609bf6706f5
         io.opentelemetry.discovery.logs/enabled: "false"
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -100,9 +100,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7a506ad806824335ca14c263a3e38029d4304449aefb819e4cc74e805e46376
+        checksum/config: 58609ca973f124fe14990b855632bdcf6912dd7bf7f240464b083b35d082de16
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -105,9 +105,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 49fa0b0bfa7b0a76f9f2f780f2b19bc4e78502b97fa4caf8017e53f6524a8b79
+        checksum/config: 1e899fec8a4c80a4b4f17954e73a8d408c195ea78d535bde8d1e3a34acb567e5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -138,9 +138,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 797d69c2801ff4d2b60173e6292e0817890ea3566f7df8656b6b8428b248ca39
+        checksum/config: 68cc7f22dd658e6bc3472587e6a30ebe9924de3717694b358a6e959bfd429117
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -162,9 +162,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 041f0edf6111610c4c7113f4b7f933fc60d50ccde3a6f928900663de358858b4
+        checksum/config: a14069551ade253519b09deb040128c202e23cd30185d9c1497e28effc576367
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 681aff5a601d80a28d2981cd78c24cf9f277504b77b55c5707635d18d43078e9
+        checksum/config: be3dcba5b98c05967dc451d64cc6c7a1945138bb421e722212415f33e2fe56a7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 681aff5a601d80a28d2981cd78c24cf9f277504b77b55c5707635d18d43078e9
+        checksum/config: be3dcba5b98c05967dc451d64cc6c7a1945138bb421e722212415f33e2fe56a7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -104,9 +104,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e459ac1f661adac63d1680d08b345ba7a02c9e24e0a4c30ef70268588364022b
+        checksum/config: 80a57a057646222a4d0a2bb6a850c44f3ca9b05752a798aab6e1340f1959786c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -94,9 +94,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f3adfc58d2d2e00908623b019a9cfc6d81a4df20de2c47d3df8555cb0eaff04a
+        checksum/config: 9f965fd98a3a8710de3554deb359689b3236db044f59fbc50a36f40f2dc8f4fb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 46b0b1adfa45c78a6de93a91da4e04aca8d2b38620edbadbf7c7049630cf241a
+        checksum/config: ff20e5d1a75553983f999b88007ff90e78cfb174484c897caf85c6a95c274c04
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -54,9 +54,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1eb898ae1238f23d5d5b472ce6841a5f61f5dac7c4df167af98b0a1ad9dca65e
+        checksum/config: 861be049fca738db10664fa7673f4012ba2c5bef9115bac41cd2e91e4fa53ac3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -89,12 +89,19 @@ data:
                   endpoint: http://localhost:4318
                   protocol: http/protobuf
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}
         traces:
           processors:
           - batch:

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 785695f04137d86fee64ae7672b8cb7823a08b453e873fc1824b4c7b7d6983d5
+        checksum/config: e450f0204284d8961b6c9b02bf972f73845e89f2b7fe97144d069a226dfafc43
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -131,9 +131,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 74f741b0f3259e53dae3e2678f0b447d68849f6369a0adc23ca822cfd42f795c
+        checksum/config: 79e7530430f03a01775fb33be0e7d16e678e441029e77f8d1d80fdb0b2d2d5ca
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -99,9 +99,16 @@ data:
                     - k8s.pod.ip
                     - k8s.pod.name
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e11f5f1d93d8974b0417e04eb0bfe207b0f5e07f4aaf0842b2c14bcfe8ba57d0
+        checksum/config: 2fe790e272e4089ad12c4d8f148c04cb5281a3512ae8912f2e63dad6348a0d7f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-env-values/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -92,16 +92,8 @@ data:
                   port: 8888
                   with_resource_constant_labels:
                     included:
-                    - host.name
                     - k8s.namespace.name
-                    - k8s.node.ip
-                    - k8s.node.name
-                    - k8s.pod.ip
-                    - k8s.pod.name
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: default
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: default

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9e47c8a8cbe15db6794ce3f19f52305fa15e8cfbc7e8758e2c634e74959983c4
+        checksum/config: 11dcb71f26cb34540fd6f2eb2aee2e3c5bd88ce0cfcbb6ed75db51918368ddc9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/old-metrics-url-values/values.yaml
+++ b/charts/opentelemetry-collector/examples/old-metrics-url-values/values.yaml
@@ -14,4 +14,6 @@ config:
       metrics:
         address: example.com:8888
       resource:
-        "k8s.namespace.name": "default"
+        attributes:
+          - name: k8s.namespace.name
+            value: "default"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0fd60be56ea82d4d04e55f191337f4c8e9e44fa4840efec92f016fc7e059f189
+        checksum/config: 6e91271f687d9d7c365f22e26370511c172bf4f79554689813683d0371957aef
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0fd60be56ea82d4d04e55f191337f4c8e9e44fa4840efec92f016fc7e059f189
+        checksum/config: 6e91271f687d9d7c365f22e26370511c172bf4f79554689813683d0371957aef
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 46b0b1adfa45c78a6de93a91da4e04aca8d2b38620edbadbf7c7049630cf241a
+        checksum/config: ff20e5d1a75553983f999b88007ff90e78cfb174484c897caf85c6a95c274c04
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -91,9 +91,16 @@ data:
                   host: ${env:MY_POD_IP}
                   port: 8888
         resource:
-          host.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.namespace.name: ${env:OTEL_K8S_NAMESPACE}
-          k8s.node.ip: ${env:OTEL_K8S_NODE_IP}
-          k8s.node.name: ${env:OTEL_K8S_NODE_NAME}
-          k8s.pod.ip: ${env:OTEL_K8S_POD_IP}
-          k8s.pod.name: ${env:OTEL_K8S_POD_NAME}
+          attributes:
+          - name: k8s.namespace.name
+            value: ${env:OTEL_K8S_NAMESPACE}
+          - name: k8s.node.name
+            value: ${env:OTEL_K8S_NODE_NAME}
+          - name: k8s.node.ip
+            value: ${env:OTEL_K8S_NODE_IP}
+          - name: k8s.pod.name
+            value: ${env:OTEL_K8S_POD_NAME}
+          - name: k8s.pod.ip
+            value: ${env:OTEL_K8S_POD_IP}
+          - name: host.name
+            value: ${env:OTEL_K8S_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 46b0b1adfa45c78a6de93a91da4e04aca8d2b38620edbadbf7c7049630cf241a
+        checksum/config: ff20e5d1a75553983f999b88007ff90e78cfb174484c897caf85c6a95c274c04
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.159.0
+    helm.sh/chart: opentelemetry-collector-0.160.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -34,10 +34,14 @@ metrics:
           prometheus:
             host: {{ .address._0 | replace "{env!" "{env:" }}
             port: {{ .address._1 }}
-            {{- if .Values.config.service.telemetry.resource }}
+            {{- if .Values.config.service.telemetry.resource.attributes }}
             with_resource_constant_labels:
               included:
-              {{- range (keys .Values.config.service.telemetry.resource | sortAlpha) }}
+              {{- $names := list }}
+              {{- range .Values.config.service.telemetry.resource.attributes }}
+              {{- $names = append $names .name }}
+              {{- end }}
+              {{- range ($names | sortAlpha) }}
               - {{ println . }}
               {{- end }}
             {{- end }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -251,12 +251,19 @@ config:
   service:
     telemetry:
       resource:
-        k8s.namespace.name: "${env:OTEL_K8S_NAMESPACE}"
-        k8s.node.name: "${env:OTEL_K8S_NODE_NAME}"
-        k8s.node.ip: "${env:OTEL_K8S_NODE_IP}"
-        k8s.pod.name: "${env:OTEL_K8S_POD_NAME}"
-        k8s.pod.ip: "${env:OTEL_K8S_POD_IP}"
-        host.name: "${env:OTEL_K8S_NODE_NAME}"
+        attributes:
+          - name: k8s.namespace.name
+            value: "${env:OTEL_K8S_NAMESPACE}"
+          - name: k8s.node.name
+            value: "${env:OTEL_K8S_NODE_NAME}"
+          - name: k8s.node.ip
+            value: "${env:OTEL_K8S_NODE_IP}"
+          - name: k8s.pod.name
+            value: "${env:OTEL_K8S_POD_NAME}"
+          - name: k8s.pod.ip
+            value: "${env:OTEL_K8S_POD_IP}"
+          - name: host.name
+            value: "${env:OTEL_K8S_NODE_NAME}"
       metrics:
         readers:
           - pull:


### PR DESCRIPTION
#### Description

The collector chart's default `config.service.telemetry.resource` uses the legacy inline-map form. Since Collector appVersion 0.153.0 this form is deprecated, so the Collector logs a deprecation warning on every startup.

This migrates the default to the supported `resource.attributes` array form (`- name: ... value: ...`), which clears the warning. Because each attribute's `type` defaults to `string`, the values are explicitly string-typed, so this also removes the all-numeric node-name int-coercion problem tracked in #2250 without needing `!!str` tags.

Changes:
- `values.yaml`: `service.telemetry.resource` map -> `resource.attributes` array.
- `templates/_config.tpl`: build `with_resource_constant_labels.included` from `resource.attributes[].name`; the list is still alpha-sorted, so rendered output for that block is unchanged.
- `Chart.yaml`: 0.159.0 -> 0.160.0.
- `UPGRADING.md`: note for users who override `service.telemetry.resource` with the legacy map (it cannot be combined with `attributes`).
- Regenerated examples via `make generate-examples`. One example (`old-metrics-url-values`) that overrode the resource block was migrated to the array form too.

This supersedes #2273, which addressed #2250 on the same `values.yaml` block via `!!str` tags.

#### Link to tracking issue
Fixes #2255
Closes #2250


