### PR TITLE
fix(opentelemetry-operator): make cert-manager test address configurable

### DIFF
--- a/charts/opentelemetry-operator/Chart.yaml
+++ b/charts/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.120.2
+version: 0.120.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
@@ -1,2 +1,7 @@
 testFramework:
-  certManagerAddress: cert-manager-webhook.cert-manager.svc
+  certManager:
+    env:
+      - name: CERT_MANAGER_CLUSTERIP
+        value: "cert-manager-webhook.cert-manager.svc"
+      - name: CERT_MANAGER_PORT
+        value: "443"

--- a/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
@@ -1,7 +1,0 @@
-testFramework:
-  certManager:
-    env:
-      - name: CERT_MANAGER_CLUSTERIP
-        value: "cert-manager-webhook.cert-manager.svc"
-      - name: CERT_MANAGER_PORT
-        value: "443"

--- a/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
+++ b/charts/opentelemetry-operator/ci/cert-manager-address-values.yaml
@@ -1,0 +1,2 @@
+testFramework:
+  certManagerAddress: cert-manager-webhook.cert-manager.svc

--- a/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -404,7 +404,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.2
+        helm.sh/chart: opentelemetry-operator-0.120.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -21,7 +21,7 @@ spec:
       image: "busybox:latest"
       env:
         - name: CERT_MANAGER_CLUSTERIP
-          value: "cert-manager-webhook.cert-manager"
+          value: cert-manager-webhook.cert-manager
         - name: CERT_MANAGER_PORT
           value: "443"
       command:

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/default/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -409,7 +409,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -25,7 +25,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.2
+        helm.sh/chart: opentelemetry-operator-0.120.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -21,7 +21,7 @@ spec:
       image: "busybox:latest"
       env:
         - name: CERT_MANAGER_CLUSTERIP
-          value: "cert-manager-webhook.cert-manager"
+          value: cert-manager-webhook.cert-manager
         - name: CERT_MANAGER_PORT
           value: "443"
       command:

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/feature-gates/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -91,7 +91,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/certmanager.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -404,7 +404,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -26,7 +26,7 @@ spec:
         checksum/config: 0da985a5e8e6c8d2ffbbcdbd02b166f0c8b47a193418632712111fcc71a431d5
         kubectl.kubernetes.io/default-container: manager
       labels:
-        helm.sh/chart: opentelemetry-operator-0.120.2
+        helm.sh/chart: opentelemetry-operator-0.120.3
         app.kubernetes.io/name: opentelemetry-operator
         app.kubernetes.io/version: "0.156.0"
         app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: opentelemetry-operator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
@@ -21,7 +21,7 @@ spec:
       image: "busybox:latest"
       env:
         - name: CERT_MANAGER_CLUSTERIP
-          value: "cert-manager-webhook.cert-manager"
+          value: cert-manager-webhook.cert-manager
         - name: CERT_MANAGER_PORT
           value: "443"
       command:

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-certmanager-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-operator/examples/manager-config/rendered/tests/test-service-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "example-opentelemetry-operator-metrics-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ metadata:
   name: "example-opentelemetry-operator-webhook-test"
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-operator-0.120.2
+    helm.sh/chart: opentelemetry-operator-0.120.3
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/version: "0.156.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
@@ -14,10 +14,7 @@ spec:
     - name: wget
       image: "{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       env:
-        - name: CERT_MANAGER_CLUSTERIP
-          value: {{ .Values.testFramework.certManagerAddress | quote }}
-        - name: CERT_MANAGER_PORT
-          value: "443"
+{{ toYaml .Values.testFramework.certManager.env | indent 8 }}
       command:
         - sh
         - -c

--- a/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
@@ -14,7 +14,7 @@ spec:
     - name: wget
       image: "{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       env:
-{{ toYaml .Values.testFramework.certManager.env | indent 8 }}
+        {{- toYaml .Values.testFramework.certManager.env | nindent 8 }}
       command:
         - sh
         - -c

--- a/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
@@ -15,7 +15,7 @@ spec:
       image: "{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       env:
         - name: CERT_MANAGER_CLUSTERIP
