### PR TITLE
Add contextpropagation option to OpenTelemetry eBPF instrumentation

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.10.0
+version: 0.11.0
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"
@@ -24,9 +24,9 @@ spec:
     metadata:
       annotations:
         checksum/config: cebc6cbd97dd4aeed2dfc128f33c47c60f2b30b543963f7ed5def3894ed2267e
-        
+
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cebc6cbd97dd4aeed2dfc128f33c47c60f2b30b543963f7ed5def3894ed2267e
+        checksum/config: 5de284a0f4491a570574ed506384174d68f8bb2309d6ec6c131ee1cfd9a17723
 
       labels:
         helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
@@ -37,6 +37,8 @@ spec:
       serviceAccountName: example-opentelemetry-ebpf-instrumentation
       hostPID: true
       initContainers:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: ebpf-instrument
           image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0
@@ -58,7 +60,19 @@ spec:
           volumeMounts:
             - mountPath: /etc/ebpf-instrument/config
               name: ebpf-instrument-config
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+              readOnly: true
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
       volumes:
         - name: ebpf-instrument-config
           configMap:
             name: example-opentelemetry-ebpf-instrumentation
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 5de284a0f4491a570574ed506384174d68f8bb2309d6ec6c131ee1cfd9a17723
-
+        
       labels:
         helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
@@ -36,9 +36,9 @@ spec:
     spec:
       serviceAccountName: example-opentelemetry-ebpf-instrumentation
       hostPID: true
-      initContainers:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
       containers:
         - name: ebpf-instrument
           image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"
@@ -24,9 +24,9 @@ spec:
     metadata:
       annotations:
         checksum/config: cebc6cbd97dd4aeed2dfc128f33c47c60f2b30b543963f7ed5def3894ed2267e
-        
+
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cebc6cbd97dd4aeed2dfc128f33c47c60f2b30b543963f7ed5def3894ed2267e
+        checksum/config: 5de284a0f4491a570574ed506384174d68f8bb2309d6ec6c131ee1cfd9a17723
 
       labels:
         helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
@@ -37,6 +37,8 @@ spec:
       serviceAccountName: example-opentelemetry-ebpf-instrumentation
       hostPID: true
       initContainers:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: ebpf-instrument
           image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0
@@ -60,7 +62,19 @@ spec:
           volumeMounts:
             - mountPath: /etc/ebpf-instrument/config
               name: ebpf-instrument-config
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+              readOnly: true
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
       volumes:
         - name: ebpf-instrument-config
           configMap:
             name: example-opentelemetry-ebpf-instrumentation
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 5de284a0f4491a570574ed506384174d68f8bb2309d6ec6c131ee1cfd9a17723
-
+        
       labels:
         helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
@@ -36,9 +36,9 @@ spec:
     spec:
       serviceAccountName: example-opentelemetry-ebpf-instrumentation
       hostPID: true
-      initContainers:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
       containers:
         - name: ebpf-instrument
           image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.10.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.11.0
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.10.0"

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
@@ -34,7 +34,8 @@ spec:
       hostPID: true
       {{- end }}
       {{- $networkEnabled := or (eq .Values.preset "network") .Values.config.data.network }}
-      {{- if $networkEnabled }}
+      {{- $contextPropagationEnabled := .Values.contextPropagation.enabled }}
+      {{- if or $networkEnabled $contextPropagationEnabled }}
       hostNetwork: true
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
@@ -62,7 +63,7 @@ spec:
                 - BPF
                 - SYS_PTRACE
                 - NET_RAW
-                {{- if $networkEnabled }}
+                {{- if or $networkEnabled $contextPropagationEnabled }}
                 - NET_ADMIN
                 {{- end }}
                 - CHECKPOINT_RESTORE
@@ -122,10 +123,14 @@ spec:
           volumeMounts:
             - mountPath: /etc/ebpf-instrument/config
               name: ebpf-instrument-config
-            {{- if $networkEnabled }}
+            {{- if or $networkEnabled $contextPropagationEnabled }}
             - mountPath: /sys/fs/cgroup
               name: cgroup
               readOnly: true
+            {{- end }}
+            {{- if $contextPropagationEnabled }}
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
             {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -150,11 +155,16 @@ spec:
         - name: ebpf-instrument-config
           configMap:
             name: {{ default (include "obi.fullname" .) .Values.config.name }}
-        {{- if $networkEnabled }}
+        {{- if or $networkEnabled $contextPropagationEnabled }}
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
             type: Directory
+        {{- end }}
+        {{- if $contextPropagationEnabled }}
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
         {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/opentelemetry-ebpf-instrumentation/values.schema.json
+++ b/charts/opentelemetry-ebpf-instrumentation/values.schema.json
@@ -245,6 +245,15 @@
       "description": "If set to false, deploys an unprivileged / less privileged setup",
       "default": true
     },
+    "contextPropagation": {
+      "type": "object",
+      "title": "Context Propagation",
+      "description": "SEnables context propagation support",
+      "additionalProperties": true,
+      "example": {
+        "enabled": true
+      }
+    },
     "extraCapabilities": {
       "type": "array",
       "title": "Extra Capabilities",

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -59,10 +59,15 @@ podSecurityContext: {}
 # -- If set to false, deploys an unprivileged / less privileged setup.
 privileged: true
 
+# -- Enables context propagation support.
+contextPropagation:
+  enabled: true
+
 # -- Extra capabilities for unprivileged / less privileged setup.
 extraCapabilities: []
   # - SYS_RESOURCE       # <-- pre 5.11 only. Allows Opentelemetry eBPF Instrumentation to increase the amount of locked memory.
-# - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+  # - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+  # - NET_ADMIN          # <-- Required to inject HTTP and TCP context propagation information. This will be added when contextPropagation is enabled.
 
 # -- Security context for privileged setup.
 securityContext:


### PR DESCRIPTION
#### Description

The OBI fix https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2580 added mitigation code to handle broken linux kernels with the bug exposed by our use of sock_maps. However, the fix was added with normal tracepoints (not raw tracepoints), which require that tracefs is mounted.

This PR adds the tracefs mount.

#### Link to tracking issue

Not directly related, but the issues Below happened due to the embedded OBI code. The downstream helm charts have been fixed but this PR is upstreaming the Helm fixes.
https://github.com/grafana/beyla/issues/2941
https://github.com/grafana/alloy/issues/6085

#### Authorship

- [x] I, a human, wrote this pull request description myself.
