### PR TITLE
[chart/opentelemetry-ebpf-instrumentation] only configure prometheus_export when a Service can scrape it

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.12.0
+version: 0.12.1
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"
@@ -33,6 +33,3 @@ data:
       endpoint: http://${HOST_IP}:4318
     otel_traces_export:
       endpoint: http://${HOST_IP}:4317
-    prometheus_export:
-      path: /metrics
-      port: 9090

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0d1a73264e6b2f2b0494386f23a2616df5c8fff342fa6e44f11f6c2d6e47a05d
+        checksum/config: e09dc9b0d6afaf564744509f86baa438fb5b4788101b22480b34ca05b13ac105
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.11.0"
@@ -45,10 +45,6 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          ports:
-          - name: metrics
-            containerPort: 9090
-            protocol: TCP
           env:
             - name: OTEL_EBPF_CONFIG_PATH
               value: "/etc/ebpf-instrument/config/ebpf-instrument-config.yml"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/default/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/cache-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"
@@ -33,6 +33,3 @@ data:
       endpoint: http://${HOST_IP}:4318
     otel_traces_export:
       endpoint: http://${HOST_IP}:4317
-    prometheus_export:
-      path: /metrics
-      port: 9090

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"
@@ -23,10 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0d1a73264e6b2f2b0494386f23a2616df5c8fff342fa6e44f11f6c2d6e47a05d
+        checksum/config: e09dc9b0d6afaf564744509f86baa438fb5b4788101b22480b34ca05b13ac105
         
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v0.11.0"
@@ -45,10 +45,6 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          ports:
-          - name: metrics
-            containerPort: 9090
-            protocol: TCP
           env:
             - name: OTEL_EBPF_CONFIG_PATH
               value: "/etc/ebpf-instrument/config/ebpf-instrument-config.yml"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/with-k8s-cache/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.0
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.12.1
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v0.11.0"

--- a/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
@@ -143,8 +143,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Generate the configmap data based on preset and configuration values
 */}}
+{{/*
+Whether the Prometheus scrape endpoint should be configured.
+
+OBI only expires Prometheus metric children while serving a scrape, so an
+endpoint that nothing scrapes retains every series for the lifetime of the
+process. The ServiceMonitor requires a Service, so service.enabled is the
+only condition needed.
+*/}}
+{{- define "obi.prometheusExportEnabled" -}}
+{{- if .Values.service.enabled -}}
+true
+{{- end -}}
+{{- end }}
+
 {{- define "obi.configData" -}}
 {{- $config := deepCopy .Values.config.data }}
+{{- if not (include "obi.prometheusExportEnabled" .) }}
+{{- $_ := unset $config "prometheus_export" }}
+{{- end }}
 {{- if eq .Values.preset "network" }}
 {{- if not .Values.config.data.network }}
 {{- $_ := set $config "network" (dict "enable" true) }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemonset.yaml
@@ -75,17 +75,24 @@ spec:
               drop:
                 - ALL
           {{- end }}
+          {{- $promExport := dict }}
+          {{- if include "obi.prometheusExportEnabled" . }}
+          {{- $promExport = ((.Values.config.data).prometheus_export) | default dict }}
+          {{- end }}
+          {{- $metricsPort := .Values.service.targetPort | default ($promExport).port }}
+          {{- $internalMetricsPort := and
+                    (or .Values.service.internalMetrics.targetPort ((.Values.config.data.internal_metrics).prometheus).port)
+                    (ne ($promExport).port ((.Values.config.data.internal_metrics).prometheus).port)
+                    (ne .Values.service.internalMetrics.targetPort .Values.service.targetPort) }}
+          {{- if or $metricsPort $internalMetricsPort .Values.config.data.profile_port }}
           ports:
-          {{- if (or (.Values.service.targetPort) ((.Values.config.data.prometheus_export).port)) }}
+          {{- end }}
+          {{- if $metricsPort }}
           - name: {{ .Values.service.portName }}
-            containerPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
+            containerPort: {{ $metricsPort }}
             protocol: TCP
           {{- end }}
-          {{- if (and
-                    (or .Values.service.internalMetrics.targetPort ((.Values.config.data.internal_metrics).prometheus).port)
-                    (ne ((.Values.config.data).prometheus_export).port ((.Values.config.data.internal_metrics).prometheus).port)
-                    (ne .Values.service.internalMetrics.targetPort .Values.service.targetPort)
-                  ) }}
+          {{- if $internalMetricsPort }}
           - name: {{ .Values.service.internalMetrics.portName }}
             containerPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
             protocol: TCP

--- a/charts/opentelemetry-ebpf-instrumentation/tests/configmap_test.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/tests/configmap_test.yaml
@@ -18,3 +18,28 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: omits prometheus_export when no Service can scrape it
+    asserts:
+      - notMatchRegex:
+          path: data["ebpf-instrument-config.yml"]
+          pattern: prometheus_export
+
+  - it: keeps prometheus_export when a Service is enabled
+    set:
+      service:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["ebpf-instrument-config.yml"]
+          pattern: prometheus_export
+
+  - it: omits prometheus_export when only a ServiceMonitor is enabled
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["ebpf-instrument-config.yml"]
+          pattern: prometheus_export
+

--- a/charts/opentelemetry-ebpf-instrumentation/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/tests/daemonset_test.yaml
@@ -22,3 +22,23 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].configMap.name
           value: external-config
+
+  - it: omits the metrics container port when no Service can scrape it
+    template: templates/daemonset.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].ports
+
+  - it: renders the metrics container port when a Service is enabled
+    template: templates/daemonset.yaml
+    set:
+      service:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 9090
+            protocol: TCP
+


### PR DESCRIPTION
#### Description
OBI defaulted to enable prometheus exporter.
But the prometheus exporter expires Prometheus metric children only while serving a scrape. 
So without anyone scrapping it (no service) then metrics were not evicted and memory consumption grows without eviction

This fixes to only enable prometheus export when service is explicitly turned on
#### Link to tracking issue

#### Authorship

- [x] I, a human, wrote this pull request description myself.
