### PR TITLE
fix(kube-stack): grant leader election lease RBAC

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.19.1
+version: 0.19.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.19.1
+    helm.sh/chart: opentelemetry-kube-stack-0.19.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.19.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.19.2"

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -184,12 +184,12 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $clusterMetricsEnabled = (any $clusterMetricsEnabled (dig "config" "receivers" "k8s_cluster" false $collector)) }}
 {{- if (dig "presets" "clusterMetrics" "enabled" false $collector) }}
 {{- $clusterMetricsEnabled = true }}
-{{- $useLeaderElection = (any $useLeaderElection (and (eq $collector.mode "daemonset") (not (dig "presets" "clusterMetrics" "disableLeaderElection" false $collector)))) }}
+{{- $useLeaderElection = (any $useLeaderElection (not (dig "presets" "clusterMetrics" "disableLeaderElection" false $collector))) }}
 {{- end }}
 {{- $eventsEnabled = (any $eventsEnabled (dig "config" "receivers" "k8s_cluster" false $collector)) }}
 {{- if (dig "presets" "kubernetesEvents" "enabled" false $collector) }}
 {{- $eventsEnabled = true }}
-{{- $useLeaderElection = (any $useLeaderElection (and (eq $collector.mode "daemonset") (not (dig "presets" "kubernetesEvents" "disableLeaderElection" false $collector)))) }}
+{{- $useLeaderElection = (any $useLeaderElection (not (dig "presets" "kubernetesEvents" "disableLeaderElection" false $collector))) }}
 {{- end }}
 {{- if (dig "presets" "kubernetesObjects" "enabled" false $collector) }}
 {{- $kubernetesObjectsEnabled = true }}


### PR DESCRIPTION
#### Description

The `clusterMetrics` and `kubernetesEvents` presets enable the `k8s_leader_elector` extension even when the collector is deployed in `deployment` mode. However, the ClusterRole generation logic in `_helpers.tpl` only set `$useLeaderElection` when the collector mode was `daemonset`. As a result, the rendered collector configuration enabled leader election while the rendered ClusterRole omitted the required `coordination.k8s.io/leases` RBAC permissions for non-daemonset collectors. This made the leader election configuration and RBAC generation inconsistent, preventing deployment-based collectors from creating and renewing Kubernetes Lease objects.

This change removes the `mode == daemonset` restriction from the `$useLeaderElection` evaluation for the `clusterMetrics` and `kubernetesEvents` presets. When either preset is enabled and `disableLeaderElection` is `false`, the chart now generates the required lease RBAC permissions regardless of the collector deployment mode, aligning RBAC generation with the generated collector configuration. The existing `disableLeaderElection` behavior is preserved, and the `kubernetesObjects` preset remains unchanged because it only uses leader election for daemonset collectors. The kube-stack chart version is bumped from `0.19.1` to `0.19.2`, and the checked-in rendered examples are regenerated accordingly.

Validation was performed with:

* `helm lint charts/opentelemetry-kube-stack`
* `make check-examples CHARTS=opentelemetry-kube-stack`

The rendered output was also verified for the following deployment scenarios:

* `deployment + clusterMetrics.enabled=true` → lease RBAC is generated.
* `deployment + clusterMetrics.enabled=true + clusterMetrics.disableLeaderElection=true` → lease RBAC is not generated.
* `deployment + kubernetesEvents.enabled=true` → lease RBAC is generated.
* `deployment + kubernetesObjects.enabled=true` → lease RBAC is not generated.

#### Link to tracking issue

Fixes #2311

#### Authorship

* [O] I, a human, wrote this pull request description myself.
