### PR TITLE
opentelemetry-demo: fix product-catalog instrumentation

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.40.9
+version: 0.40.10
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -1,11 +1,56 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-product-catalog-otel-config
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.40.10
+    
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  otel-config.yml: |
+    file_format: "1.0"
+    disabled: false
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    meter_provider:
+      readers:
+        - periodic:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    propagator:
+      composite:
+        - tracecontext:
+        - baggage:
+    resource:
+      attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -30,7 +75,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -55,7 +100,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +125,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -105,7 +150,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -130,7 +175,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +206,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +231,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +256,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +281,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +309,7 @@ kind: Service
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -289,7 +334,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -314,7 +359,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -339,7 +384,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -364,7 +409,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -389,7 +434,7 @@ kind: Service
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -414,7 +459,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -439,7 +484,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -464,7 +509,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -489,7 +534,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -514,7 +559,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: accounting
     
@@ -584,7 +629,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -653,7 +698,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -732,7 +777,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -822,7 +867,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -889,7 +934,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -958,7 +1003,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -1086,7 +1131,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: fraud-detection
     
@@ -1160,7 +1205,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -1259,7 +1304,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1367,7 +1412,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -1438,7 +1483,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -1515,7 +1560,7 @@ kind: Deployment
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -1577,7 +1622,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -1662,7 +1707,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -1735,7 +1780,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -1820,7 +1865,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -1881,11 +1926,19 @@ spec:
               value: database
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_CONFIG_FILE
+              value: /otel-config.yaml
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-otel-config
+              mountPath: /otel-config.yml
+              subPath: otel-config.yml
       volumes:
+        - name: product-catalog-otel-config
+          configMap:
+            name: product-catalog-product-catalog-otel-config
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1893,7 +1946,7 @@ kind: Deployment
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -1980,7 +2033,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -2053,7 +2106,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -2126,7 +2179,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -2193,7 +2246,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -1,11 +1,56 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-product-catalog-otel-config
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.40.10
+    
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  otel-config.yml: |
+    file_format: "1.0"
+    disabled: false
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    meter_provider:
+      readers:
+        - periodic:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    propagator:
+      composite:
+        - tracecontext:
+        - baggage:
+    resource:
+      attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -30,7 +75,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -55,7 +100,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +125,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -105,7 +150,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -130,7 +175,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +206,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +231,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +256,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +281,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +309,7 @@ kind: Service
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -289,7 +334,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -314,7 +359,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -339,7 +384,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -364,7 +409,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -389,7 +434,7 @@ kind: Service
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -414,7 +459,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -439,7 +484,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -464,7 +509,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -489,7 +534,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -514,7 +559,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: accounting
     
@@ -588,7 +633,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -661,7 +706,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -744,7 +789,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -838,7 +883,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -909,7 +954,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -982,7 +1027,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -1114,7 +1159,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: fraud-detection
     
@@ -1192,7 +1237,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -1295,7 +1340,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1405,7 +1450,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -1478,7 +1523,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -1557,7 +1602,7 @@ kind: Deployment
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -1621,7 +1666,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -1710,7 +1755,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -1787,7 +1832,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -1872,7 +1917,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -1933,6 +1978,8 @@ spec:
               value: database
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_CONFIG_FILE
+              value: /otel-config.yaml
             - name: TEAM_NAME
               value: helix
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -1941,7 +1988,13 @@ spec:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-otel-config
+              mountPath: /otel-config.yml
+              subPath: otel-config.yml
       volumes:
+        - name: product-catalog-otel-config
+          configMap:
+            name: product-catalog-product-catalog-otel-config
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1949,7 +2002,7 @@ kind: Deployment
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -2038,7 +2091,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -2115,7 +2168,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -2192,7 +2245,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -2263,7 +2316,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -1,11 +1,56 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-product-catalog-otel-config
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.40.10
+    
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  otel-config.yml: |
+    file_format: "1.0"
+    disabled: false
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    meter_provider:
+      readers:
+        - periodic:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    propagator:
+      composite:
+        - tracecontext:
+        - baggage:
+    resource:
+      attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -30,7 +75,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -55,7 +100,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +125,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -105,7 +150,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -130,7 +175,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +206,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +231,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +256,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +281,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +309,7 @@ kind: Service
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -289,7 +334,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -314,7 +359,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -339,7 +384,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -364,7 +409,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -389,7 +434,7 @@ kind: Service
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -414,7 +459,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -439,7 +484,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -464,7 +509,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -489,7 +534,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -514,7 +559,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: accounting
     
@@ -584,7 +629,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -653,7 +698,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -732,7 +777,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -822,7 +867,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -889,7 +934,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -958,7 +1003,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -1086,7 +1131,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: fraud-detection
     
@@ -1160,7 +1205,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -1259,7 +1304,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1367,7 +1412,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -1438,7 +1483,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -1515,7 +1560,7 @@ kind: Deployment
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -1577,7 +1622,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -1662,7 +1707,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -1735,7 +1780,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -1820,7 +1865,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -1881,11 +1926,19 @@ spec:
               value: database
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_CONFIG_FILE
+              value: /otel-config.yaml
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-otel-config
+              mountPath: /otel-config.yml
+              subPath: otel-config.yml
       volumes:
