### PR TITLE
fix(opentelemetry-kube-stack): add namespace to hook and Instrumentation resources

### DIFF
--- a/charts/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/templates/hooks.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- end}}
@@ -13,6 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -50,6 +53,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "opentelemetry-kube-stack.name" . }}-pre-delete-job
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
@@ -4,6 +4,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: {{ include "opentelemetry-kube-stack.instrumentation" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-kube-stack.labels" $ | nindent 4 }}
     {{- include "opentelemetry-kube-stack.renderkv" .Values.instrumentation.labels | indent 4 }}


### PR DESCRIPTION
## Problem

`hooks.yaml` (ServiceAccount, Role, RoleBinding, Job) and `instrumentation.yaml` (Instrumentation CR) are missing `namespace: {{ .Release.Namespace }}` in their metadata.

When deploying with plain `helm install` the Kubernetes API server injects the namespace from the request context, so this is invisible. However, when the chart is post-processed with tools such as kustomize (via `helmCharts:`), the rendered manifests lack an explicit namespace field. **kustomize ≥ 5.8.0** no longer applies its namespace transformer to `helmCharts:`-rendered resources ([kubernetes-sigs/kustomize#6058](https://github.com/kubernetes-sigs/kustomize/issues/6058)), which causes these resources to end up without a namespace and fail to apply.

## Fix

Add `namespace: {{ .Release.Namespace }}` to the metadata of all five affected resources:

- `hooks.yaml`: `ServiceAccount`, `Role`, `RoleBinding`, `Job`
- `instrumentation.yaml`: `Instrumentation`

This aligns with how every other namespaced resource in the chart is authored and is considered best practice for Helm templates.