### PR TITLE
[opentelemetry-collector] Add unprivileged and additionalCapabilities setting to profiling preset

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.166.0
+version: 0.167.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7caf8d27ea6b5122b54df84efee8e52657ba1c67e300c29bb73613e4f85d8da5
+        checksum/config: fda994e20cc890963e7dd15b2e011f85d7c52749ee8a917a11575c23b040ec43
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d0ac2dc6adb1aede512bfe22b0d04aa4d982b760dd5c7c87e0538dad7d42e6c
+        checksum/config: bd764e2dc14c1762e25bb3f76ef752ce64a619fbc8109e4a2084d566b13534e8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 96835730253319fa456c1743e525e9ac8b6c79896522c60448fbf89e5962fd7c
+        checksum/config: 2f36d0a85de9991e4a57ec5b1618a3e4c57a9517beb4a625253962a19be66f6a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d0ac2dc6adb1aede512bfe22b0d04aa4d982b760dd5c7c87e0538dad7d42e6c
+        checksum/config: bd764e2dc14c1762e25bb3f76ef752ce64a619fbc8109e4a2084d566b13534e8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f4ab2634d4eb0b7049a9bfc66cc2ec426d12f39dadd4eb1fad1b346627ac739e
+        checksum/config: 01f69935229089a02c432981ea0523fed2c8ffbf829c622fab67a14946a32b8b
         io.opentelemetry.discovery.logs/enabled: "false"
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 09503affe6894cbada69315e9faf9399a6984421d643bb8ea4f22f9d17641d0c
+        checksum/config: 9eaee6cda94935d0e5fc1e2fd0a11ac3dff4914abceba0d316771bc116508e44
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d1db101441f5b180cbf7c72d77374c161d0fe99ec2ae0cba4efcfa20aff8ea03
+        checksum/config: 36ab0811ca5173ddad7197b442815f591dfb3761aac930353ca420fbfc86d4b2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: eb1a745903748d4de9264b9089aaf651251c795f7175dbc0eb0c47364c82d259
+        checksum/config: c36caf8727213f8b6f8e1ef8663add1975db51d9336c4417ff9a1931fc763241
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7cbda1eb6945c08f3bd19947586c98c54ba24daa2c4822fcadd6005060b7b90d
+        checksum/config: 0c107baf148b0ce6bc4fd159cc7a93838a8b45378bc7172de3b3fe512a4ffa7a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e0ed386fae08bc400ee8cbf5ad3c6e474dfe79dc190fa03d54da463ee830d81
+        checksum/config: 8b092d4b9d1b265ae8e8d32580b661f9eca0029f90b3cf3dba0abeebf476bae6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e0ed386fae08bc400ee8cbf5ad3c6e474dfe79dc190fa03d54da463ee830d81
+        checksum/config: 8b092d4b9d1b265ae8e8d32580b661f9eca0029f90b3cf3dba0abeebf476bae6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9134b247cab1795e97d515e8e10847482352b1a93d5b6815df16bc6af43d42b6
+        checksum/config: 55a4e2c0cfd094b936a9ccdfce74d250c4ad38976cfecc0b437ede9ae4d18860
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2fc497d6fadae2a7f6ded653d28b067d14afc990c1cb851de1779fb1b6c8c290
+        checksum/config: 409d8203ef894ca28ca2467c5d0dde8dd74b4d019785a3136afbc0d0207d615b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d0ac2dc6adb1aede512bfe22b0d04aa4d982b760dd5c7c87e0538dad7d42e6c
+        checksum/config: bd764e2dc14c1762e25bb3f76ef752ce64a619fbc8109e4a2084d566b13534e8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a0487da622657e6812b83fd3067990106166852d3eda0f299f68bf94e705d272
+        checksum/config: e9b969683e8d8e7afdbb4f02f12be7915071c290af1f84ddcf6250be28cf6feb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 67f9c3b16425cef0fa45af14dfd56b4133274f6bad508408833878a78eb4e6c2
+        checksum/config: bb396c8dc6c452beef70b5e64038e7d07c558608838ad30af6486138a31a5927
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a53a1a70a867ffb4d2266d7921cbb1b5bf5dcd3e689276bccbe81cd58e9373f5
+        checksum/config: b455d19b5b3945bc29aa3519d31242a890ce130a95355e9bf6c21273039de118
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 17767a96c12ce16b2f0ef85ddd6fe9e2212ebf32dbfeb17895fefcb63e75c4a6
+        checksum/config: c335fe2b7bf139989ac811687ac0d51d19b26dcc7c8aa334c3b9675fcbf09d9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 17767a96c12ce16b2f0ef85ddd6fe9e2212ebf32dbfeb17895fefcb63e75c4a6
+        checksum/config: c335fe2b7bf139989ac811687ac0d51d19b26dcc7c8aa334c3b9675fcbf09d9d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d0ac2dc6adb1aede512bfe22b0d04aa4d982b760dd5c7c87e0538dad7d42e6c
+        checksum/config: bd764e2dc14c1762e25bb3f76ef752ce64a619fbc8109e4a2084d566b13534e8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d0ac2dc6adb1aede512bfe22b0d04aa4d982b760dd5c7c87e0538dad7d42e6c
+        checksum/config: bd764e2dc14c1762e25bb3f76ef752ce64a619fbc8109e4a2084d566b13534e8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.166.0
+    helm.sh/chart: opentelemetry-collector-0.167.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.157.0"