+        - name: product-catalog-otel-config
+          configMap:
+            name: product-catalog-product-catalog-otel-config
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1893,7 +1946,7 @@ kind: Deployment
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -1980,7 +2033,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -2053,7 +2106,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -2126,7 +2179,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -2193,7 +2246,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/component.yaml
@@ -1,11 +1,56 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-product-catalog-otel-config
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.40.10
+    
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  otel-config.yml: |
+    file_format: "1.0"
+    disabled: false
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    meter_provider:
+      readers:
+        - periodic:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    propagator:
+      composite:
+        - tracecontext:
+        - baggage:
+    resource:
+      attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -30,7 +75,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -55,7 +100,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +125,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -105,7 +150,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -130,7 +175,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +206,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +231,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +256,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +281,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +309,7 @@ kind: Service
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -289,7 +334,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -314,7 +359,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -339,7 +384,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -364,7 +409,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -389,7 +434,7 @@ kind: Service
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -414,7 +459,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -439,7 +484,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -464,7 +509,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -489,7 +534,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -514,7 +559,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: accounting
     
@@ -584,7 +629,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -653,7 +698,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -732,7 +777,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -822,7 +867,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -889,7 +934,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -958,7 +1003,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -1086,7 +1131,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: fraud-detection
     
@@ -1160,7 +1205,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -1259,7 +1304,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1367,7 +1412,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -1438,7 +1483,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -1515,7 +1560,7 @@ kind: Deployment
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -1577,7 +1622,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -1662,7 +1707,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -1735,7 +1780,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -1820,7 +1865,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -1881,11 +1926,19 @@ spec:
               value: database
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_CONFIG_FILE
+              value: /otel-config.yaml
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-otel-config
+              mountPath: /otel-config.yml
+              subPath: otel-config.yml
       volumes:
+        - name: product-catalog-otel-config
+          configMap:
+            name: product-catalog-product-catalog-otel-config
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1893,7 +1946,7 @@ kind: Deployment
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -1980,7 +2033,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -2053,7 +2106,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -2126,7 +2179,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -2193,7 +2246,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -1,11 +1,56 @@
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-product-catalog-otel-config
+  labels:
+    helm.sh/chart: opentelemetry-demo-0.40.10
+    
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/managed-by: Helm
+data:
+  otel-config.yml: |
+    file_format: "1.0"
+    disabled: false
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    meter_provider:
+      readers:
+        - periodic:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_grpc:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    propagator:
+      composite:
+        - tracecontext:
+        - baggage:
+    resource:
+      attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: v1
 kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -30,7 +75,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -55,7 +100,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -80,7 +125,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -105,7 +150,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -130,7 +175,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -161,7 +206,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -186,7 +231,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -211,7 +256,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -236,7 +281,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -264,7 +309,7 @@ kind: Service
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -289,7 +334,7 @@ kind: Service
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -314,7 +359,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -339,7 +384,7 @@ kind: Service
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -364,7 +409,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -389,7 +434,7 @@ kind: Service
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -414,7 +459,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -439,7 +484,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -464,7 +509,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -489,7 +534,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -514,7 +559,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: accounting
     
@@ -584,7 +629,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: ad
     
@@ -653,7 +698,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: cart
     
@@ -732,7 +777,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: checkout
     
@@ -822,7 +867,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: currency
     
@@ -889,7 +934,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: email
     
@@ -958,7 +1003,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: flagd
     
@@ -1086,7 +1131,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: fraud-detection
     
@@ -1160,7 +1205,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend
     
@@ -1259,7 +1304,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1367,7 +1412,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: image-provider
     
@@ -1438,7 +1483,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: kafka
     
@@ -1515,7 +1560,7 @@ kind: Deployment
 metadata:
   name: llm
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: llm
     
@@ -1577,7 +1622,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: load-generator
     
@@ -1662,7 +1707,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: payment
     
@@ -1735,7 +1780,7 @@ kind: Deployment
 metadata:
   name: postgresql
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: postgresql
     
@@ -1820,7 +1865,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-catalog
     
@@ -1881,11 +1926,19 @@ spec:
               value: database
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_CONFIG_FILE
+              value: /otel-config.yaml
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-otel-config
+              mountPath: /otel-config.yml
+              subPath: otel-config.yml
       volumes:
+        - name: product-catalog-otel-config
+          configMap:
+            name: product-catalog-product-catalog-otel-config
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
@@ -1893,7 +1946,7 @@ kind: Deployment
 metadata:
   name: product-reviews
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: product-reviews
     
@@ -1980,7 +2033,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: quote
     
@@ -2053,7 +2106,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: recommendation
     
@@ -2126,7 +2179,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: shipping
     
@@ -2193,7 +2246,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: valkey-cart
     
@@ -2253,7 +2306,7 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     opentelemetry.io/name: frontend-proxy
     

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.40.9
+    helm.sh/chart: opentelemetry-demo-0.40.10
     
     
     app.kubernetes.io/version: "2.2.0"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -583,6 +583,41 @@ components:
         value: database
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
+      - name: OTEL_CONFIG_FILE
+        value: /otel-config.yaml
+    mountedConfigMaps:
+      - name: product-catalog-otel-config
+        mountPath: /otel-config.yml
+        subPath: otel-config.yml
+        data:
+          otel-config.yml: |
+            file_format: "1.0"
+            disabled: false
+            logger_provider:
+              processors:
+                - batch:
+                    exporter:
+                      otlp_grpc:
+                        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            meter_provider:
+              readers:
+                - periodic:
+                    exporter:
+                      otlp_grpc:
+                        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+                        temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+            tracer_provider:
+              processors:
+                - batch:
+                    exporter:
+                      otlp_grpc:
+                        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+            propagator:
+              composite:
+                - tracecontext:
+                - baggage:
+            resource:
+              attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
     resources:
       limits:
         memory: 20Mi


### PR DESCRIPTION
#### Description

The service is missing the configuration from declarative config and so it's not instrumented.
Pass it as config map to match what the docker counterpart is doing in opentelemetry-demo.

#### Link to tracking issue

Fixes #2312

#### Authorship

- [x] I, a human, wrote this pull request description myself.