-          value: "cert-manager-webhook.cert-manager"
+          value: {{ .Values.testFramework.certManagerAddress | quote }}
         - name: CERT_MANAGER_PORT
           value: "443"
       command:

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1969,18 +1969,59 @@
       "default": {},
       "title": "The testFramework Schema",
       "required": [
-        "certManagerAddress",
+        "certManager",
         "image",
         "securityContext"
       ],
       "additionalProperties": false,
       "properties": {
-        "certManagerAddress": {
-          "type": "string",
-          "default": "cert-manager-webhook.cert-manager",
-          "title": "The cert-manager webhook address used by the Helm test hook",
+        "certManager": {
+          "type": "object",
+          "default": {},
+          "title": "The cert-manager test configuration Schema",
+          "required": [
+            "env"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "env": {
+              "type": "array",
+              "default": [],
+              "title": "Environment variables used by the cert-manager Helm test hook",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          },
           "examples": [
-            "cert-manager-webhook.cert-manager"
+            {
+              "env": [
+                {
+                  "name": "CERT_MANAGER_CLUSTERIP",
+                  "value": "cert-manager-webhook.cert-manager"
+                },
+                {
+                  "name": "CERT_MANAGER_PORT",
+                  "value": "443"
+                }
+              ]
+            }
           ]
         },
         "image": {
@@ -2033,7 +2074,18 @@
       },
       "examples": [
         {
-          "certManagerAddress": "cert-manager-webhook.cert-manager",
+          "certManager": {
+            "env": [
+              {
+                "name": "CERT_MANAGER_CLUSTERIP",
+                "value": "cert-manager-webhook.cert-manager"
+              },
+              {
+                "name": "CERT_MANAGER_PORT",
+                "value": "443"
+              }
+            ]
+          },
           "image": {
             "repository": "busybox",
             "tag": "latest"
@@ -2234,7 +2286,18 @@
         "fsGroup": 65532
       },
       "testFramework": {
-        "certManagerAddress": "cert-manager-webhook.cert-manager",
+        "certManager": {
+          "env": [
+            {
+              "name": "CERT_MANAGER_CLUSTERIP",
+              "value": "cert-manager-webhook.cert-manager"
+            },
+            {
+              "name": "CERT_MANAGER_PORT",
+              "value": "443"
+            }
+          ]
+        },
         "image": {
           "repository": "busybox",
           "tag": "latest"

--- a/charts/opentelemetry-operator/values.schema.json
+++ b/charts/opentelemetry-operator/values.schema.json
@@ -1969,11 +1969,20 @@
       "default": {},
       "title": "The testFramework Schema",
       "required": [
+        "certManagerAddress",
         "image",
         "securityContext"
       ],
       "additionalProperties": false,
       "properties": {
+        "certManagerAddress": {
+          "type": "string",
+          "default": "cert-manager-webhook.cert-manager",
+          "title": "The cert-manager webhook address used by the Helm test hook",
+          "examples": [
+            "cert-manager-webhook.cert-manager"
+          ]
+        },
         "image": {
           "type": "object",
           "default": {},
@@ -2024,6 +2033,7 @@
       },
       "examples": [
         {
+          "certManagerAddress": "cert-manager-webhook.cert-manager",
           "image": {
             "repository": "busybox",
             "tag": "latest"
@@ -2224,6 +2234,7 @@
         "fsGroup": 65532
       },
       "testFramework": {
+        "certManagerAddress": "cert-manager-webhook.cert-manager",
         "image": {
           "repository": "busybox",
           "tag": "latest"

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -398,6 +398,8 @@ securityContext:
 automountServiceAccountToken: true
 
 testFramework:
+  ## Address used by the Helm test hook to verify the cert-manager webhook.
+  certManagerAddress: cert-manager-webhook.cert-manager
   image:
     repository: busybox
     tag: latest

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -398,8 +398,12 @@ securityContext:
 automountServiceAccountToken: true
 
 testFramework:
-  ## Address used by the Helm test hook to verify the cert-manager webhook.
-  certManagerAddress: cert-manager-webhook.cert-manager
+  certManager:
+    env:
+      - name: CERT_MANAGER_CLUSTERIP
+        value: "cert-manager-webhook.cert-manager"
+      - name: CERT_MANAGER_PORT
+        value: "443"
   image:
     repository: busybox
     tag: latest


### PR DESCRIPTION
#### Description

The cert-manager connection test in the OpenTelemetry Operator chart hard-codes the webhook address `cert-manager-webhook.cert-manager`. As a result, `helm test` fails when cert-manager uses a different release name or namespace.

This PR adds `testFramework.certManagerAddress` and uses it in the existing cert-manager connection test. The default remains `cert-manager-webhook.cert-manager`, so existing installations require no changes. Keeping the setting under the existing `testFramework` section also makes its test-only purpose explicit.

Changes:

- Add `testFramework.certManagerAddress` to the chart values and schema.
- Use the configured address in the existing cert-manager connection test.
- Add a CI values case for a non-default address.
- Bump the operator chart version from `0.120.2` to `0.120.3` and regenerate the rendered examples.

Verification: chart-testing lint with all nine operator CI values cases, Helm 4.0.5 lint, schema validation, example generation and operator example checks, and default and custom rendering all pass. Default rendering is unchanged apart from the expected `helm.sh/chart` version labels.

#### Link to tracking issue

Fixes #2323

#### Authorship

- [x] I, a human, wrote this pull request description myself.