--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -14,7 +14,7 @@
 {{ fail "[ERROR] presets.profiling is enabled but podSecurityContext.runAsNonRoot is true. The eBPF profiler requires runAsUser: 0 to run. Set podSecurityContext.runAsNonRoot to false or remove it." }}
 {{ end }}
 {{- if .Values.securityContext }}
-[WARNING] presets.profiling is enabled with a custom securityContext. The preset will NOT inject runAsUser: 0 and privileged: true automatically; required by the eBPF profiler to function. Ensure your securityContext sets runAsUser: 0 plus either privileged: true, or right capabilities otherwise.
+[WARNING] presets.profiling is enabled with a custom securityContext. The preset will NOT inject runAsUser: 0 and capabilities automatically; required by the eBPF profiler to function. Ensure your securityContext sets runAsUser: 0 plus the right capabilities (BPF, PERFMON, SYS_PTRACE, SYS_RESOURCE, DAC_READ_SEARCH, SYSLOG, CHECKPOINT_RESTORE, IPC_LOCK) otherwise.
 {{ end }}
 {{ end }}
 

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -112,6 +112,9 @@ Create the name of the clusterRoleBinding to use
 {{- if .Values.podAnnotations }}
 {{- tpl (.Values.podAnnotations | toYaml) . }}
 {{- end }}
+{{- if and (not .Values.securityContext) .Values.presets.profiling.enabled (semverCompare "< 1.30-0" .Capabilities.KubeVersion.Version) }}
+container.apparmor.security.beta.kubernetes.io/{{ include "opentelemetry-collector.lowercase_chartname" . }}: unconfined
+{{- end }}
 {{- end }}
 
 {{- define "opentelemetry-collector.podLabels" -}}

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -28,18 +28,14 @@ containers:
       - {{ . }}
       {{- end }}
     securityContext:
-      {{- if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) (.Values.presets.profiling.unprivileged) }}
+      {{- if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) }}
       runAsUser: 0
       runAsGroup: 0
       privileged: false
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
-        add: {{ concat (list "BPF" "PERFMON" "SYS_PTRACE" "SYS_RESOURCE" "DAC_READ_SEARCH" "SYSLOG" "CHECKPOINT_RESTORE" "IPC_LOCK") .Values.presets.profiling.additionalCapabilities | toJson }}
-      {{- else if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) }}
-      runAsUser: 0
-      runAsGroup: 0
-      privileged: true
+        add: ["BPF", "PERFMON", "SYS_PTRACE", "SYS_RESOURCE", "DAC_READ_SEARCH", "SYSLOG", "CHECKPOINT_RESTORE", "IPC_LOCK"]
       {{- else if and (not (.Values.securityContext)) (.Values.presets.logsCollection.storeCheckpoints) }}
       runAsUser: 0
       runAsGroup: 0

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -28,7 +28,15 @@ containers:
       - {{ . }}
       {{- end }}
     securityContext:
-      {{- if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) }}
+      {{- if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) (.Values.presets.profiling.unprivileged) }}
+      runAsUser: 0
+      runAsGroup: 0
+      privileged: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+        add: {{ concat (list "BPF" "PERFMON" "SYS_PTRACE" "SYS_RESOURCE" "DAC_READ_SEARCH" "SYSLOG" "CHECKPOINT_RESTORE" "IPC_LOCK") .Values.presets.profiling.additionalCapabilities | toJson }}
+      {{- else if and (not (.Values.securityContext)) (.Values.presets.profiling.enabled) }}
       runAsUser: 0
       runAsGroup: 0
       privileged: true

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -39,6 +39,8 @@ containers:
       appArmorProfile:
         type: Unconfined
       {{- end }}
+      seLinuxOptions:
+        type: spc_t
       capabilities:
         drop: [ALL]
         add: ["BPF", "PERFMON", "SYS_PTRACE", "SYS_RESOURCE", "DAC_READ_SEARCH", "SYSLOG", "CHECKPOINT_RESTORE", "IPC_LOCK"]

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -33,6 +33,12 @@ containers:
       runAsGroup: 0
       privileged: false
       allowPrivilegeEscalation: false
