### PR TITLE
[opentelemetry-operator] Support custom annotations on CRDs via crds.…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ define get-crd
 @sed -i 's/opentelemetry-operator-system/{{ template "opentelemetry-operator.namespace" . }}/g' $(1)
 @sed -i 's/opentelemetry-operator-webhook-service/{{ template "opentelemetry-operator.fullname" . }}-webhook/g' $(1)
 @sed -i '1s/^/{{- if .Values.crds.create }}\n/' $(1)
+@sed -i '0,/^  annotations:/s//  annotations:\n{{- with .Values.crds.annotations }}\n{{ toYaml . | indent 4 }}\n{{- end }}/' $(1)
 @sed -i 's#\(.*\)path: /convert#&\n\1port: {{ .Values.admissionWebhooks.servicePort }}#' $(1)
 @sed -i 's#\(.*\)conversion:#{{- if .Values.admissionWebhooks.create }}\n&#' $(1)
 @sed -i 's#\(.*\)- v1beta1#&\n{{- end }}#' $(1)
@@ -128,5 +129,6 @@ define get-clusterobservability-crd
 @curl -s -o $(1) $(2)
 @sed -i '1s/^---/{{- if .Values.crds.create }}/' $(1)
 @sed -i '1a{{- if get .Values.manager.featureGatesMap "operator.clusterobservability" }}' $(1)
+@sed -i '0,/^  annotations:/s//  annotations:\n{{- with .Values.crds.annotations }}\n{{ toYaml . | indent 4 }}\n{{- end }}/' $(1)
 @echo '{{- end }}\n{{- end }}' >> $(1)
 endef

--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.120.0
+version: 0.121.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_clusterobservabilities.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_clusterobservabilities.yaml
@@ -4,6 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- with .Values.crds.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterobservabilities.opentelemetry.io
 spec:

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_opampbridges.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- with .Values.crds.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetry.io_targetallocators.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- with .Values.crds.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetrycollector.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- with .Values.crds.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     cert-manager.io/inject-ca-from: {{ include "opentelemetry-operator.webhookCertAnnotation" . }}
     controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null

--- a/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
+++ b/charts/opentelemetry-operator/conf/crds/crd-opentelemetryinstrumentation.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- with .Values.crds.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   labels:

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -403,7 +403,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.0
+        helm.sh/chart: opentelemetry-operator-0.121.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -408,7 +408,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.0
+        helm.sh/chart: opentelemetry-operator-0.121.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -403,7 +403,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ spec:
         checksum/config: 0da985a5e8e6c8d2ffbbcdbd02b166f0c8b47a193418632712111fcc71a431d5
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.0
+        helm.sh/chart: opentelemetry-operator-0.121.0
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.0
+    helm.sh/chart: opentelemetry-operator-0.121.0
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1820,6 +1820,16 @@
           "examples": [
             true
           ]
+        },
+        "annotations": {
+          "type": "object",
+          "default": {},
+          "title": "Additional CRD annotations",
+          "required": [],
+          "properties": {},
+          "examples": [
+            {}
+          ]
         }
       },
       "examples": [

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -349,6 +349,9 @@ admissionWebhooks:
 ## See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0560-to-0570 for more details.
 crds:
   create: true
+  ## Additional annotations to add to all CRDs, e.g. set "helm.sh/resource-policy": keep
+  ## to prevent Helm from deleting them when the chart is uninstalled.
+  annotations: {}
 
 ## Create the provided Roles and RoleBindings
 ##


### PR DESCRIPTION
This PR adds a new crds.annotations value to the opentelemetry-operator chart. By default it is empty ({}), so nothing changes for existing users.
The purpose is to let users set annotations on the CRDs — for example helm.sh/resource-policy: keep — so the CRDs are not deleted when the chart is uninstalled.
The CRD files under conf/crds/ are generated by the Makefile, so I added the annotation template to the get-crd steps and regenerated the files. This keeps the check-operator-crds CI check passing. I also bumped the chart version to 0.121.0, added the new value to values.schema.json, and regenerated the examples.
Tested: default rendering is unchanged; with the annotation set it appears on all CRDs; helm lint passes.
Link to tracking issue
Fixes #1713