### PR TITLE
[opentelemetry-kube-stack] Replace daemon collector resource detection `env` &`k8snode` detectors with `env` & `k8s_api` presets

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.19.0
+version: 0.19.1
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.19.1
+version: 0.20.0
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -102,10 +102,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -101,7 +101,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/clusterrole.yaml
@@ -51,6 +51,14 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
+
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -34,10 +34,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -33,7 +33,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/clusterrole.yaml
@@ -51,6 +51,14 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
+
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -34,10 +34,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -33,7 +33,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
@@ -51,6 +51,14 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
+
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -34,10 +34,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -33,7 +33,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
@@ -65,6 +65,13 @@ rules:
   resources:
   - leases
 - apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
+- apiGroups: [""]
   resources: ["namespaces", "pods", "nodes", "services", "serviceaccounts"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -93,10 +93,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -92,7 +92,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/clusterrole.yaml
@@ -51,6 +51,14 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
+
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -29,7 +29,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -30,10 +30,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -97,10 +97,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -96,7 +96,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -88,6 +88,14 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
+      resourcedetection/env:
+        detectors:
+        - env
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
     receivers:
       filelog:
         exclude:
@@ -232,7 +240,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -257,6 +265,14 @@ spec:
         - action: insert
           key: k8s.cluster.name
           value: 'demo'
+      resourcedetection/env:
+        detectors:
+        - env
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
     receivers:
       otlp:
         protocols:
@@ -365,7 +381,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -387,6 +403,15 @@ spec:
       oidc:
         audience: 12345678-1234-5678-1234-567812345678
         issuer_url: https://login.microsoftonline.com/87654321-8765-4321-8765-432187654321/v2.0
+    processors:
+      resourcedetection/env:
+        detectors:
+        - env
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
     receivers:
       otlp:
         protocols:

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -88,14 +88,6 @@ spec:
             name: k8s.namespace.name
         - sources:
           - from: connection
-      resourcedetection/env:
-        detectors:
-        - env
-        - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
     receivers:
       filelog:
         exclude:
@@ -265,14 +257,6 @@ spec:
         - action: insert
           key: k8s.cluster.name
           value: 'demo'
-      resourcedetection/env:
-        detectors:
-        - env
-        - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
     receivers:
       otlp:
         protocols:
@@ -403,15 +387,6 @@ spec:
       oidc:
         audience: 12345678-1234-5678-1234-567812345678
         issuer_url: https://login.microsoftonline.com/87654321-8765-4321-8765-432187654321/v2.0
-    processors:
-      resourcedetection/env:
-        detectors:
-        - env
-        - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
     receivers:
       otlp:
         protocols:

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/clusterrole.yaml
@@ -111,6 +111,13 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -255,10 +255,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -80,11 +80,6 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -80,6 +80,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:
@@ -173,7 +178,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -254,7 +259,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/clusterrole.yaml
@@ -51,6 +51,14 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
+
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
@@ -34,7 +34,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -35,10 +35,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 ---
 # Source: opentelemetry-kube-stack/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -97,10 +97,6 @@ spec:
         detectors:
         - env
         - k8s_api
-        k8s_api:
-          resource_attributes:
-            k8s.cluster.uid:
-              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.0
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.0
+    helm.sh/chart: opentelemetry-kube-stack-0.19.1
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -96,7 +96,11 @@ spec:
       resourcedetection/env:
         detectors:
         - env
-        - k8snode
+        - k8s_api
+        k8s_api:
+          resource_attributes:
+            k8s.cluster.uid:
+              enabled: true
         override: false
         timeout: 2s
     receivers:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.0"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.0"

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -639,8 +639,6 @@ receivers:
 {{- end }}
 
 {{- if .collector.presets.resourceDetection.k8sApi.enabled }}
-{{- $k8sApiResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionK8sApiDetectorConfig" . | fromYaml }}
-{{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $k8sApiResourceDetectionProcessor }}
 {{- $detectors = append $detectors "k8s_api" | uniq }}
 {{- end }}
 {{- $_ := set $resourceDetectionProcessor "detectors" $detectors }}
@@ -670,13 +668,6 @@ aks:
 gcp:
   resource_attributes:
     k8s.cluster.name:
-      enabled: true
-{{- end -}}
-
-{{- define "opentelemetry-kube-stack.collector.resourceDetectionK8sApiDetectorConfig" -}}
-k8s_api:
-  resource_attributes:
-    k8s.cluster.uid:
       enabled: true
 {{- end -}}
 

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -71,7 +71,7 @@ target allocator has a receiver to populate.
 {{- $config = (include "opentelemetry-kube-stack.collector.applyClusterMetricsConfig" (dict "collector" $collector "namespace" .namespace) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if or .collector.presets.resourceDetection.eks.enabled .collector.presets.resourceDetection.aks.enabled .collector.presets.resourceDetection.gcp.enabled }}
+{{- if or .collector.presets.resourceDetection.env.enabled .collector.presets.resourceDetection.eks.enabled .collector.presets.resourceDetection.aks.enabled .collector.presets.resourceDetection.gcp.enabled .collector.presets.resourceDetection.k8sApi.enabled }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyResourceDetectionConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
@@ -616,6 +616,10 @@ receivers:
 {{- $resourceDetectionProcessor := get $processors "resourcedetection/env" | default dict }}
 {{- $detectors := get $resourceDetectionProcessor "detectors" | default list }}
 
+{{- if .collector.presets.resourceDetection.env.enabled }}
+{{- $detectors = append $detectors "env" | uniq }}
+{{- end }}
+
 {{- if .collector.presets.resourceDetection.aks.enabled }}
 {{- $aksResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionAksDetectorConfig" . | fromYaml }}
 {{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $aksResourceDetectionProcessor }}
@@ -632,6 +636,12 @@ receivers:
 {{- $gcpResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionGcpDetectorConfig" . | fromYaml }}
 {{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $gcpResourceDetectionProcessor }}
 {{- $detectors = append $detectors "gcp" | uniq }}
+{{- end }}
+
+{{- if .collector.presets.resourceDetection.k8sApi.enabled }}
+{{- $k8sApiResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionK8sApiDetectorConfig" . | fromYaml }}
+{{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $k8sApiResourceDetectionProcessor }}
+{{- $detectors = append $detectors "k8s_api" | uniq }}
 {{- end }}
 {{- $_ := set $resourceDetectionProcessor "detectors" $detectors }}
 
@@ -660,6 +670,13 @@ aks:
 gcp:
   resource_attributes:
     k8s.cluster.name:
+      enabled: true
+{{- end -}}
+
+{{- define "opentelemetry-kube-stack.collector.resourceDetectionK8sApiDetectorConfig" -}}
+k8s_api:
+  resource_attributes:
+    k8s.cluster.uid:
       enabled: true
 {{- end -}}
 

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -125,7 +125,7 @@ target allocator has a receiver to populate.
 {{- $config = (include "opentelemetry-kube-stack.collector.applyClusterMetricsConfig" (dict "collector" $collector "namespace" .namespace) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if or .collector.presets.resourceDetection.env.enabled .collector.presets.resourceDetection.eks.enabled .collector.presets.resourceDetection.aks.enabled .collector.presets.resourceDetection.gcp.enabled .collector.presets.resourceDetection.k8sApi.enabled }}
+{{- if or .collector.presets.resourceDetection.env.enabled .collector.presets.resourceDetection.eks.enabled .collector.presets.resourceDetection.aks.enabled .collector.presets.resourceDetection.gcp.enabled .collector.presets.resourceDetection.k8s_api.enabled }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyResourceDetectionConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
@@ -703,7 +703,7 @@ receivers:
 {{- $detectors = append $detectors "gcp" | uniq }}
 {{- end }}
 
-{{- if .collector.presets.resourceDetection.k8sApi.enabled }}
+{{- if .collector.presets.resourceDetection.k8s_api.enabled }}
 {{- $detectors = append $detectors "k8s_api" | uniq }}
 {{- end }}
 {{- $_ := set $resourceDetectionProcessor "detectors" $detectors }}

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -204,7 +204,7 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $kubernetesObjectsApiExtensionsEnabled = (any $kubernetesObjectsApiExtensionsEnabled (dig "presets" "kubernetesObjects" "apiExtensions" "enabled" true $collector)) }}
 {{- $useLeaderElection = (any $useLeaderElection (and (eq $collector.mode "daemonset") (not (dig "presets" "kubernetesObjects" "disableLeaderElection" false $collector)))) }}
 {{- end }}
-{{- if (dig "presets" "resourceDetection" "k8sApi" "enabled" false $collector) }}
+{{- if (dig "presets" "resourceDetection" "k8s_api" "enabled" false $collector) }}
 {{- $k8sApiEnabled = true }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -177,6 +177,7 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $kubernetesObjectsPolicyEnabled := false }}
 {{- $kubernetesObjectsApiExtensionsEnabled := false }}
 {{- $useLeaderElection := false }}
+{{- $k8sApiEnabled := false }}
 {{ range $_, $collector := $.Values.collectors -}}
 {{- if $.Values.defaultCRConfig.enabled }}
 {{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
@@ -202,6 +203,9 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $kubernetesObjectsPolicyEnabled = (any $kubernetesObjectsPolicyEnabled (dig "presets" "kubernetesObjects" "policy" "enabled" true $collector)) }}
 {{- $kubernetesObjectsApiExtensionsEnabled = (any $kubernetesObjectsApiExtensionsEnabled (dig "presets" "kubernetesObjects" "apiExtensions" "enabled" true $collector)) }}
 {{- $useLeaderElection = (any $useLeaderElection (and (eq $collector.mode "daemonset") (not (dig "presets" "kubernetesObjects" "disableLeaderElection" false $collector)))) }}
+{{- end }}
+{{- if (dig "presets" "resourceDetection" "k8sApi" "enabled" false $collector) }}
+{{- $k8sApiEnabled = true }}
 {{- end }}
 {{- end }}
 {{- if $useLeaderElection }}
@@ -280,6 +284,15 @@ Optionally include the RBAC for the k8sCluster receiver
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["watch", "list"]
+{{- end }}
+{{- if $k8sApiEnabled }}
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
 {{- end }}
 {{- if $kubernetesObjectsEnabled }}
 {{- if $kubernetesObjectsCoreEnabled }}

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1655,7 +1655,7 @@
                     }
                   }
                 },
-                "k8sApi": {
+                "k8s_api": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1655,6 +1655,16 @@
                     }
                   }
                 },
+                "k8sApi": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Enables the k8s_api resource detector to detect k8s.cluster.uid, k8s.node.name and k8s.node.uid via the Kubernetes API. WARNING: the k8s.node.name and k8s.node.uid resolved are those of the collector's own node, so enabling this detector risks enriching telemetry that originates from a different node with the wrong k8s.node.name and k8s.node.uid, which is usually undesired.",
+                      "type": "boolean"
+                    }
+                  }
+                },
                 "eks": {
                   "type": "object",
                   "additionalProperties": false,
@@ -1681,16 +1691,6 @@
                   "properties": {
                     "enabled": {
                       "description": "Enables the GCP resource detector to detect k8s.cluster.name and GCP resource attributes.",
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "k8sApi": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "enabled": {
-                      "description": "Enables the k8s_api resource detector to detect k8s.cluster.uid, k8s.node.name and k8s.node.uid via the Kubernetes API.",
                       "type": "boolean"
                     }
                   }

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1643,8 +1643,18 @@
             "resourceDetection": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Configures resource detection processors. Each detector can be enabled individually. Base detectors 'env' and 'k8snode' are always included.",
+              "description": "Configures resource detection processors. Each detector can be enabled individually.",
               "properties": {
+                "env": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Enables the env resource detector to detect resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable. WARNING: this variable is set by the OpenTelemetry Operator to the collector pod's own resource attributes (e.g. k8s.pod.name, k8s.namespace.name), so enabling this detector risks injecting the collector's own identity into the telemetry it processes, which is usually undesired.",
+                      "type": "boolean"
+                    }
+                  }
+                },
                 "eks": {
                   "type": "object",
                   "additionalProperties": false,
@@ -1671,6 +1681,16 @@
                   "properties": {
                     "enabled": {
                       "description": "Enables the GCP resource detector to detect k8s.cluster.name and GCP resource attributes.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "k8sApi": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Enables the k8s_api resource detector to detect k8s.cluster.uid, k8s.node.name and k8s.node.uid via the Kubernetes API.",
                       "type": "boolean"
                     }
                   }

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -607,14 +607,24 @@ defaultCRConfig:
         # Scrape timeout, as a duration string accepted by Prometheus.
         scrapeTimeout: 10s
     resourceDetection:
-      # Each detector can be enabled individually. Base detectors 'env' and 'k8snode' are always included when any detector is enabled.
-      # Typically used to resolve the 'k8s.cluster.name' resource attribute.
+      # Each detector can be enabled individually.
+      # Detects resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable.
+      # WARNING: this variable is normally set by the OpenTelemetry Operator to the *collector
+      # pod's own* resource attributes (e.g. k8s.pod.name, k8s.namespace.name of the collector
+      # itself). Enabling this detector therefore risks injecting the collector's own identity
+      # into the resource attributes of the telemetry it processes, which is usually undesired.
+      env:
+        enabled: true
       eks:
         enabled: false
       aks:
         enabled: false
       gcp:
         enabled: false
+      # Detects k8s.cluster.uid, k8s.node.name and k8s.node.uid via the Kubernetes API.
+      # Typically used to resolve the 'k8s.cluster.name' / 'k8s.cluster.uid' resource attributes.
+      k8sApi:
+        enabled: true
 # Collectors is a map of collector configurations of the form:
 # collectors:
 #   collectorName:
@@ -671,12 +681,16 @@ collectors:
         podAnnotations:
           enabled: false
       resourceDetection:
+        env:
+          enabled: true
         aks:
           enabled: false
         gcp:
           enabled: false
         eks:
           enabled: false
+        k8sApi:
+          enabled: true
     config:
       receivers:
         otlp:
@@ -687,7 +701,6 @@ collectors:
               endpoint: 0.0.0.0:4318
       processors:
         resourcedetection/env:
-          detectors: [env, k8snode]
           timeout: 2s
           override: false
         resource/hostname:

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -615,7 +615,7 @@ defaultCRConfig:
     resourceDetection:
       env:
         enabled: false
-      k8sApi:
+      k8s_api:
         enabled: false
       eks:
         enabled: false
@@ -681,7 +681,7 @@ collectors:
       resourceDetection:
         env:
           enabled: true
-        k8sApi:
+        k8s_api:
           enabled: true
         aks:
           enabled: false

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -607,24 +607,16 @@ defaultCRConfig:
         # Scrape timeout, as a duration string accepted by Prometheus.
         scrapeTimeout: 10s
     resourceDetection:
-      # Each detector can be enabled individually.
-      # Detects resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable.
-      # WARNING: this variable is normally set by the OpenTelemetry Operator to the *collector
-      # pod's own* resource attributes (e.g. k8s.pod.name, k8s.namespace.name of the collector
-      # itself). Enabling this detector therefore risks injecting the collector's own identity
-      # into the resource attributes of the telemetry it processes, which is usually undesired.
       env:
         enabled: true
+      k8sApi:
+        enabled: false
       eks:
         enabled: false
       aks:
         enabled: false
       gcp:
         enabled: false
-      # Detects k8s.cluster.uid, k8s.node.name and k8s.node.uid via the Kubernetes API.
-      # Typically used to resolve the 'k8s.cluster.name' / 'k8s.cluster.uid' resource attributes.
-      k8sApi:
-        enabled: true
 # Collectors is a map of collector configurations of the form:
 # collectors:
 #   collectorName:
@@ -683,14 +675,14 @@ collectors:
       resourceDetection:
         env:
           enabled: true
+        k8sApi:
+          enabled: true
         aks:
           enabled: false
         gcp:
           enabled: false
         eks:
           enabled: false
-        k8sApi:
-          enabled: true
     config:
       receivers:
         otlp:

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -608,7 +608,7 @@ defaultCRConfig:
         scrapeTimeout: 10s
     resourceDetection:
       env:
-        enabled: true
+        enabled: false
       k8sApi:
         enabled: false
       eks:


### PR DESCRIPTION
#### Description

Replace the `k8snode` detector that has been deprecated with the [OTel Collector Contrib v0.154.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0) by the new `k8s_api` detector:
* Introduce presets `resourceDetection/k8sApi` and `resourceDetection/env`, default `false`
* Replace the manually defined `env` & `k8snode` detectors of the `daemon` collector pipeline config (in `values.yaml`) by activation of the new `resourcedetection/env` and `resourcedetection/k8sApi` presets 

Change can be reverted setting `presets/resourceDetection/k8sApi: false` & `presets/resourceDetection/env: false` and declaring `k8snode`  & `env` in the list of detectors of the `resourcedetection/env` processor of the `daemon` collector `values.yaml`.

This change includes the required `ClusterRole` rules (nodes: get/list, namespaces/kube-system: get) added conditionally when the preset is enabled.

Assisted-by: Claude Sonnet 5

#### Link to tracking issue

Fixes:
- https://github.com/open-telemetry/opentelemetry-helm-charts/issues/2268

#### Authorship

- [x] I, a human, wrote this pull request description myself.