+      seccompProfile:
+        type: Unconfined
+      {{- if semverCompare ">= 1.30-0" .Capabilities.KubeVersion.Version }}
+      appArmorProfile:
+        type: Unconfined
+      {{- end }}
       capabilities:
         drop: [ALL]
         add: ["BPF", "PERFMON", "SYS_PTRACE", "SYS_RESOURCE", "DAC_READ_SEARCH", "SYSLOG", "CHECKPOINT_RESTORE", "IPC_LOCK"]

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -333,17 +333,6 @@
             "enabled": {
               "description": "Specifies whether the collector should collect profiling data.",
               "type": "boolean"
-            },
-            "unprivileged": {
-              "description": "Run unprivileged with a minimal capability set instead of privileged: true.",
-              "type": "boolean"
-            },
-            "additionalCapabilities": {
-              "description": "Extra capabilities to add when unprivileged, for additional components in the pipeline.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
             }
           }
         }

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -333,6 +333,17 @@
             "enabled": {
               "description": "Specifies whether the collector should collect profiling data.",
               "type": "boolean"
+            },
+            "unprivileged": {
+              "description": "Run unprivileged with a minimal capability set instead of privileged: true.",
+              "type": "boolean"
+            },
+            "additionalCapabilities": {
+              "description": "Extra capabilities to add when unprivileged, for additional components in the pipeline.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -138,6 +138,10 @@ presets:
   # See https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler for more details.
   profiling:
     enabled: false
+    # Run unprivileged with a minimal capability set instead of privileged: true.
+    unprivileged: false
+    # Extra capabilities to add when unprivileged, for additional components in the pipeline.
+    additionalCapabilities: []
 
   # Configures the collector to detect resource attributes using the resourcedetection processor.
   # Adds the resourcedetection/env processor to all pipelines.

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -131,17 +131,13 @@ presets:
   # Adds profiles pipeline with the profiling receiver,
   # and adds the necessary volumes, security context and host PID access.
   #
-  # Warning: The profiling receiver requires privileged access and hostPID,
+  # Warning: The profiling receiver requires elevated capabilities and hostPID,
   # so it should be used with a dedicated collector distribution (e.g. otelcol-ebpf-profiler)
   # rather than the general-purpose k8s distribution. This avoids granting elevated privileges
   # to the same collector that handles metrics, traces, and logs.
   # See https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler for more details.
   profiling:
     enabled: false
-    # Run unprivileged with a minimal capability set instead of privileged: true.
-    unprivileged: false
-    # Extra capabilities to add when unprivileged, for additional components in the pipeline.
-    additionalCapabilities: []
 
   # Configures the collector to detect resource attributes using the resourcedetection processor.
   # Adds the resourcedetection/env processor to all pipelines.


### PR DESCRIPTION
#### Description

The helm charts with the profiling preset run a collector with `privileged: true` which could make this instance a
high risk target for pod compromise.

The profiler can run unprivileged with a small set of capabilities instead of full privilege.
Today, the only way to run unprivileged is to write a complete `securityContext` block.

This PR replaces `privileged: true` with a minimal capability set based on the [current profiler's minimum kernel version `5.10`](https://github.com/open-telemetry/opentelemetry-ebpf-profiler#supported-linux-kernel-version).

##### Capabilities

- `BPF`, `PERFMON`: load eBPF programs / perf_event_open
- `SYS_PTRACE`, `DAC_READ_SEARCH`, `CHECKPOINT_RESTORE`: read process memory and open memory-mapped files
- `SYSLOG`: kernel ring buffer
- `IPC_LOCK`, `SYS_RESOURCE`: locked memory for eBPF maps / raise rlimits

When the `profiling` preset is enabled and no custom `securityContext` is set, the following values are applied:

```yaml
runAsUser: 0
runAsGroup: 0
privileged: false
allowPrivilegeEscalation: false
seccompProfile:
  type: Unconfined
appArmorProfile: # set as annotation on Kubernetes < 1.30
  type: Unconfined
capabilities:
  drop: [ALL]
  add: [BPF, PERFMON, SYS_PTRACE, SYS_RESOURCE, DAC_READ_SEARCH, SYSLOG, CHECKPOINT_RESTORE, IPC_LOCK]
```
For collectors running additional components that could require any other capabilities, they can still write a fully custom `securityContext`

##### Validating

The Datadog eBPF profiler distribution has been running unprivileged under this capability set for some time across different node sizes and kernel versions. The distribution uses the following components:
- `k8s_attributes` configured by the `profiling` and `kubernetesAttributes` (with `extractAllPodLabels`) templates
- `otlp_http` exporter
- `resource_detection` with the `system` detector
- `prometheus` receiver for collector self-telemetry metrics
- custom processor to retrieve specific Datadog node hostnames

The set was also tested using `opentelemetry-collector-ebpf-profiler 0.155.0` on ubuntu 24.04.4 and 26.04 (arm64/amd64) and with all the available components in the image individually.
Only the `batch` component did not work with error `telemetry type is not supported`, so unrelated to this.

Happy to discuss if the direction doesn't sound right or if there are more validation steps to take!

#### Authorship

- [x] I, a human, wrote this pull request description myself.