### PR TITLE
fix(opentelemetry-kube-stack): update prometheus-crds

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.3
+version: 0.20.4
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.1
+version: 0.20.2
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/charts/prometheus-crds/README.md
+++ b/charts/opentelemetry-kube-stack/charts/prometheus-crds/README.md
@@ -12,9 +12,11 @@ This approach is inspired by the kube-prometheus-stack approach which you can se
 Right now, upgrades are NOT handled by this chart, however that could change in the future. This is what is run to bring in the CRDs today.
 
 > [!NOTE]
-> The prometheus operator version should be equal to what is documented in the opentelemetry operator's compatability matrix [here](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#opentelemetry-operator-vs-kubernetes-vs-cert-manager-vs-prometheus-operator)
+> The prometheus operator version should be equal to what is documented in the opentelemetry operator's compatability matrix [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md#compatibility-matrix)
 
 ```bash
-wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.74.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+wget https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ```

--- a/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_podmonitors.yaml
+++ b/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_podmonitors.yaml
@@ -3,26 +3,34 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-    operator.prometheus.io/version: 0.74.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.92.0
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
   names:
     categories:
-    - prometheus-operator
+      - prometheus-operator
     kind: PodMonitor
     listKind: PodMonitorList
     plural: podmonitors
     shortNames:
-    - pmon
+      - pmon
     singular: podmonitor
   scope: Namespaced
   versions:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: PodMonitor defines monitoring for a set of pods.
+        description: |-
+          The `PodMonitor` custom resource definition (CRD) defines how `Prometheus` and `PrometheusAgent` can scrape metrics from a group of pods.
+          Among other things, it allows to specify:
+          * The pods to scrape via label selectors.
+          * The container ports to scrape.
+          * Authentication credentials to use.
+          * Target and metric relabeling.
+
+          `Prometheus` and `PrometheusAgent` objects select `PodMonitor` objects using label and namespace selectors.
         properties:
           apiVersion:
             description: |-
@@ -42,98 +50,136 @@ spec:
           metadata:
             type: object
           spec:
-            description: Specification of desired Pod selection for target discovery
-              by Prometheus.
+            description:
+              spec defines the specification of desired Pod selection for
+              target discovery by Prometheus.
             properties:
               attachMetadata:
                 description: |-
-                  `attachMetadata` defines additional metadata which is added to the
+                  attachMetadata defines additional metadata which is added to the
                   discovered targets.
 
-
-                  It requires Prometheus >= v2.37.0.
+                  It requires Prometheus >= v2.35.0.
                 properties:
                   node:
                     description: |-
-                      When set to true, Prometheus must have the `get` permission on the
-                      `Nodes` objects.
+                      node when set to true, Prometheus attaches node metadata to the discovered
+                      targets.
+
+                      The Prometheus service account must have the `list` and `watch`
+                      permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:
                 description: |-
-                  When defined, bodySizeLimit specifies a job level limit on the size
+                  bodySizeLimit when defined specifies a job level limit on the size
                   of uncompressed response body that will be accepted by Prometheus.
-
 
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
+              fallbackScrapeProtocol:
+                description: |-
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
-                  The label to use to retrieve the job name from.
+                  jobLabel defines the label to use to retrieve the job name from.
                   `jobLabel` selects the label from the associated Kubernetes `Pod`
                   object which will be used as the `job` label for all metrics.
-
 
                   For example if `jobLabel` is set to `foo` and the Kubernetes `Pod`
                   object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
                   label to all ingested metrics.
-
 
                   If the value of this field is empty, the `job` label of the metrics
                   defaults to the namespace and name of the PodMonitor object (e.g. `<namespace>/<name>`).
                 type: string
               keepDroppedTargets:
                 description: |-
-                  Per-scrape limit on the number of targets dropped by relabeling
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
                   that will be kept in memory. 0 means no limit.
-
 
                   It requires Prometheus >= v2.47.0.
                 format: int64
                 type: integer
               labelLimit:
                 description: |-
-                  Per-scrape limit on number of labels that will be accepted for a sample.
-
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelNameLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels name that will be accepted for a sample.
-
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelValueLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels value that will be accepted for a sample.
-
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               namespaceSelector:
                 description: |-
-                  Selector to select which namespaces the Kubernetes `Pods` objects
-                  are discovered from.
+                  namespaceSelector defines in which namespace(s) Prometheus should discover the pods.
+                  By default, the pods are discovered in the same namespace as the `PodMonitor` object but it is possible to select pods across different/all namespaces.
                 properties:
                   any:
                     description: |-
-                      Boolean describing whether all namespaces are selected in contrast to a
+                      any defines the boolean describing whether all namespaces are selected in contrast to a
                       list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
+                    description:
+                      matchNames defines the list of namespace names to
+                      select from.
                     items:
                       type: string
                     type: array
                 type: object
+              nativeHistogramBucketLimit:
+                description: |-
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
+                  buckets will be merged to stay within the limit.
+                  It requires Prometheus >= v2.45.0.
+                format: int64
+                type: integer
+              nativeHistogramMinBucketFactor:
+                anyOf:
+                  - type: integer
+                  - type: string
+                description: |-
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
+                  buckets will be merged to increase the factor sufficiently.
+                  It requires Prometheus >= v2.50.0.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               podMetricsEndpoints:
-                description: List of endpoints part of this PodMonitor.
+                description:
+                  podMetricsEndpoints defines how to scrape metrics from
+                  the selected pods.
                 items:
                   description: |-
                     PodMetricsEndpoint defines an endpoint serving Prometheus metrics to be scraped by
@@ -141,402 +187,738 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        `authorization` configures the Authorization header credentials to use when
-                        scraping the target.
+                        authorization configures the Authorization header credentials used by
+                        the client.
 
-
-                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                        Cannot be set at the same time as `basicAuth`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
                       description: |-
-                        `basicAuth` configures the Basic Authentication credentials to use when
-                        scraping the target.
+                        basicAuth defines the Basic Authentication credentials used by the
+                        client.
 
-
-                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                        Cannot be set at the same time as `authorization`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenSecret:
                       description: |-
-                        `bearerTokenSecret` specifies a key of a Secret containing the bearer
-                        token for scraping targets. The secret needs to be in the same namespace
-                        as the PodMonitor object and readable by the Prometheus Operator.
+                        bearerTokenSecret defines a key of a Secret containing the bearer token
+                        used by the client for authentication. The secret needs to be in the
+                        same namespace as the custom resource and readable by the Prometheus
+                        Operator.
 
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `oauth2`.
 
                         Deprecated: use `authorization` instead.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: '`enableHttp2` can be used to disable HTTP2 when
-                        scraping the target.'
+                      description: enableHttp2 can be used to disable HTTP2.
                       type: boolean
                     filterRunning:
                       description: |-
-                        When true, the pods which are not running (e.g. either in Failed or
+                        filterRunning when true, the pods which are not running (e.g. either in Failed or
                         Succeeded state) are dropped during the target discovery.
 
-
                         If unset, the filtering is enabled.
-
 
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
                       type: boolean
                     followRedirects:
                       description: |-
-                        `followRedirects` defines whether the scrape requests should follow HTTP
-                        3xx redirects.
+                        followRedirects defines whether the client should follow HTTP 3xx
+                        redirects.
                       type: boolean
                     honorLabels:
                       description: |-
-                        When true, `honorLabels` preserves the metric's labels when they collide
+                        honorLabels when true preserves the metric's labels when they collide
                         with the target's labels.
                       type: boolean
                     honorTimestamps:
                       description: |-
-                        `honorTimestamps` controls whether Prometheus preserves the timestamps
+                        honorTimestamps defines whether Prometheus preserves the timestamps
                         when exposed by the target.
                       type: boolean
                     interval:
                       description: |-
-                        Interval at which Prometheus scrapes the metrics from the target.
-
+                        interval at which Prometheus scrapes the metrics from the target.
 
                         If empty, Prometheus uses the global scrape interval.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: |-
-                        `metricRelabelings` configures the relabeling rules to apply to the
+                        metricRelabelings defines the relabeling rules to apply to the
                         samples before ingestion.
                       items:
                         description: |-
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
-
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                               Default: "Replace"
                             enum:
-                            - replace
-                            - Replace
-                            - keep
-                            - Keep
-                            - drop
-                            - Drop
-                            - hashmod
-                            - HashMod
-                            - labelmap
-                            - LabelMap
-                            - labeldrop
-                            - LabelDrop
-                            - labelkeep
-                            - LabelKeep
-                            - lowercase
-                            - Lowercase
-                            - uppercase
-                            - Uppercase
-                            - keepequal
-                            - KeepEqual
-                            - dropequal
-                            - DropEqual
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
-
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description:
+                              regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description:
+                              separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
                         type: object
                       type: array
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
                     oauth2:
                       description: |-
-                        `oauth2` configures the OAuth2 settings to use when scraping the target.
-
+                        oauth2 defines the OAuth2 settings used by the client.
 
                         It requires Prometheus >= 2.27.0.
 
-
-                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `bearerTokenSecret`.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     params:
                       additionalProperties:
                         items:
                           type: string
                         type: array
-                      description: '`params` define optional HTTP URL parameters.'
+                      description: params define optional HTTP URL parameters.
                       type: object
                     path:
                       description: |-
-                        HTTP path from which to scrape for metrics.
-
+                        path defines the HTTP path from which to scrape for metrics.
 
                         If empty, Prometheus uses the default value (e.g. `/metrics`).
                       type: string
                     port:
                       description: |-
-                        Name of the Pod port which this endpoint refers to.
+                        port defines the `Pod` port name which exposes the endpoint.
 
+                        If the pod doesn't expose a port with the same name, it will result
+                        in no targets being discovered.
 
-                        It takes precedence over `targetPort`.
+                        If a `Pod` has multiple `Port`s with the same name (which is not
+                        recommended), one target instance per unique port number will be
+                        generated.
+
+                        It takes precedence over the `portNumber` and `targetPort` fields.
                       type: string
-                    proxyUrl:
+                    portNumber:
                       description: |-
-                        `proxyURL` configures the HTTP Proxy URL (e.g.
-                        "http://proxyserver:2195") to go through when scraping the target.
+                        portNumber defines the `Pod` port number which exposes the endpoint.
+
+                        The `Pod` must declare the specified `Port` in its spec or the
+                        target will be dropped by Prometheus.
+
+                        This cannot be used to enable scraping of an undeclared port.
+                        To scrape targets on a port which isn't exposed, you need to use
+                        relabeling to override the `__address__` label (but beware of
+                        duplicate targets if the `Pod` has other declared ports).
+
+                        In practice Prometheus will select targets for which the
+                        matches the target's __meta_kubernetes_pod_container_port_number.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     relabelings:
                       description: |-
-                        `relabelings` configures the relabeling rules to apply the target's
+                        relabelings defines the relabeling rules to apply the target's
                         metadata labels.
-
 
                         The Operator automatically adds relabelings for a few standard Kubernetes fields.
 
-
                         The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
-
 
                         More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                       items:
@@ -544,258 +926,306 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
-
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                               Default: "Replace"
                             enum:
-                            - replace
-                            - Replace
-                            - keep
-                            - Keep
-                            - drop
-                            - Drop
-                            - hashmod
-                            - HashMod
-                            - labelmap
-                            - LabelMap
-                            - labeldrop
-                            - LabelDrop
-                            - labelkeep
-                            - LabelKeep
-                            - lowercase
-                            - Lowercase
-                            - uppercase
-                            - Uppercase
-                            - keepequal
-                            - KeepEqual
-                            - dropequal
-                            - DropEqual
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
-
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description:
+                              regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description:
+                              separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     scheme:
-                      description: |-
-                        HTTP scheme to use for scraping.
-
-
-                        `http` and `https` are the expected values unless you rewrite the
-                        `__scheme__` label via relabeling.
-
-
-                        If empty, Prometheus uses the default value `http`.
+                      description: scheme defines the HTTP scheme to use for scraping.
                       enum:
-                      - http
-                      - https
+                        - http
+                        - https
+                        - HTTP
+                        - HTTPS
                       type: string
                     scrapeTimeout:
                       description: |-
-                        Timeout after which Prometheus considers the scrape to be failed.
-
+                        scrapeTimeout defines the timeout after which Prometheus considers the scrape to be failed.
 
                         If empty, Prometheus uses the global scrape timeout unless it is less
                         than the target's scrape interval value in which the latter is used.
+                        The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
-                      - type: integer
-                      - type: string
+                        - type: integer
+                        - type: string
                       description: |-
-                        Name or number of the target port of the `Pod` object behind the Service, the
+                        targetPort defines the name or number of the target port of the `Pod` object behind the Service, the
                         port must be specified with container port property.
 
-
-                        Deprecated: use 'port' instead.
+                        Deprecated: use 'port' or 'portNumber' instead.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the target.
+                      description:
+                        tlsConfig defines the TLS configuration used by
+                        the client.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     trackTimestampsStaleness:
                       description: |-
-                        `trackTimestampsStaleness` defines whether Prometheus tracks staleness of
+                        trackTimestampsStaleness defines whether Prometheus tracks staleness of
                         the metrics that have an explicit timestamp present in scraped data.
                         Has no effect if `honorTimestamps` is false.
-
 
                         It requires Prometheus >= v2.48.0.
                       type: boolean
@@ -803,29 +1233,39 @@ spec:
                 type: array
               podTargetLabels:
                 description: |-
-                  `podTargetLabels` defines the labels which are transferred from the
+                  podTargetLabels defines the labels which are transferred from the
                   associated Kubernetes `Pod` object onto the ingested metrics.
                 items:
                   type: string
                 type: array
               sampleLimit:
                 description: |-
-                  `sampleLimit` defines a per-scrape limit on the number of scraped samples
+                  sampleLimit defines a per-scrape limit on the number of scraped samples
                   that will be accepted.
                 format: int64
                 type: integer
               scrapeClass:
-                description: The scrape class to apply.
+                description: scrapeClass defines the scrape class to apply.
                 minLength: 1
                 type: string
+              scrapeClassicHistograms:
+                description: |-
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
+                  It requires Prometheus >= v2.45.0.
+
+                  Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
+                type: boolean
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
               scrapeProtocols:
                 description: |-
-                  `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
                   protocols supported by Prometheus in order of preference (from most to least preferred).
 
-
                   If unset, Prometheus uses its default value.
-
 
                   It requires Prometheus >= v2.49.0.
                 items:
@@ -836,19 +1276,24 @@ spec:
                     * `OpenMetricsText1.0.0`
                     * `PrometheusProto`
                     * `PrometheusText0.0.4`
+                    * `PrometheusText1.0.0`
                   enum:
-                  - PrometheusProto
-                  - OpenMetricsText0.0.1
-                  - OpenMetricsText1.0.0
-                  - PrometheusText0.0.4
+                    - PrometheusProto
+                    - OpenMetricsText0.0.1
+                    - OpenMetricsText1.0.0
+                    - PrometheusText0.0.4
+                    - PrometheusText1.0.0
                   type: string
                 type: array
                 x-kubernetes-list-type: set
               selector:
-                description: Label selector to select the Kubernetes `Pod` objects.
+                description:
+                  selector defines the label selector to select the Kubernetes
+                  `Pod` objects to scrape metrics from.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
+                    description:
+                      matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
                       description: |-
@@ -856,7 +1301,8 @@ spec:
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
+                          description:
+                            key is the label key that the selector applies
                             to.
                           type: string
                         operator:
@@ -873,11 +1319,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
-                      - key
-                      - operator
+                        - key
+                        - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
@@ -888,17 +1336,142 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              selectorMechanism:
+                description: |-
+                  selectorMechanism defines the mechanism used to select the endpoints to scrape.
+                  By default, the selection process relies on relabel configurations to filter the discovered targets.
+                  Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
+                  Which strategy is best for your use case needs to be carefully evaluated.
+
+                  It requires Prometheus >= v2.17.0.
+                enum:
+                  - RelabelConfig
+                  - RoleSelector
+                type: string
               targetLimit:
                 description: |-
-                  `targetLimit` defines a limit on the number of scraped targets that will
+                  targetLimit defines a limit on the number of scraped targets that will
                   be accepted.
                 format: int64
                 type: integer
             required:
-            - selector
+              - selector
+            type: object
+          status:
+            description: |-
+              status defines the status subresource. It is under active development and is updated only when the
+              "StatusForConfigurationResources" feature gate is enabled.
+
+              Most recent observed status of the PodMonitor. Read-only.
+              More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bindings:
+                description:
+                  bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
+                items:
+                  description:
+                    WorkloadBinding is a link between a configuration resource
+                    and a workload resource.
+                  properties:
+                    conditions:
+                      description:
+                        conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
+                      items:
+                        description:
+                          ConfigResourceCondition describes the status
+                          of configuration resources linked to Prometheus, PrometheusAgent,
+                          Alertmanager or ThanosRuler.
+                        properties:
+                          lastTransitionTime:
+                            description:
+                              lastTransitionTime defines the time of the
+                              last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description:
+                              message defines the human-readable message
+                              indicating details for the condition's last transition.
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration defines the .metadata.generation that the
+                              condition was set based upon. For instance, if `.metadata.generation` is
+                              currently 12, but the `.status.conditions[].observedGeneration` is 9, the
+                              condition is out of date with respect to the current state of the object.
+                            format: int64
+                            type: integer
+                          reason:
+                            description: reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition.
+                            minLength: 1
+                            type: string
+                          type:
+                            description: |-
+                              type of the condition being reported.
+                              Currently, only "Accepted" is supported.
+                            enum:
+                              - Accepted
+                            minLength: 1
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    group:
+                      description: group defines the group of the referenced resource.
+                      enum:
+                        - monitoring.coreos.com
+                      type: string
+                    name:
+                      description: name defines the name of the referenced object.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description:
+                        namespace defines the namespace of the referenced
+                        object.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description:
+                        resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
+                      enum:
+                        - prometheuses
+                        - prometheusagents
+                        - thanosrulers
+                        - alertmanagers
+                      type: string
+                  required:
+                    - group
+                    - name
+                    - namespace
+                    - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                  - group
+                  - resource
+                  - name
+                  - namespace
+                x-kubernetes-list-type: map
             type: object
         required:
-        - spec
+          - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_probes.yaml
+++ b/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_probes.yaml
@@ -3,26 +3,33 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-    operator.prometheus.io/version: 0.74.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.92.0
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
   names:
     categories:
-    - prometheus-operator
+      - prometheus-operator
     kind: Probe
     listKind: ProbeList
     plural: probes
     shortNames:
-    - prb
+      - prb
     singular: probe
   scope: Namespaced
   versions:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Probe defines monitoring for a set of static targets or ingresses.
+        description: |-
+          The `Probe` custom resource definition (CRD) defines how to scrape metrics from prober exporters such as the [blackbox exporter](https://github.com/prometheus/blackbox_exporter).
+
+          The `Probe` resource needs 2 pieces of information:
+          * The list of probed addresses which can be defined statically or by discovering Kubernetes Ingress objects.
+          * The prober which exposes the availability of probed endpoints (over various protocols such HTTP, TCP, ICMP, ...) as Prometheus metrics.
+
+          `Prometheus` and `PrometheusAgent` objects select `Probe` objects using label and namespace selectors.
         properties:
           apiVersion:
             description: |-
@@ -42,244 +49,296 @@ spec:
           metadata:
             type: object
           spec:
-            description: Specification of desired Ingress selection for target discovery
-              by Prometheus.
+            description:
+              spec defines the specification of desired Ingress selection
+              for target discovery by Prometheus.
             properties:
               authorization:
-                description: Authorization section for this endpoint
+                description: |-
+                  authorization configures the Authorization header credentials used by
+                  the client.
+
+                  Cannot be set at the same time as `basicAuth`, `bearerTokenSecret` or `oauth2`.
                 properties:
                   credentials:
-                    description: Selects a key of a Secret in the namespace that contains
-                      the credentials for authentication.
+                    description:
+                      credentials defines a key of a Secret in the namespace
+                      that contains the credentials for authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
                     description: |-
-                      Defines the authentication type. The value is case-insensitive.
-
+                      type defines the authentication type. The value is case-insensitive.
 
                       "Basic" is not a supported value.
-
 
                       Default: "Bearer"
                     type: string
                 type: object
               basicAuth:
                 description: |-
-                  BasicAuth allow an endpoint to authenticate over basic authentication.
-                  More info: https://prometheus.io/docs/operating/configuration/#endpoint
+                  basicAuth defines the Basic Authentication credentials used by the
+                  client.
+
+                  Cannot be set at the same time as `authorization`, `bearerTokenSecret` or `oauth2`.
                 properties:
                   password:
                     description: |-
-                      `password` specifies a key of a Secret containing the password for
+                      password defines a key of a Secret containing the password for
                       authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
                     description: |-
-                      `username` specifies a key of a Secret containing the username for
+                      username defines a key of a Secret containing the username for
                       authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               bearerTokenSecret:
                 description: |-
-                  Secret to mount to read bearer token for scraping targets. The secret
-                  needs to be in the same namespace as the probe and accessible by
-                  the Prometheus Operator.
+                  bearerTokenSecret defines a key of a Secret containing the bearer token
+                  used by the client for authentication. The secret needs to be in the
+                  same namespace as the custom resource and readable by the Prometheus
+                  Operator.
+
+                  Cannot be set at the same time as `authorization`, `basicAuth` or `oauth2`.
+
+                  Deprecated: use `authorization` instead.
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
+                    description:
+                      The key of the secret to select from.  Must be a
                       valid secret key.
                     type: string
                   name:
+                    default: ""
                     description: |-
                       Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                     type: string
                   optional:
                     description: Specify whether the Secret or its key must be defined
                     type: boolean
                 required:
-                - key
+                  - key
                 type: object
                 x-kubernetes-map-type: atomic
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
+              enableHttp2:
+                description: enableHttp2 can be used to disable HTTP2.
+                type: boolean
+              fallbackScrapeProtocol:
+                description: |-
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  - PrometheusText1.0.0
+                type: string
+              followRedirects:
+                description: |-
+                  followRedirects defines whether the client should follow HTTP 3xx
+                  redirects.
+                type: boolean
               interval:
                 description: |-
-                  Interval at which targets are probed using the configured prober.
+                  interval at which targets are probed using the configured prober.
                   If not specified Prometheus' global scrape interval is used.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               jobName:
-                description: The job name assigned to scraped metrics by default.
+                description: jobName assigned to scraped metrics by default.
                 type: string
               keepDroppedTargets:
                 description: |-
-                  Per-scrape limit on the number of targets dropped by relabeling
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
                   that will be kept in memory. 0 means no limit.
-
 
                   It requires Prometheus >= v2.47.0.
                 format: int64
                 type: integer
               labelLimit:
                 description: |-
-                  Per-scrape limit on number of labels that will be accepted for a sample.
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels name that will be accepted for a sample.
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels value that will be accepted for a sample.
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               metricRelabelings:
-                description: MetricRelabelConfigs to apply to samples before ingestion.
+                description:
+                  metricRelabelings defines the RelabelConfig to apply
+                  to samples before ingestion.
                 items:
                   description: |-
                     RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                     scraped samples and remote write samples.
-
 
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
                       default: replace
                       description: |-
-                        Action to perform based on the regex matching.
-
+                        action to perform based on the regex matching.
 
                         `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                         Default: "Replace"
                       enum:
-                      - replace
-                      - Replace
-                      - keep
-                      - Keep
-                      - drop
-                      - Drop
-                      - hashmod
-                      - HashMod
-                      - labelmap
-                      - LabelMap
-                      - labeldrop
-                      - LabelDrop
-                      - labelkeep
-                      - LabelKeep
-                      - lowercase
-                      - Lowercase
-                      - uppercase
-                      - Uppercase
-                      - keepequal
-                      - KeepEqual
-                      - dropequal
-                      - DropEqual
+                        - replace
+                        - Replace
+                        - keep
+                        - Keep
+                        - drop
+                        - Drop
+                        - hashmod
+                        - HashMod
+                        - labelmap
+                        - LabelMap
+                        - labeldrop
+                        - LabelDrop
+                        - labelkeep
+                        - LabelKeep
+                        - lowercase
+                        - Lowercase
+                        - uppercase
+                        - Uppercase
+                        - keepequal
+                        - KeepEqual
+                        - dropequal
+                        - DropEqual
                       type: string
                     modulus:
                       description: |-
-                        Modulus to take of the hash of the source label values.
-
+                        modulus to take of the hash of the source label values.
 
                         Only applicable when the action is `HashMod`.
                       format: int64
                       type: integer
                     regex:
-                      description: Regular expression against which the extracted
-                        value is matched.
+                      description:
+                        regex defines the regular expression against which
+                        the extracted value is matched.
                       type: string
                     replacement:
                       description: |-
-                        Replacement value against which a Replace action is performed if the
+                        replacement value against which a Replace action is performed if the
                         regular expression matches.
-
 
                         Regex capture groups are available.
                       type: string
                     separator:
-                      description: Separator is the string between concatenated SourceLabels.
+                      description:
+                        separator defines the string between concatenated
+                        SourceLabels.
                       type: string
                     sourceLabels:
                       description: |-
-                        The source labels select values from existing labels. Their content is
+                        sourceLabels defines the source labels select values from existing labels. Their content is
                         concatenated using the configured Separator and matched against the
                         configured regular expression.
                       items:
                         description: |-
-                          LabelName is a valid Prometheus label name which may only contain ASCII
-                          letters, numbers, as well as underscores.
-                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                          LabelName is a valid Prometheus label name.
+                          For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                          For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                         type: string
                       type: array
                     targetLabel:
                       description: |-
-                        Label to which the resulting string is written in a replacement.
-
+                        targetLabel defines the label to which the resulting string is written in a replacement.
 
                         It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                         `KeepEqual` and `DropEqual` actions.
-
 
                         Regex capture groups are available.
                       type: string
@@ -287,153 +346,530 @@ spec:
                 type: array
               module:
                 description: |-
-                  The module to use for probing specifying how to probe the target.
+                  module to use for probing specifying how to probe the target.
                   Example module configuring in the blackbox exporter:
                   https://github.com/prometheus/blackbox_exporter/blob/master/example.yml
                 type: string
+              nativeHistogramBucketLimit:
+                description: |-
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
+                  buckets will be merged to stay within the limit.
+                  It requires Prometheus >= v2.45.0.
+                format: int64
+                type: integer
+              nativeHistogramMinBucketFactor:
+                anyOf:
+                  - type: integer
+                  - type: string
+                description: |-
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
+                  buckets will be merged to increase the factor sufficiently.
+                  It requires Prometheus >= v2.50.0.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               oauth2:
-                description: OAuth2 for the URL. Only valid in Prometheus versions
-                  2.27.0 and newer.
+                description: |-
+                  oauth2 defines the OAuth2 settings used by the client.
+
+                  It requires Prometheus >= 2.27.0.
+
+                  Cannot be set at the same time as `authorization`, `basicAuth` or `bearerTokenSecret`.
                 properties:
                   clientId:
                     description: |-
-                      `clientId` specifies a key of a Secret or ConfigMap containing the
+                      clientId defines a key of a Secret or ConfigMap containing the
                       OAuth2 client's ID.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
                         properties:
                           key:
                             description: The key to select.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
+                            description:
+                              Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
+                            description:
+                              The key of the secret to select from.  Must
                               be a valid secret key.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description:
+                              Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   clientSecret:
                     description: |-
-                      `clientSecret` specifies a key of a Secret containing the OAuth2
+                      clientSecret defines a key of a Secret containing the OAuth2
                       client's secret.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   endpointParams:
                     additionalProperties:
                       type: string
                     description: |-
-                      `endpointParams` configures the HTTP parameters to append to the token
+                      endpointParams configures the HTTP parameters to append to the token
                       URL.
                     type: object
+                  noProxy:
+                    description: |-
+                      noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                      that should be excluded from proxying. IP and domain names can
+                      contain port numbers.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: string
+                  proxyConnectHeader:
+                    additionalProperties:
+                      items:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    description: |-
+                      proxyConnectHeader optionally specifies headers to send to
+                      proxies during CONNECT requests.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  proxyFromEnvironment:
+                    description: |-
+                      proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: boolean
+                  proxyUrl:
+                    description: proxyUrl defines the HTTP proxy server to use.
+                    pattern: ^(http|https|socks5)://.+$
+                    type: string
                   scopes:
-                    description: '`scopes` defines the OAuth2 scopes used for the
-                      token request.'
+                    description:
+                      scopes defines the OAuth2 scopes used for the token
+                      request.
                     items:
                       type: string
                     type: array
+                  tlsConfig:
+                    description: |-
+                      tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                      It requires Prometheus >= v2.43.0.
+                    properties:
+                      ca:
+                        description:
+                          ca defines the Certificate authority used when
+                          verifying server certificates.
+                        properties:
+                          configMap:
+                            description:
+                              configMap defines the ConfigMap containing
+                              data to use for the targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secret:
+                            description:
+                              secret defines the Secret containing data
+                              to use for the targets.
+                            properties:
+                              key:
+                                description:
+                                  The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      cert:
+                        description:
+                          cert defines the Client certificate to present
+                          when doing client-authentication.
+                        properties:
+                          configMap:
+                            description:
+                              configMap defines the ConfigMap containing
+                              data to use for the targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secret:
+                            description:
+                              secret defines the Secret containing data
+                              to use for the targets.
+                            properties:
+                              key:
+                                description:
+                                  The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      insecureSkipVerify:
+                        description:
+                          insecureSkipVerify defines how to disable target
+                          certificate validation.
+                        type: boolean
+                      keySecret:
+                        description:
+                          keySecret defines the Secret containing the client
+                          key file for the targets.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      maxVersion:
+                        description: |-
+                          maxVersion defines the maximum acceptable TLS version.
+
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                        enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                        type: string
+                      minVersion:
+                        description: |-
+                          minVersion defines the minimum acceptable TLS version.
+
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                        enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                        type: string
+                      serverName:
+                        description:
+                          serverName is used to verify the hostname for
+                          the targets.
+                        type: string
+                    type: object
                   tokenUrl:
-                    description: '`tokenURL` configures the URL to fetch the token
-                      from.'
-                    minLength: 1
+                    description: tokenUrl defines the URL to fetch the token from.
+                    pattern: ^(http|https)://.+$
                     type: string
                 required:
-                - clientId
-                - clientSecret
-                - tokenUrl
+                  - clientId
+                  - clientSecret
+                  - tokenUrl
                 type: object
+              params:
+                description: |-
+                  params defines the list of HTTP query parameters for the scrape.
+                  Please note that the `.spec.module` field takes precedence over the `module` parameter from this list when both are defined.
+                  The module name must be added using Module under ProbeSpec.
+                items:
+                  description:
+                    ProbeParam defines specification of extra parameters
+                    for a Probe.
+                  properties:
+                    name:
+                      description: name defines the parameter name
+                      minLength: 1
+                      type: string
+                    values:
+                      description: values defines the parameter values
+                      items:
+                        minLength: 1
+                        type: string
+                      minItems: 1
+                      type: array
+                  required:
+                    - name
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                  - name
+                x-kubernetes-list-type: map
               prober:
                 description: |-
-                  Specification for the prober to use for probing targets.
+                  prober defines the specification for the prober to use for probing targets.
                   The prober.URL parameter is required. Targets cannot be probed if left empty.
                 properties:
+                  noProxy:
+                    description: |-
+                      noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                      that should be excluded from proxying. IP and domain names can
+                      contain port numbers.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: string
                   path:
                     default: /probe
                     description: |-
-                      Path to collect metrics from.
+                      path to collect metrics from.
                       Defaults to `/probe`.
                     type: string
+                  proxyConnectHeader:
+                    additionalProperties:
+                      items:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    description: |-
+                      proxyConnectHeader optionally specifies headers to send to
+                      proxies during CONNECT requests.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  proxyFromEnvironment:
+                    description: |-
+                      proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: boolean
                   proxyUrl:
-                    description: Optional ProxyURL.
+                    description: proxyUrl defines the HTTP proxy server to use.
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scheme:
-                    description: |-
-                      HTTP scheme to use for scraping.
-                      `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling.
-                      If empty, Prometheus uses the default value `http`.
+                    description:
+                      scheme defines the HTTP scheme to use when scraping
+                      the prober.
                     enum:
-                    - http
-                    - https
+                      - http
+                      - https
+                      - HTTP
+                      - HTTPS
                     type: string
                   url:
-                    description: Mandatory URL of the prober.
+                    description: |-
+                      url defines the address of the prober.
+
+                      Unlike what the name indicates, the value should be in the form of
+                      `address:port` without any scheme which should be specified in the
+                      `scheme` field.
+                    minLength: 1
                     type: string
                 required:
-                - url
+                  - url
                 type: object
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
+                description:
+                  sampleLimit defines per-scrape limit on number of scraped
                   samples that will be accepted.
                 format: int64
                 type: integer
               scrapeClass:
-                description: The scrape class to apply.
+                description: scrapeClass defines the scrape class to apply.
                 minLength: 1
                 type: string
+              scrapeClassicHistograms:
+                description: |-
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
+                  It requires Prometheus >= v2.45.0.
+
+                  Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
+                type: boolean
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
               scrapeProtocols:
                 description: |-
-                  `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
                   protocols supported by Prometheus in order of preference (from most to least preferred).
 
-
                   If unset, Prometheus uses its default value.
-
 
                   It requires Prometheus >= v2.49.0.
                 items:
@@ -444,27 +880,32 @@ spec:
                     * `OpenMetricsText1.0.0`
                     * `PrometheusProto`
                     * `PrometheusText0.0.4`
+                    * `PrometheusText1.0.0`
                   enum:
-                  - PrometheusProto
-                  - OpenMetricsText0.0.1
-                  - OpenMetricsText1.0.0
-                  - PrometheusText0.0.4
+                    - PrometheusProto
+                    - OpenMetricsText0.0.1
+                    - OpenMetricsText1.0.0
+                    - PrometheusText0.0.4
+                    - PrometheusText1.0.0
                   type: string
                 type: array
                 x-kubernetes-list-type: set
               scrapeTimeout:
                 description: |-
-                  Timeout for scraping metrics from the Prometheus exporter.
+                  scrapeTimeout defines the timeout for scraping metrics from the Prometheus exporter.
                   If not specified, the Prometheus global scrape timeout is used.
+                  The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
+                description:
+                  targetLimit defines a limit on the number of scraped
                   targets that will be accepted.
                 format: int64
                 type: integer
               targets:
-                description: Targets defines a set of static or dynamically discovered
+                description:
+                  targets defines a set of static or dynamically discovered
                   targets to probe.
                 properties:
                   ingress:
@@ -474,22 +915,26 @@ spec:
                       If `staticConfig` is also defined, `staticConfig` takes precedence.
                     properties:
                       namespaceSelector:
-                        description: From which namespaces to select Ingress objects.
+                        description:
+                          namespaceSelector defines from which namespaces
+                          to select Ingress objects.
                         properties:
                           any:
                             description: |-
-                              Boolean describing whether all namespaces are selected in contrast to a
+                              any defines the boolean describing whether all namespaces are selected in contrast to a
                               list restricting them.
                             type: boolean
                           matchNames:
-                            description: List of namespace names to select from.
+                            description:
+                              matchNames defines the list of namespace
+                              names to select from.
                             items:
                               type: string
                             type: array
                         type: object
                       relabelingConfigs:
                         description: |-
-                          RelabelConfigs to apply to the label set of the target before it gets
+                          relabelingConfigs to apply to the label set of the target before it gets
                           scraped.
                           The original ingress address is available via the
                           `__tmp_prometheus_ingress_address` label. It can be used to customize the
@@ -501,98 +946,94 @@ spec:
                             RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                             scraped samples and remote write samples.
 
-
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
                               default: replace
                               description: |-
-                                Action to perform based on the regex matching.
-
+                                action to perform based on the regex matching.
 
                                 `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                                 Default: "Replace"
                               enum:
-                              - replace
-                              - Replace
-                              - keep
-                              - Keep
-                              - drop
-                              - Drop
-                              - hashmod
-                              - HashMod
-                              - labelmap
-                              - LabelMap
-                              - labeldrop
-                              - LabelDrop
-                              - labelkeep
-                              - LabelKeep
-                              - lowercase
-                              - Lowercase
-                              - uppercase
-                              - Uppercase
-                              - keepequal
-                              - KeepEqual
-                              - dropequal
-                              - DropEqual
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
                               type: string
                             modulus:
                               description: |-
-                                Modulus to take of the hash of the source label values.
-
+                                modulus to take of the hash of the source label values.
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
                               type: integer
                             regex:
-                              description: Regular expression against which the extracted
-                                value is matched.
+                              description:
+                                regex defines the regular expression against
+                                which the extracted value is matched.
                               type: string
                             replacement:
                               description: |-
-                                Replacement value against which a Replace action is performed if the
+                                replacement value against which a Replace action is performed if the
                                 regular expression matches.
-
 
                                 Regex capture groups are available.
                               type: string
                             separator:
-                              description: Separator is the string between concatenated
+                              description:
+                                separator defines the string between concatenated
                                 SourceLabels.
                               type: string
                             sourceLabels:
                               description: |-
-                                The source labels select values from existing labels. Their content is
+                                sourceLabels defines the source labels select values from existing labels. Their content is
                                 concatenated using the configured Separator and matched against the
                                 configured regular expression.
                               items:
                                 description: |-
-                                  LabelName is a valid Prometheus label name which may only contain ASCII
-                                  letters, numbers, as well as underscores.
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  LabelName is a valid Prometheus label name.
+                                  For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                  For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                                 type: string
                               type: array
                             targetLabel:
                               description: |-
-                                Label to which the resulting string is written in a replacement.
-
+                                targetLabel defines the label to which the resulting string is written in a replacement.
 
                                 It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                                 `KeepEqual` and `DropEqual` actions.
-
 
                                 Regex capture groups are available.
                               type: string
                           type: object
                         type: array
                       selector:
-                        description: Selector to select the Ingress objects.
+                        description: selector to select the Ingress objects.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
+                            description:
+                              matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
                               description: |-
@@ -600,7 +1041,8 @@ spec:
                                 relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
+                                  description:
+                                    key is the label key that the selector
                                     applies to.
                                   type: string
                                 operator:
@@ -617,11 +1059,13 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               required:
-                              - key
-                              - operator
+                                - key
+                                - operator
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           matchLabels:
                             additionalProperties:
                               type: string
@@ -643,12 +1087,13 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels assigned to all metrics scraped from the
-                          targets.
+                        description:
+                          labels defines all labels assigned to all metrics
+                          scraped from the targets.
                         type: object
                       relabelingConfigs:
                         description: |-
-                          RelabelConfigs to apply to the label set of the targets before it gets
+                          relabelingConfigs defines relabelings to be apply to the label set of the targets before it gets
                           scraped.
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         items:
@@ -656,225 +1101,395 @@ spec:
                             RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                             scraped samples and remote write samples.
 
-
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
                               default: replace
                               description: |-
-                                Action to perform based on the regex matching.
-
+                                action to perform based on the regex matching.
 
                                 `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                                 Default: "Replace"
                               enum:
-                              - replace
-                              - Replace
-                              - keep
-                              - Keep
-                              - drop
-                              - Drop
-                              - hashmod
-                              - HashMod
-                              - labelmap
-                              - LabelMap
-                              - labeldrop
-                              - LabelDrop
-                              - labelkeep
-                              - LabelKeep
-                              - lowercase
-                              - Lowercase
-                              - uppercase
-                              - Uppercase
-                              - keepequal
-                              - KeepEqual
-                              - dropequal
-                              - DropEqual
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
                               type: string
                             modulus:
                               description: |-
-                                Modulus to take of the hash of the source label values.
-
+                                modulus to take of the hash of the source label values.
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
                               type: integer
                             regex:
-                              description: Regular expression against which the extracted
-                                value is matched.
+                              description:
+                                regex defines the regular expression against
+                                which the extracted value is matched.
                               type: string
                             replacement:
                               description: |-
-                                Replacement value against which a Replace action is performed if the
+                                replacement value against which a Replace action is performed if the
                                 regular expression matches.
-
 
                                 Regex capture groups are available.
                               type: string
                             separator:
-                              description: Separator is the string between concatenated
+                              description:
+                                separator defines the string between concatenated
                                 SourceLabels.
                               type: string
                             sourceLabels:
                               description: |-
-                                The source labels select values from existing labels. Their content is
+                                sourceLabels defines the source labels select values from existing labels. Their content is
                                 concatenated using the configured Separator and matched against the
                                 configured regular expression.
                               items:
                                 description: |-
-                                  LabelName is a valid Prometheus label name which may only contain ASCII
-                                  letters, numbers, as well as underscores.
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  LabelName is a valid Prometheus label name.
+                                  For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                  For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                                 type: string
                               type: array
                             targetLabel:
                               description: |-
-                                Label to which the resulting string is written in a replacement.
-
+                                targetLabel defines the label to which the resulting string is written in a replacement.
 
                                 It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                                 `KeepEqual` and `DropEqual` actions.
-
 
                                 Regex capture groups are available.
                               type: string
                           type: object
                         type: array
                       static:
-                        description: The list of hosts to probe.
+                        description: static defines the list of hosts to probe.
                         items:
                           type: string
                         type: array
                     type: object
                 type: object
               tlsConfig:
-                description: TLS configuration to use when scraping the endpoint.
+                description: tlsConfig defines the TLS configuration used by the client.
                 properties:
                   ca:
-                    description: Certificate authority used when verifying server
-                      certificates.
+                    description:
+                      ca defines the Certificate authority used when verifying
+                      server certificates.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
                         properties:
                           key:
                             description: The key to select.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
+                            description:
+                              Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
+                            description:
+                              The key of the secret to select from.  Must
                               be a valid secret key.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description:
+                              Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   cert:
-                    description: Client certificate to present when doing client-authentication.
+                    description:
+                      cert defines the Client certificate to present when
+                      doing client-authentication.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
                         properties:
                           key:
                             description: The key to select.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
+                            description:
+                              Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
+                            description:
+                              The key of the secret to select from.  Must
                               be a valid secret key.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description:
+                              Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   insecureSkipVerify:
-                    description: Disable target certificate validation.
+                    description:
+                      insecureSkipVerify defines how to disable target
+                      certificate validation.
                     type: boolean
                   keySecret:
-                    description: Secret containing the client key file for the targets.
+                    description:
+                      keySecret defines the Secret containing the client
+                      key file for the targets.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
+                  maxVersion:
+                    description: |-
+                      maxVersion defines the maximum acceptable TLS version.
+
+                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                    enum:
+                      - TLS10
+                      - TLS11
+                      - TLS12
+                      - TLS13
+                    type: string
+                  minVersion:
+                    description: |-
+                      minVersion defines the minimum acceptable TLS version.
+
+                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                    enum:
+                      - TLS10
+                      - TLS11
+                      - TLS12
+                      - TLS13
+                    type: string
                   serverName:
-                    description: Used to verify the hostname for the targets.
+                    description:
+                      serverName is used to verify the hostname for the
+                      targets.
                     type: string
                 type: object
             type: object
+          status:
+            description: |-
+              status defines the status subresource. It is under active development and is updated only when the
+              "StatusForConfigurationResources" feature gate is enabled.
+
+              Most recent observed status of the Probe. Read-only.
+              More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bindings:
+                description:
+                  bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
+                items:
+                  description:
+                    WorkloadBinding is a link between a configuration resource
+                    and a workload resource.
+                  properties:
+                    conditions:
+                      description:
+                        conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
+                      items:
+                        description:
+                          ConfigResourceCondition describes the status
+                          of configuration resources linked to Prometheus, PrometheusAgent,
+                          Alertmanager or ThanosRuler.
+                        properties:
+                          lastTransitionTime:
+                            description:
+                              lastTransitionTime defines the time of the
+                              last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description:
+                              message defines the human-readable message
+                              indicating details for the condition's last transition.
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration defines the .metadata.generation that the
+                              condition was set based upon. For instance, if `.metadata.generation` is
+                              currently 12, but the `.status.conditions[].observedGeneration` is 9, the
+                              condition is out of date with respect to the current state of the object.
+                            format: int64
+                            type: integer
+                          reason:
+                            description: reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition.
+                            minLength: 1
+                            type: string
+                          type:
+                            description: |-
+                              type of the condition being reported.
+                              Currently, only "Accepted" is supported.
+                            enum:
+                              - Accepted
+                            minLength: 1
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    group:
+                      description: group defines the group of the referenced resource.
+                      enum:
+                        - monitoring.coreos.com
+                      type: string
+                    name:
+                      description: name defines the name of the referenced object.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description:
+                        namespace defines the namespace of the referenced
+                        object.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description:
+                        resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
+                      enum:
+                        - prometheuses
+                        - prometheusagents
+                        - thanosrulers
+                        - alertmanagers
+                      type: string
+                  required:
+                    - group
+                    - name
+                    - namespace
+                    - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                  - group
+                  - resource
+                  - name
+                  - namespace
+                x-kubernetes-list-type: map
+            type: object
         required:
-        - spec
+          - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_scrapeconfigs.yaml
@@ -3,19 +3,19 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-    operator.prometheus.io/version: 0.74.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.92.0
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
   names:
     categories:
-    - prometheus-operator
+      - prometheus-operator
     kind: ScrapeConfig
     listKind: ScrapeConfigList
     plural: scrapeconfigs
     shortNames:
-    - scfg
+      - scfg
     singular: scrapeconfig
   scope: Namespaced
   versions:
@@ -44,454 +44,53 @@ spec:
           metadata:
             type: object
           spec:
-            description: ScrapeConfigSpec is a specification of the desired configuration
-              for a scrape configuration.
+            description: spec defines the specification of ScrapeConfigSpec.
             properties:
-              NomadSDConfigs:
-                description: NomadSDConfigs defines a list of Nomad service discovery
-                  configurations.
-                items:
-                  description: |-
-                    NomadSDConfig configurations allow retrieving scrape targets from Nomad's Service API.
-                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#nomad_sd_config
-                  properties:
-                    allowStale:
-                      description: |-
-                        The information to access the Nomad API. It is to be defined
-                        as the Nomad documentation requires.
-                      type: boolean
-                    authorization:
-                      description: Authorization header to use on every scrape request.
-                      properties:
-                        credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        type:
-                          description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
-
-                            "Basic" is not a supported value.
-
-
-                            Default: "Bearer"
-                          type: string
-                      type: object
-                    basicAuth:
-                      description: BasicAuth information to use on every scrape request.
-                      properties:
-                        password:
-                          description: |-
-                            `password` specifies a key of a Secret containing the password for
-                            authentication.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        username:
-                          description: |-
-                            `username` specifies a key of a Secret containing the username for
-                            authentication.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                    enableHTTP2:
-                      description: Whether to enable HTTP2.
-                      type: boolean
-                    followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
-                      type: boolean
-                    namespace:
-                      type: string
-                    noProxy:
-                      description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
-                        that should be excluded from proxying. IP and domain names can
-                        contain port numbers.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      type: string
-                    oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be set at the same time as `authorization` or `basic_auth`.
-                      properties:
-                        clientId:
-                          description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
-                            OAuth2 client's ID.
-                          properties:
-                            configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            secret:
-                              description: Secret containing data to use for the targets.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                        clientSecret:
-                          description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
-                            client's secret.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        endpointParams:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
-                            URL.
-                          type: object
-                        scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
-                          items:
-                            type: string
-                          type: array
-                        tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
-                          type: string
-                      required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
-                      type: object
-                    proxyConnectHeader:
-                      additionalProperties:
-                        items:
-                          description: SecretKeySelector selects a key of a Secret.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        type: array
-                      description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
-                        proxies during CONNECT requests.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    proxyFromEnvironment:
-                      description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      type: boolean
-                    proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
-                      type: string
-                    refreshInterval:
-                      description: |-
-                        Duration is a valid time duration that can be parsed by Prometheus model.ParseDuration() function.
-                        Supported units: y, w, d, h, m, s, ms
-                        Examples: `30s`, `1m`, `1h20m15s`, `15d`
-                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
-                      type: string
-                    region:
-                      type: string
-                    server:
-                      minLength: 1
-                      type: string
-                    tagSeparator:
-                      type: string
-                    tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
-                      properties:
-                        ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
-                          properties:
-                            configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            secret:
-                              description: Secret containing data to use for the targets.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                        cert:
-                          description: Client certificate to present when doing client-authentication.
-                          properties:
-                            configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            secret:
-                              description: Secret containing data to use for the targets.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                        insecureSkipVerify:
-                          description: Disable target certificate validation.
-                          type: boolean
-                        keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        serverName:
-                          description: Used to verify the hostname for the targets.
-                          type: string
-                      type: object
-                  required:
-                  - server
-                  type: object
-                type: array
               authorization:
-                description: Authorization header to use on every scrape request.
+                description:
+                  authorization defines the header to use on every scrape
+                  request.
                 properties:
                   credentials:
-                    description: Selects a key of a Secret in the namespace that contains
-                      the credentials for authentication.
+                    description:
+                      credentials defines a key of a Secret in the namespace
+                      that contains the credentials for authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
                     description: |-
-                      Defines the authentication type. The value is case-insensitive.
-
+                      type defines the authentication type. The value is case-insensitive.
 
                       "Basic" is not a supported value.
-
 
                       Default: "Bearer"
                     type: string
                 type: object
               azureSDConfigs:
-                description: AzureSDConfigs defines a list of Azure service discovery
+                description:
+                  azureSDConfigs defines a list of Azure service discovery
                   configurations.
                 items:
                   description: |-
@@ -500,122 +99,875 @@ spec:
                   properties:
                     authenticationMethod:
                       description: |-
-                        # The authentication method, either `OAuth` or `ManagedIdentity` or `SDK`.
+                        authenticationMethod defines the authentication method, either `OAuth` or `ManagedIdentity` or `SDK`.
                         See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
                         SDK authentication method uses environment variables by default.
                         See https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication
                       enum:
-                      - OAuth
-                      - ManagedIdentity
-                      - SDK
+                        - OAuth
+                        - ManagedIdentity
+                        - SDK
+                        - WorkloadIdentity
                       type: string
+                    authorization:
+                      description: |-
+                        authorization defines the authorization header configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `oAuth2`, or `basicAuth`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: |-
+                        basicAuth defines the information to authenticate against the target HTTP endpoint.
+                        More info: https://prometheus.io/docs/operating/configuration/#endpoints
+                        Cannot be set at the same time as `authorization`, or `oAuth2`.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
                     clientID:
-                      description: Optional client ID. Only required with the OAuth
-                        authentication method.
+                      description:
+                        clientID defines client ID. Only required with
+                        the OAuth authentication method.
+                      minLength: 1
                       type: string
                     clientSecret:
-                      description: Optional client secret. Only required with the
-                        OAuth authentication method.
+                      description:
+                        clientSecret defines client secret. Only required
+                        with the OAuth authentication method.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
                     environment:
-                      description: The Azure environment.
+                      description: environment defines the Azure environment.
+                      minLength: 1
                       type: string
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
                     port:
                       description: |-
-                        The port to scrape metrics from. If using the public IP address, this must
+                        port defines the port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
                     refreshInterval:
-                      description: RefreshInterval configures the refresh interval
-                        at which Prometheus will re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     resourceGroup:
-                      description: Optional resource group name. Limits discovery
-                        to this resource group.
+                      description: |-
+                        resourceGroup defines resource group name. Limits discovery to this resource group.
+                        Requires  Prometheus v2.35.0 and above
+                      minLength: 1
                       type: string
                     subscriptionID:
-                      description: The subscription ID. Always required.
+                      description:
+                        subscriptionID defines subscription ID. Always
+                        required.
                       minLength: 1
                       type: string
                     tenantID:
-                      description: Optional tenant ID. Only required with the OAuth
-                        authentication method.
+                      description:
+                        tenantID defines tenant ID. Only required with
+                        the OAuth authentication method.
+                      minLength: 1
                       type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration applying
+                        to the target HTTP endpoint.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
                   required:
-                  - subscriptionID
+                    - subscriptionID
                   type: object
                 type: array
               basicAuth:
-                description: BasicAuth information to use on every scrape request.
+                description:
+                  basicAuth defines information to use on every scrape
+                  request.
                 properties:
                   password:
                     description: |-
-                      `password` specifies a key of a Secret containing the password for
+                      password defines a key of a Secret containing the password for
                       authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
                     description: |-
-                      `username` specifies a key of a Secret containing the username for
+                      username defines a key of a Secret containing the username for
                       authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
+              bodySizeLimit:
+                description: |-
+                  bodySizeLimit defines a per-scrape limit on the size of the uncompressed
+                  response body that will be accepted by Prometheus. Targets responding with
+                  a body larger than this many bytes will cause the scrape to fail.
+
+                  It requires Prometheus >= v2.28.0.
+                pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                type: string
               consulSDConfigs:
-                description: ConsulSDConfigs defines a list of Consul service discovery
+                description:
+                  consulSDConfigs defines a list of Consul service discovery
                   configurations.
                 items:
                   description: |-
@@ -624,230 +976,535 @@ spec:
                   properties:
                     allowStale:
                       description: |-
-                        Allow stale Consul results (see https://www.consul.io/api/features/consistency.html). Will reduce load on Consul.
+                        allowStale Consul results (see https://www.consul.io/api/features/consistency.html). Will reduce load on Consul.
                         If unset, Prometheus uses its default value.
                       type: boolean
                     authorization:
-                      description: Authorization header configuration to authenticate
-                        against the Consul Server.
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Consul Server.
+                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
                       description: |-
-                        BasicAuth information to authenticate against the Consul Server.
+                        basicAuth defines the information to authenticate against the Consul Server.
                         More info: https://prometheus.io/docs/operating/configuration/#endpoints
+                        Cannot be set at the same time as `authorization`, or `oauth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     datacenter:
-                      description: Consul Datacenter name, if not provided it will
-                        use the local Consul Agent Datacenter.
+                      description:
+                        datacenter defines the consul Datacenter name,
+                        if not provided it will use the local Consul Agent Datacenter.
+                      minLength: 1
                       type: string
                     enableHTTP2:
-                      description: |-
-                        Whether to enable HTTP2.
-                        If unset, Prometheus uses its default value.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
+                    filter:
+                      description: |-
+                        filter defines the filter expression used to filter the catalog results.
+                        See https://developer.hashicorp.com/consul/api-docs/catalog#filtering
+                        It requires Prometheus >= 3.0.0.
+                      minLength: 1
+                      type: string
                     followRedirects:
-                      description: |-
-                        Configure whether HTTP requests follow HTTP 3xx redirects.
-                        If unset, Prometheus uses its default value.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
+                    healthFilter:
+                      description: |-
+                        healthFilter defines the filter expression used to filter the health results.
+                        See https://developer.hashicorp.com/consul/api-docs/health#filtering
+                        It requires Prometheus >= 3.11.2.
+                      minLength: 1
+                      type: string
                     namespace:
-                      description: Namespaces are only supported in Consul Enterprise.
+                      description: |-
+                        namespace are only supported in Consul Enterprise.
+
+                        It requires Prometheus >= 2.28.0.
+                      minLength: 1
                       type: string
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     nodeMeta:
                       additionalProperties:
                         type: string
-                      description: Node metadata key/value pairs to filter nodes for
-                        a given service.
+                      description: |-
+                        nodeMeta defines the node metadata key/value pairs to filter nodes for a given service.
+                        Starting with Consul 1.14, it is recommended to use `filter` with the `NodeMeta` selector instead.
                       type: object
                       x-kubernetes-map-type: atomic
                     oauth2:
-                      description: Optional OAuth 2.0 configuration.
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     partition:
-                      description: Admin Partitions are only supported in Consul Enterprise.
+                      description:
+                        partition defines the admin Partitions are only
+                        supported in Consul Enterprise.
+                      minLength: 1
+                      type: string
+                    pathPrefix:
+                      description: |-
+                        pathPrefix defines the prefix for URIs for when consul is behind an API gateway (reverse proxy).
+
+                        It requires Prometheus >= 2.45.0.
+                      minLength: 1
                       type: string
                     proxyConnectHeader:
                       additionalProperties:
@@ -855,238 +1512,315 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
-                        The time after which the provided names are refreshed.
-                        On large setup it might be a good idea to increase this value because the catalog will change all the time.
-                        If unset, Prometheus uses its default value.
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     scheme:
-                      description: HTTP Scheme default "http"
+                      description: scheme defines the HTTP Scheme.
                       enum:
-                      - HTTP
-                      - HTTPS
+                        - http
+                        - https
+                        - HTTP
+                        - HTTPS
                       type: string
                     server:
-                      description: A valid string consisting of a hostname or IP followed
-                        by an optional port number.
+                      description:
+                        server defines the consul server address. A valid
+                        string consisting of a hostname or IP followed by an optional
+                        port number.
                       minLength: 1
                       type: string
                     services:
-                      description: A list of services for which targets are retrieved.
-                        If omitted, all services are scraped.
+                      description:
+                        services defines a list of services for which targets
+                        are retrieved. If omitted, all services are scraped.
                       items:
                         type: string
                       type: array
-                      x-kubernetes-list-type: atomic
+                      x-kubernetes-list-type: set
                     tagSeparator:
                       description: |-
-                        The string by which Consul tags are joined into the tag label.
+                        tagSeparator defines the string by which Consul tags are joined into the tag label.
                         If unset, Prometheus uses its default value.
+                      minLength: 1
                       type: string
                     tags:
-                      description: An optional list of tags used to filter nodes for
-                        a given service. Services must contain all tags in the list.
+                      description: |-
+                        tags defines an optional list of tags used to filter nodes for a given service. Services must contain all tags in the list.
+                        Starting with Consul 1.14, it is recommended to use `filter` with the `ServiceTags` selector instead.
                       items:
                         type: string
                       type: array
-                      x-kubernetes-list-type: atomic
+                      x-kubernetes-list-type: set
                     tlsConfig:
-                      description: TLS Config
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Consul API.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     tokenRef:
-                      description: Consul ACL TokenRef, if not provided it will use
-                        the ACL from the local Consul Agent.
+                      description:
+                        tokenRef defines the consul ACL TokenRef, if not
+                        provided it will use the ACL from the local Consul Agent.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                   required:
-                  - server
+                    - server
                   type: object
                 type: array
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
               digitalOceanSDConfigs:
-                description: DigitalOceanSDConfigs defines a list of DigitalOcean
+                description:
+                  digitalOceanSDConfigs defines a list of DigitalOcean
                   service discovery configurations.
                 items:
                   description: |-
@@ -1096,159 +1830,427 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        Authorization header configuration to authenticate against the DigitalOcean API.
+                        authorization defines the header configuration to authenticate against the DigitalOcean API.
                         Cannot be set at the same time as `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be set at the same time as `authorization`.
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     port:
-                      description: The port to scrape metrics from.
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     proxyConnectHeader:
                       additionalProperties:
@@ -1256,181 +2258,243 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
-                      description: Refresh interval to re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the DigitalOcean API.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   type: object
                 type: array
               dnsSDConfigs:
-                description: DNSSDConfigs defines a list of DNS service discovery
+                description:
+                  dnsSDConfigs defines a list of DNS service discovery
                   configurations.
                 items:
                   description: |-
@@ -1439,42 +2503,49 @@ spec:
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#dns_sd_config
                   properties:
                     names:
-                      description: A list of DNS domain names to be queried.
+                      description:
+                        names defines a list of DNS domain names to be
+                        queried.
                       items:
+                        minLength: 1
                         type: string
                       minItems: 1
                       type: array
                     port:
                       description: |-
-                        The port number used if the query type is not SRV
+                        port defines the port to scrape metrics from. If using the public IP address, this must
                         Ignored for SRV records
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     refreshInterval:
                       description: |-
-                        RefreshInterval configures the time after which the provided names are refreshed.
+                        refreshInterval defines the time after which the provided names are refreshed.
                         If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     type:
                       description: |-
-                        The type of DNS query to perform. One of SRV, A, AAAA, MX or NS.
+                        type defines the type of DNS query to perform. One of SRV, A, AAAA, MX or NS.
                         If not set, Prometheus uses its default value.
 
-
-                        When set to NS, It requires Prometheus >= 2.49.0.
+                        When set to NS, it requires Prometheus >= v2.49.0.
+                        When set to MX, it requires Prometheus >= v2.38.0
                       enum:
-                      - SRV
-                      - A
-                      - AAAA
-                      - MX
-                      - NS
+                        - A
+                        - AAAA
+                        - MX
+                        - NS
+                        - SRV
                       type: string
                   required:
-                  - names
+                    - names
                   type: object
                 type: array
               dockerSDConfigs:
-                description: DockerSDConfigs defines a list of Docker service discovery
+                description:
+                  dockerSDConfigs defines a list of Docker service discovery
                   configurations.
                 items:
                   description: |-
@@ -1485,235 +2556,535 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        Authorization header configuration to authenticate against the Docker API.
+                        authorization defines the header configuration to authenticate against the Docker daemon.
                         Cannot be set at the same time as `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
-                      description: BasicAuth information to use on every scrape request.
+                      description:
+                        basicAuth defines information to use on every scrape
+                        request.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     filters:
-                      description: Optional filters to limit the discovery process
-                        to a subset of the available resources.
+                      description:
+                        filters defines filters to limit the discovery
+                        process to a subset of the available resources.
                       items:
-                        description: DockerFilter is the configuration to limit the
-                          discovery process to a subset of available resources.
+                        description:
+                          Filter name and value pairs to limit the discovery
+                          process to a subset of available resources.
                         properties:
                           name:
+                            description: name of the Filter.
+                            minLength: 1
                             type: string
                           values:
+                            description: values defines values to filter on.
                             items:
+                              minLength: 1
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                         required:
-                        - name
-                        - values
+                          - name
+                          - values
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
                     host:
-                      description: Address of the docker daemon
+                      description: host defines the address of the docker daemon.
                       minLength: 1
+                      pattern: ^[a-zA-Z][a-zA-Z0-9+.-]*://.+$
                       type: string
                     hostNetworkingHost:
-                      description: The host to use if the container is in host networking
-                        mode.
+                      description:
+                        hostNetworkingHost defines the host to use if the
+                        container is in host networking mode.
+                      minLength: 1
                       type: string
+                    matchFirstNetwork:
+                      description: |-
+                        matchFirstNetwork defines whether to match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses true by default.
+                        It requires Prometheus >= v2.54.1.
+                      type: boolean
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be set at the same time as `authorization`.
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     port:
-                      description: The port to scrape metrics from.
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     proxyConnectHeader:
                       additionalProperties:
@@ -1721,183 +3092,1029 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
-                      description: Time after which the container is refreshed.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Docker daemon.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   required:
-                  - host
+                    - host
+                  type: object
+                type: array
+              dockerSwarmSDConfigs:
+                description:
+                  dockerSwarmSDConfigs defines a list of Dockerswarm service
+                  discovery configurations.
+                items:
+                  description: |-
+                    DockerSwarmSDConfig configurations allow retrieving scrape targets from Docker Swarm engine.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#dockerswarm_sd_config
+                  properties:
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Docker Swarm API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description:
+                        basicAuth defines information to use on every scrape
+                        request.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    filters:
+                      description: |-
+                        filters defines the filters to limit the discovery process to a subset of available
+                        resources.
+                        The available filters are listed in the upstream documentation:
+                        Services: https://docs.docker.com/engine/api/v1.40/#operation/ServiceList
+                        Tasks: https://docs.docker.com/engine/api/v1.40/#operation/TaskList
+                        Nodes: https://docs.docker.com/engine/api/v1.40/#operation/NodeList
+                      items:
+                        description:
+                          Filter name and value pairs to limit the discovery
+                          process to a subset of available resources.
+                        properties:
+                          name:
+                            description: name of the Filter.
+                            minLength: 1
+                            type: string
+                          values:
+                            description: values defines values to filter on.
+                            items:
+                              minLength: 1
+                              type: string
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                          - name
+                          - values
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    host:
+                      description: host defines the address of the Docker daemon
+                      pattern: ^[a-zA-Z][a-zA-Z0-9+.-]*://.+$
+                      type: string
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    port:
+                      description: |-
+                        port defines the port to scrape metrics from. If using the public IP address, this must
+                        tasks and services that don't have published ports.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    role:
+                      description:
+                        role of the targets to retrieve. Must be `Services`,
+                        `Tasks`, or `Nodes`.
+                      enum:
+                        - Services
+                        - Tasks
+                        - Nodes
+                      type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Docker Swarm daemon.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                  required:
+                    - host
+                    - role
                   type: object
                 type: array
               ec2SDConfigs:
-                description: EC2SDConfigs defines a list of EC2 service discovery
+                description:
+                  ec2SDConfigs defines a list of EC2 service discovery
                   configurations.
                 items:
                   description: |-
@@ -1905,100 +4122,384 @@ spec:
                     The private IP address is used by default, but may be changed to the public IP address with relabeling.
                     The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
+
+                    The EC2 service discovery requires AWS API keys or role ARN for authentication.
+                    BasicAuth, Authorization and OAuth2 fields are not present on purpose.
                   properties:
                     accessKey:
-                      description: AccessKey is the AWS API key.
+                      description: accessKey defines the AWS API key.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    enableHTTP2:
+                      description: |-
+                        enableHTTP2 defines whether to enable HTTP2.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
                     filters:
                       description: |-
-                        Filters can be used optionally to filter the instance list by other criteria.
+                        filters can be used optionally to filter the instance list by other criteria.
                         Available filter criteria can be found here:
                         https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
                         Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+                        It requires Prometheus >= v2.3.0
                       items:
-                        description: EC2Filter is the configuration for filtering
-                          EC2 instances.
+                        description:
+                          Filter name and value pairs to limit the discovery
+                          process to a subset of available resources.
                         properties:
                           name:
+                            description: name of the Filter.
+                            minLength: 1
                             type: string
                           values:
+                            description: values defines values to filter on.
                             items:
+                              minLength: 1
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                         required:
-                        - name
-                        - values
+                          - name
+                          - values
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    followRedirects:
+                      description: |-
+                        followRedirects defines whether HTTP requests follow HTTP 3xx redirects.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
                     port:
                       description: |-
-                        The port to scrape metrics from. If using the public IP address, this must
+                        port defines the port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
                     refreshInterval:
-                      description: RefreshInterval configures the refresh interval
-                        at which Prometheus will re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     region:
-                      description: The AWS region
+                      description: region defines the AWS region.
+                      minLength: 1
                       type: string
                     roleARN:
-                      description: AWS Role ARN, an alternative to using AWS API keys.
+                      description:
+                        roleARN defines an alternative to using AWS API
+                        keys.
+                      minLength: 1
                       type: string
                     secretKey:
-                      description: SecretKey is the AWS API secret.
+                      description: secretKey defines the AWS API secret.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    tlsConfig:
+                      description: |-
+                        tlsConfig defines the TLS configuration to connect to the EC2 API.
+                        It requires Prometheus >= v2.41.0
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
                   type: object
                 type: array
               enableCompression:
                 description: |-
-                  When false, Prometheus will request uncompressed response from the scraped target.
-
+                  enableCompression when false, Prometheus will request uncompressed response from the scraped target.
 
                   It requires Prometheus >= v2.49.0.
 
-
                   If unset, Prometheus uses true by default.
                 type: boolean
+              enableHTTP2:
+                description: enableHTTP2 defines whether to enable HTTP2.
+                type: boolean
               eurekaSDConfigs:
-                description: EurekaSDConfigs defines a list of Eureka service discovery
+                description:
+                  eurekaSDConfigs defines a list of Eureka service discovery
                   configurations.
                 items:
                   description: |-
@@ -2007,205 +4508,482 @@ spec:
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#eureka_sd_config
                   properties:
                     authorization:
-                      description: Authorization header to use on every scrape request.
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Eureka server.
+                        Cannot be set at the same time as `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
-                      description: BasicAuth information to use on every scrape request.
+                      description:
+                        basicAuth defines the BasicAuth information to
+                        use on every scrape request.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be set at the same time as `authorization` or `basic_auth`.
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     proxyConnectHeader:
                       additionalProperties:
@@ -2213,187 +4991,263 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
-                      description: Refresh interval to re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     server:
-                      description: The URL to connect to the Eureka server.
-                      minLength: 1
+                      description:
+                        server defines the URL to connect to the Eureka
+                        server.
+                      pattern: ^https?://.+$
                       type: string
                     tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Eureka server.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   required:
-                  - server
+                    - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
-                description: FileSDConfigs defines a list of file service discovery
+                description:
+                  fileSDConfigs defines a list of file service discovery
                   configurations.
                 items:
                   description: |-
@@ -2402,7 +5256,7 @@ spec:
                   properties:
                     files:
                       description: |-
-                        List of files to be used for file discovery. Recommendation: use absolute paths. While relative paths work, the
+                        files defines the list of files to be used for file discovery. Recommendation: use absolute paths. While relative paths work, the
                         prometheus-operator project makes no guarantees about the working directory where the configuration file is
                         stored.
                         Files must be mounted using Prometheus.ConfigMaps or Prometheus.Secrets.
@@ -2412,17 +5266,20 @@ spec:
                         type: string
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
                     refreshInterval:
-                      description: RefreshInterval configures the refresh interval
-                        at which Prometheus will reload the content of the files.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                   required:
-                  - files
+                    - files
                   type: object
                 type: array
               gceSDConfigs:
-                description: GCESDConfigs defines a list of GCE service discovery
+                description:
+                  gceSDConfigs defines a list of GCE service discovery
                   configurations.
                 items:
                   description: |-
@@ -2431,11 +5288,9 @@ spec:
                     the public IP address with relabeling.
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#gce_sd_config
 
-
                     The GCE service discovery will load the Google Cloud credentials
                     from the file specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.
                     See https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform
-
 
                     A pre-requisite for using GCESDConfig is that a Secret containing valid
                     Google Cloud credentials is mounted into the Prometheus or PrometheusAgent
@@ -2444,40 +5299,49 @@ spec:
                   properties:
                     filter:
                       description: |-
-                        Filter can be used optionally to filter the instance list by other criteria
+                        filter defines the filter that can be used optionally to filter the instance list by other criteria
                         Syntax of this filter is described in the filter query parameter section:
                         https://cloud.google.com/compute/docs/reference/latest/instances/list
+                      minLength: 1
                       type: string
                     port:
                       description: |-
-                        The port to scrape metrics from. If using the public IP address, this must
+                        port defines the port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     project:
-                      description: The Google Cloud Project ID
+                      description: project defines the Google Cloud Project ID
                       minLength: 1
                       type: string
                     refreshInterval:
-                      description: RefreshInterval configures the refresh interval
-                        at which Prometheus will re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     tagSeparator:
-                      description: The tag separator is used to separate the tags
-                        on concatenation
+                      description:
+                        tagSeparator defines the tag separator is used
+                        to separate the tags on concatenation
+                      minLength: 1
                       type: string
                     zone:
-                      description: The zone of the scrape targets. If you need multiple
-                        zones use multiple GCESDConfigs.
+                      description:
+                        zone defines the zone of the scrape targets. If
+                        you need multiple zones use multiple GCESDConfigs.
                       minLength: 1
                       type: string
                   required:
-                  - project
-                  - zone
+                    - project
+                    - zone
                   type: object
                 type: array
               hetznerSDConfigs:
-                description: HetznerSDConfigs defines a list of Hetzner service discovery
+                description:
+                  hetznerSDConfigs defines a list of Hetzner service discovery
                   configurations.
                 items:
                   description: |-
@@ -2487,211 +5351,495 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        Authorization header configuration, required when role is hcloud.
-                        Role robot does not support bearer token authentication.
+                        authorization defines the header configuration to authenticate against the Hetzner API.
+                        Cannot be set at the same time as `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
-                      description: |-
-                        BasicAuth information to use on every scrape request, required when role is robot.
-                        Role hcloud does not support basic auth.
+                      description:
+                        basicAuth defines information to use on every scrape
+                        request.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
+                    labelSelector:
+                      description: |-
+                        labelSelector defines the label selector used to filter the servers when fetching them from the API.
+                        It requires Prometheus >= v3.5.0.
+                      minLength: 1
+                      type: string
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be used at the same time as `basic_auth` or `authorization`.
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     port:
-                      description: The port to scrape metrics from.
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     proxyConnectHeader:
                       additionalProperties:
@@ -2699,199 +5847,265 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
-                      description: The time after which the servers are refreshed.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     role:
-                      description: The Hetzner role of entities that should be discovered.
+                      description:
+                        role defines the Hetzner role of entities that
+                        should be discovered.
                       enum:
-                      - hcloud
-                      - Hcloud
-                      - robot
-                      - Robot
+                        - hcloud
+                        - Hcloud
+                        - robot
+                        - Robot
                       type: string
                     tlsConfig:
-                      description: TLS configuration to use on every scrape request.
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Hetzner API.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   required:
-                  - role
+                    - role
                   type: object
                 type: array
               honorLabels:
-                description: HonorLabels chooses the metric's labels on collisions
-                  with target labels.
+                description: |-
+                  honorLabels defines when true the metric's labels when they collide
+                  with the target's labels.
                 type: boolean
               honorTimestamps:
-                description: HonorTimestamps controls whether Prometheus respects
-                  the timestamps present in scraped data.
+                description: |-
+                  honorTimestamps defines whether Prometheus preserves the timestamps
+                  when exposed by the target.
                 type: boolean
               httpSDConfigs:
-                description: HTTPSDConfigs defines a list of HTTP service discovery
+                description:
+                  httpSDConfigs defines a list of HTTP service discovery
                   configurations.
                 items:
                   description: |-
@@ -2899,302 +6113,1434 @@ spec:
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
                   properties:
                     authorization:
-                      description: Authorization header configuration to authenticate
-                        against the target HTTP endpoint.
+                      description: |-
+                        authorization defines the authorization header configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `oAuth2`, or `basicAuth`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
                       description: |-
-                        BasicAuth information to authenticate against the target HTTP endpoint.
+                        basicAuth defines information to use on every scrape request.
                         More info: https://prometheus.io/docs/operating/configuration/#endpoints
+                        Cannot be set at the same time as `authorization`, or `oAuth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
                     proxyConnectHeader:
                       additionalProperties:
                         items:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
-                        RefreshInterval configures the refresh interval at which Prometheus will re-query the
-                        endpoint to update the target list.
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
+                      description:
+                        tlsConfig defines the TLS configuration applying
+                        to the target HTTP endpoint.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     url:
-                      description: URL from which the targets are fetched.
-                      minLength: 1
-                      pattern: ^http(s)?://.+$
+                      description:
+                        url defines the URL from which the targets are
+                        fetched.
+                      pattern: ^https?://.+$
                       type: string
                   required:
-                  - url
+                    - url
                   type: object
                 type: array
+              ionosSDConfigs:
+                description:
+                  ionosSDConfigs defines a list of IONOS service discovery
+                  configurations.
+                items:
+                  description: |-
+                    IonosSDConfig configurations allow retrieving scrape targets from IONOS resources.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ionos_sd_config
+                  properties:
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the IONOS API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    datacenterID:
+                      description:
+                        datacenterID defines the unique ID of the IONOS
+                        data center.
+                      minLength: 1
+                      type: string
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    port:
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the IONOS API.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                  required:
+                    - authorization
+                    - datacenterID
+                  type: object
+                type: array
+              jobName:
+                description: |-
+                  jobName defines the value of the `job` label assigned to the scraped metrics by default.
+
+                  The `job_name` field in the rendered scrape configuration is always controlled by the
+                  operator to prevent duplicate job names, which Prometheus does not allow. Instead the
+                  `job` label is set by means of relabeling configs.
+                minLength: 1
+                type: string
               keepDroppedTargets:
                 description: |-
-                  Per-scrape limit on the number of targets dropped by relabeling
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
                   that will be kept in memory. 0 means no limit.
-
 
                   It requires Prometheus >= v2.47.0.
                 format: int64
                 type: integer
               kubernetesSDConfigs:
-                description: KubernetesSDConfigs defines a list of Kubernetes service
+                description:
+                  kubernetesSDConfigs defines a list of Kubernetes service
                   discovery configurations.
                 items:
                   description: |-
@@ -3203,21 +7549,22 @@ spec:
                   properties:
                     apiServer:
                       description: |-
-                        The API server address consisting of a hostname or IP address followed
+                        apiServer defines the API server address consisting of a hostname or IP address followed
                         by an optional port number.
                         If left empty, Prometheus is assumed to run inside
                         of the cluster. It will discover API servers automatically and use the pod's
                         CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
+                      minLength: 1
                       type: string
                     attachMetadata:
                       description: |-
-                        Optional metadata to attach to discovered targets.
-                        It requires Prometheus >= v2.35.0 for `pod` role and
-                        Prometheus >= v2.37.0 for `endpoints` and `endpointslice` roles.
+                        attachMetadata defines the metadata to attach to discovered targets.
+                        It requires Prometheus >= v2.35.0 when using the `Pod` role and
+                        Prometheus >= v2.37.0 for `Endpoints` and `Endpointslice` roles.
                       properties:
                         node:
                           description: |-
-                            Attaches node metadata to discovered targets.
+                            node attaches node metadata to discovered targets.
                             When set to true, Prometheus must have the `get` permission on the
                             `Nodes` objects.
                             Only valid for Pod, Endpoint and Endpointslice roles.
@@ -3225,224 +7572,500 @@ spec:
                       type: object
                     authorization:
                       description: |-
-                        Authorization header to use on every scrape request.
+                        authorization defines the authorization header to use on every scrape request.
                         Cannot be set at the same time as `basicAuth`, or `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
                       description: |-
-                        BasicAuth information to use on every scrape request.
+                        basicAuth defines information to use on every scrape request.
                         Cannot be set at the same time as `authorization`, or `oauth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
                     namespaces:
-                      description: Optional namespace discovery. If omitted, Prometheus
-                        discovers targets across all namespaces.
+                      description:
+                        namespaces defines the namespace discovery. If
+                        omitted, Prometheus discovers targets across all namespaces.
                       properties:
                         names:
                           description: |-
-                            List of namespaces where to watch for resources.
+                            names defines a list of namespaces where to watch for resources.
                             If empty and `ownNamespace` isn't true, Prometheus watches for resources in all namespaces.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: set
                         ownNamespace:
-                          description: Includes the namespace in which the Prometheus
-                            pod exists to the list of watched namesapces.
+                          description:
+                            ownNamespace includes the namespace in which
+                            the Prometheus pod runs to the list of watched namespaces.
                           type: boolean
                       type: object
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
                       description: |-
-                        Optional OAuth 2.0 configuration.
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
                         Cannot be set at the same time as `authorization`, or `basicAuth`.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     proxyConnectHeader:
                       additionalProperties:
@@ -3450,228 +8073,289 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     role:
-                      description: Role of the Kubernetes entities that should be
-                        discovered.
+                      description: |-
+                        role defines the Kubernetes role of the entities that should be discovered.
+                        Role `Endpointslice` requires Prometheus >= v2.21.0
                       enum:
-                      - Node
-                      - node
-                      - Service
-                      - service
-                      - Pod
-                      - pod
-                      - Endpoints
-                      - endpoints
-                      - EndpointSlice
-                      - endpointslice
-                      - Ingress
-                      - ingress
+                        - Pod
+                        - Endpoints
+                        - Ingress
+                        - Service
+                        - Node
+                        - EndpointSlice
                       type: string
                     selectors:
-                      description: Selector to select objects.
+                      description: |-
+                        selectors defines the selector to select objects.
+                        It requires Prometheus >= v2.17.0
                       items:
                         description: K8SSelectorConfig is Kubernetes Selector Config
                         properties:
                           field:
+                            description: |-
+                              field defines an optional field selector to limit the service discovery to resources which have fields with specific values.
+                              e.g: `metadata.name=foobar`
+                            minLength: 1
                             type: string
                           label:
+                            description: |-
+                              label defines an optional label selector to limit the service discovery to resources with specific labels and label values.
+                              e.g: `node.kubernetes.io/instance-type=master`
+                            minLength: 1
                             type: string
                           role:
-                            description: Role is role of the service in Kubernetes.
+                            description: |-
+                              role defines the type of Kubernetes resource to limit the service discovery to.
+                              Accepted values are: Node, Pod, Endpoints, EndpointSlice, Service, Ingress.
                             enum:
-                            - Node
-                            - node
-                            - Service
-                            - service
-                            - Pod
-                            - pod
-                            - Endpoints
-                            - endpoints
-                            - EndpointSlice
-                            - endpointslice
-                            - Ingress
-                            - ingress
+                              - Pod
+                              - Endpoints
+                              - Ingress
+                              - Service
+                              - Node
+                              - EndpointSlice
                             type: string
                         required:
-                        - role
+                          - role
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
-                      - role
+                        - role
                       x-kubernetes-list-type: map
                     tlsConfig:
-                      description: TLS configuration to use on every scrape request.
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Kubernetes API.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   required:
-                  - role
+                    - role
                   type: object
                 type: array
               kumaSDConfigs:
-                description: KumaSDConfigs defines a list of Kuma service discovery
+                description:
+                  kumaSDConfigs defines a list of Kuma service discovery
                   configurations.
                 items:
                   description: |-
@@ -3679,214 +8363,494 @@ spec:
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kuma_sd_config
                   properties:
                     authorization:
-                      description: Authorization header to use on every scrape request.
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Kuma control plane.
+                        Cannot be set at the same time as `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
-                      description: BasicAuth information to use on every scrape request.
+                      description:
+                        basicAuth defines information to use on every scrape
+                        request.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     clientID:
-                      description: Client id is used by Kuma Control Plane to compute
-                        Monitoring Assignment for specific Prometheus backend.
+                      description: |-
+                        clientID is used by Kuma Control Plane to compute Monitoring Assignment for specific Prometheus backend.
+                        It requires Prometheus >= v2.50.0.
+                      minLength: 1
                       type: string
                     enableHTTP2:
-                      description: Whether to enable HTTP2.
+                      description: enableHTTP2 defines whether to enable HTTP2.
                       type: boolean
                     fetchTimeout:
-                      description: The time after which the monitoring assignments
-                        are refreshed.
+                      description:
+                        fetchTimeout defines the time after which the monitoring
+                        assignments are refreshed.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     followRedirects:
-                      description: Configure whether HTTP requests follow HTTP 3xx
-                        redirects.
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
                       type: boolean
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: string
                     oauth2:
-                      description: |-
-                        Optional OAuth 2.0 configuration.
-                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     proxyConnectHeader:
                       additionalProperties:
@@ -3894,311 +8858,3010 @@ spec:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: object
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                        If unset, Prometheus uses its default value.
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                        It requires Prometheus >= v2.43.0.
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
-                      pattern: ^http(s)?://.+$
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
-                      description: The time to wait between polling update requests.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     server:
-                      description: Address of the Kuma Control Plane's MADS xDS server.
-                      minLength: 1
+                      description:
+                        server defines the address of the Kuma Control
+                        Plane's MADS xDS server.
+                      pattern: ^https?://.+$
                       type: string
                     tlsConfig:
-                      description: TLS configuration to use on every scrape request
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Kuma control plane.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                   required:
-                  - server
+                    - server
                   type: object
                 type: array
               labelLimit:
                 description: |-
-                  Per-scrape limit on number of labels that will be accepted for a sample.
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels name that will be accepted for a sample.
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels value that will be accepted for a sample.
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
                   Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
+              lightSailSDConfigs:
+                description:
+                  lightSailSDConfigs defines a list of Lightsail service
+                  discovery configurations.
+                items:
+                  description: |-
+                    LightSailSDConfig configurations allow retrieving scrape targets from AWS Lightsail instances.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#lightsail_sd_config
+                  properties:
+                    accessKey:
+                      description: accessKey defines the AWS API key.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Lightsail API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: |-
+                        basicAuth defines information to use on every scrape request.
+                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    endpoint:
+                      description: endpoint defines the custom endpoint to be used.
+                      minLength: 1
+                      type: string
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    port:
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    region:
+                      description: region defines the AWS region.
+                      minLength: 1
+                      type: string
+                    roleARN:
+                      description:
+                        roleARN defines the AWS Role ARN, an alternative
+                        to using AWS API keys.
+                      minLength: 1
+                      type: string
+                    secretKey:
+                      description: secretKey defines the AWS API secret.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Lightsail API.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              linodeSDConfigs:
+                description:
+                  linodeSDConfigs defines a list of Linode service discovery
+                  configurations.
+                items:
+                  description: |-
+                    LinodeSDConfig configurations allow retrieving scrape targets from Linode's Linode APIv4.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#linode_sd_config
+                  properties:
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Linode API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    port:
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    region:
+                      description: region defines the region to filter on.
+                      minLength: 1
+                      type: string
+                    tagSeparator:
+                      description:
+                        tagSeparator defines the string by which Linode
+                        Instance tags are joined into the tag label.el.
+                      minLength: 1
+                      type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Linode API.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                  type: object
+                type: array
               metricRelabelings:
-                description: MetricRelabelConfigs to apply to samples before ingestion.
+                description:
+                  metricRelabelings defines the metricRelabelings to apply
+                  to samples before ingestion.
                 items:
                   description: |-
                     RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                     scraped samples and remote write samples.
-
 
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
                       default: replace
                       description: |-
-                        Action to perform based on the regex matching.
-
+                        action to perform based on the regex matching.
 
                         `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                         Default: "Replace"
                       enum:
-                      - replace
-                      - Replace
-                      - keep
-                      - Keep
-                      - drop
-                      - Drop
-                      - hashmod
-                      - HashMod
-                      - labelmap
-                      - LabelMap
-                      - labeldrop
-                      - LabelDrop
-                      - labelkeep
-                      - LabelKeep
-                      - lowercase
-                      - Lowercase
-                      - uppercase
-                      - Uppercase
-                      - keepequal
-                      - KeepEqual
-                      - dropequal
-                      - DropEqual
+                        - replace
+                        - Replace
+                        - keep
+                        - Keep
+                        - drop
+                        - Drop
+                        - hashmod
+                        - HashMod
+                        - labelmap
+                        - LabelMap
+                        - labeldrop
+                        - LabelDrop
+                        - labelkeep
+                        - LabelKeep
+                        - lowercase
+                        - Lowercase
+                        - uppercase
+                        - Uppercase
+                        - keepequal
+                        - KeepEqual
+                        - dropequal
+                        - DropEqual
                       type: string
                     modulus:
                       description: |-
-                        Modulus to take of the hash of the source label values.
-
+                        modulus to take of the hash of the source label values.
 
                         Only applicable when the action is `HashMod`.
                       format: int64
                       type: integer
                     regex:
-                      description: Regular expression against which the extracted
-                        value is matched.
+                      description:
+                        regex defines the regular expression against which
+                        the extracted value is matched.
                       type: string
                     replacement:
                       description: |-
-                        Replacement value against which a Replace action is performed if the
+                        replacement value against which a Replace action is performed if the
                         regular expression matches.
-
 
                         Regex capture groups are available.
                       type: string
                     separator:
-                      description: Separator is the string between concatenated SourceLabels.
+                      description:
+                        separator defines the string between concatenated
+                        SourceLabels.
                       type: string
                     sourceLabels:
                       description: |-
-                        The source labels select values from existing labels. Their content is
+                        sourceLabels defines the source labels select values from existing labels. Their content is
                         concatenated using the configured Separator and matched against the
                         configured regular expression.
                       items:
                         description: |-
-                          LabelName is a valid Prometheus label name which may only contain ASCII
-                          letters, numbers, as well as underscores.
-                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                          LabelName is a valid Prometheus label name.
+                          For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                          For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                         type: string
                       type: array
                     targetLabel:
                       description: |-
-                        Label to which the resulting string is written in a replacement.
-
+                        targetLabel defines the label to which the resulting string is written in a replacement.
 
                         It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                         `KeepEqual` and `DropEqual` actions.
 
-
                         Regex capture groups are available.
                       type: string
                   type: object
+                minItems: 1
                 type: array
               metricsPath:
-                description: MetricsPath HTTP path to scrape for metrics. If empty,
-                  Prometheus uses the default value (e.g. /metrics).
+                description:
+                  metricsPath defines the HTTP path to scrape for metrics.
+                  If empty, Prometheus uses the default value (e.g. /metrics).
+                minLength: 1
                 type: string
+              nameEscapingScheme:
+                description: |-
+                  nameEscapingScheme defines the metric name escaping mode to request through content negotiation.
+
+                  It requires Prometheus >= v3.4.0.
+                enum:
+                  - AllowUTF8
+                  - Underscores
+                  - Dots
+                  - Values
+                type: string
+              nameValidationScheme:
+                description: |-
+                  nameValidationScheme defines the validation scheme for metric and label names.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                  - UTF8
+                  - Legacy
+                type: string
+              nativeHistogramBucketLimit:
+                description: |-
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
+                  buckets will be merged to stay within the limit.
+                  It requires Prometheus >= v2.45.0.
+                format: int64
+                type: integer
+              nativeHistogramMinBucketFactor:
+                anyOf:
+                  - type: integer
+                  - type: string
+                description: |-
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
+                  buckets will be merged to increase the factor sufficiently.
+                  It requires Prometheus >= v2.50.0.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               noProxy:
                 description: |-
-                  `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                  noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                   that should be excluded from proxying. IP and domain names can
                   contain port numbers.
 
-
-                  It requires Prometheus >= v2.43.0.
+                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                 type: string
+              nomadSDConfigs:
+                description:
+                  nomadSDConfigs defines a list of Nomad service discovery
+                  configurations.
+                items:
+                  description: |-
+                    NomadSDConfig configurations allow retrieving scrape targets from Nomad's Service API.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#nomad_sd_config
+                  properties:
+                    allowStale:
+                      description: |-
+                        allowStale defines the information to access the Nomad API. It is to be defined
+                        as the Nomad documentation requires.
+                      type: boolean
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the Nomad API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description:
+                        basicAuth defines information to use on every scrape
+                        request.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    namespace:
+                      description: |-
+                        namespace defines the Nomad namespace to query for service discovery.
+                        When specified, only resources within this namespace will be discovered.
+                      minLength: 1
+                      type: string
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description:
+                        oauth2 defines the configuration to use on every
+                        scrape request.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    region:
+                      description: |-
+                        region defines the Nomad region to query for service discovery.
+                        When specified, only resources within this region will be discovered.
+                      minLength: 1
+                      type: string
+                    server:
+                      description: |-
+                        server defines the Nomad server address to connect to for service discovery.
+                        This should be the full URL including protocol (e.g., "https://nomad.example.com:4646").
+                      pattern: ^https?://.+$
+                      type: string
+                    tagSeparator:
+                      description: |-
+                        tagSeparator defines the separator used to join multiple tags.
+                        This determines how Nomad service tags are concatenated into Prometheus labels.
+                      minLength: 1
+                      type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Nomad API.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                  required:
+                    - server
+                  type: object
+                type: array
+              oauth2:
+                description:
+                  oauth2 defines the configuration to use on every scrape
+                  request.
+                properties:
+                  clientId:
+                    description: |-
+                      clientId defines a key of a Secret or ConfigMap containing the
+                      OAuth2 client's ID.
+                    properties:
+                      configMap:
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
+                        properties:
+                          key:
+                            description: The key to select.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the ConfigMap or its key
+                              must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      secret:
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  clientSecret:
+                    description: |-
+                      clientSecret defines a key of a Secret containing the OAuth2
+                      client's secret.
+                    properties:
+                      key:
+                        description:
+                          The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description:
+                          Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                      - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  endpointParams:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      endpointParams configures the HTTP parameters to append to the token
+                      URL.
+                    type: object
+                  noProxy:
+                    description: |-
+                      noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                      that should be excluded from proxying. IP and domain names can
+                      contain port numbers.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: string
+                  proxyConnectHeader:
+                    additionalProperties:
+                      items:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    description: |-
+                      proxyConnectHeader optionally specifies headers to send to
+                      proxies during CONNECT requests.
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  proxyFromEnvironment:
+                    description: |-
+                      proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                      It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                    type: boolean
+                  proxyUrl:
+                    description: proxyUrl defines the HTTP proxy server to use.
+                    pattern: ^(http|https|socks5)://.+$
+                    type: string
+                  scopes:
+                    description:
+                      scopes defines the OAuth2 scopes used for the token
+                      request.
+                    items:
+                      type: string
+                    type: array
+                  tlsConfig:
+                    description: |-
+                      tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                      It requires Prometheus >= v2.43.0.
+                    properties:
+                      ca:
+                        description:
+                          ca defines the Certificate authority used when
+                          verifying server certificates.
+                        properties:
+                          configMap:
+                            description:
+                              configMap defines the ConfigMap containing
+                              data to use for the targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secret:
+                            description:
+                              secret defines the Secret containing data
+                              to use for the targets.
+                            properties:
+                              key:
+                                description:
+                                  The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      cert:
+                        description:
+                          cert defines the Client certificate to present
+                          when doing client-authentication.
+                        properties:
+                          configMap:
+                            description:
+                              configMap defines the ConfigMap containing
+                              data to use for the targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secret:
+                            description:
+                              secret defines the Secret containing data
+                              to use for the targets.
+                            properties:
+                              key:
+                                description:
+                                  The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description:
+                                  Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      insecureSkipVerify:
+                        description:
+                          insecureSkipVerify defines how to disable target
+                          certificate validation.
+                        type: boolean
+                      keySecret:
+                        description:
+                          keySecret defines the Secret containing the client
+                          key file for the targets.
+                        properties:
+                          key:
+                            description:
+                              The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description:
+                              Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      maxVersion:
+                        description: |-
+                          maxVersion defines the maximum acceptable TLS version.
+
+                          It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                        enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                        type: string
+                      minVersion:
+                        description: |-
+                          minVersion defines the minimum acceptable TLS version.
+
+                          It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                        enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                        type: string
+                      serverName:
+                        description:
+                          serverName is used to verify the hostname for
+                          the targets.
+                        type: string
+                    type: object
+                  tokenUrl:
+                    description: tokenUrl defines the URL to fetch the token from.
+                    pattern: ^(http|https)://.+$
+                    type: string
+                required:
+                  - clientId
+                  - clientSecret
+                  - tokenUrl
+                type: object
               openstackSDConfigs:
-                description: OpenStackSDConfigs defines a list of OpenStack service
+                description:
+                  openstackSDConfigs defines a list of OpenStack service
                   discovery configurations.
                 items:
                   description: |-
@@ -4207,257 +11870,444 @@ spec:
                   properties:
                     allTenants:
                       description: |-
-                        Whether the service discovery should list all instances for all projects.
+                        allTenants defines whether the service discovery should list all instances for all projects.
                         It is only relevant for the 'instance' role and usually requires admin permissions.
                       type: boolean
                     applicationCredentialId:
-                      description: ApplicationCredentialID
+                      description: applicationCredentialId defines the OpenStack applicationCredentialId.
+                      minLength: 1
                       type: string
                     applicationCredentialName:
                       description: |-
-                        The ApplicationCredentialID or ApplicationCredentialName fields are
+                        applicationCredentialName defines the ApplicationCredentialID or ApplicationCredentialName fields are
                         required if using an application credential to authenticate. Some providers
                         allow you to create an application credential to authenticate rather than a
                         password.
+                      minLength: 1
                       type: string
                     applicationCredentialSecret:
                       description: |-
-                        The applicationCredentialSecret field is required if using an application
+                        applicationCredentialSecret defines the required field if using an application
                         credential to authenticate.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                     availability:
-                      description: Availability of the endpoint to connect to.
+                      description:
+                        availability defines the availability of the endpoint
+                        to connect to.
                       enum:
-                      - Public
-                      - public
-                      - Admin
-                      - admin
-                      - Internal
-                      - internal
+                        - Public
+                        - public
+                        - Admin
+                        - admin
+                        - Internal
+                        - internal
                       type: string
                     domainID:
-                      description: DomainID
+                      description: domainID defines The OpenStack domainID.
+                      minLength: 1
                       type: string
                     domainName:
                       description: |-
-                        At most one of domainId and domainName must be provided if using username
+                        domainName defines at most one of domainId and domainName that must be provided if using username
                         with Identity V3. Otherwise, either are optional.
+                      minLength: 1
                       type: string
                     identityEndpoint:
                       description: |-
-                        IdentityEndpoint specifies the HTTP endpoint that is required to work with
+                        identityEndpoint defines the HTTP endpoint that is required to work with
                         the Identity API of the appropriate version.
+                      pattern: ^https?://.+$
                       type: string
                     password:
                       description: |-
-                        Password for the Identity V2 and V3 APIs. Consult with your provider's
+                        password defines the password for the Identity V2 and V3 APIs. Consult with your provider's
                         control panel to discover your account's preferred method of authentication.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                     port:
                       description: |-
-                        The port to scrape metrics from. If using the public IP address, this must
+                        port defines the port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
                     projectID:
-                      description: ' ProjectID'
+                      description: projectID defines the OpenStack projectID.
+                      minLength: 1
                       type: string
                     projectName:
                       description: |-
-                        The ProjectId and ProjectName fields are optional for the Identity V2 API.
+                        projectName defines an optional field for the Identity V2 API.
                         Some providers allow you to specify a ProjectName instead of the ProjectId.
                         Some require both. Your provider's authentication policies will determine
                         how these fields influence authentication.
+                      minLength: 1
                       type: string
                     refreshInterval:
-                      description: Refresh interval to re-read the instance list.
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     region:
-                      description: The OpenStack Region.
+                      description: region defines the OpenStack Region.
                       minLength: 1
                       type: string
                     role:
-                      description: The OpenStack role of entities that should be discovered.
+                      description: |-
+                        role defines the OpenStack role of entities that should be discovered.
+
+                        Note: The `LoadBalancer` role requires Prometheus >= v3.2.0.
                       enum:
-                      - Instance
-                      - instance
-                      - Hypervisor
-                      - hypervisor
+                        - Instance
+                        - Hypervisor
+                        - LoadBalancer
                       type: string
                     tlsConfig:
-                      description: TLS configuration applying to the target HTTP endpoint.
+                      description:
+                        tlsConfig defines the TLS configuration applying
+                        to the target HTTP endpoint.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     userid:
-                      description: UserID
+                      description: userid defines the OpenStack userid.
+                      minLength: 1
                       type: string
                     username:
                       description: |-
-                        Username is required if using Identity V2 API. Consult with your provider's
+                        username defines the username required if using Identity V2 API. Consult with your provider's
                         control panel to discover your account's username.
                         In Identity V3, either userid or a combination of username
                         and domainId or domainName are needed
+                      minLength: 1
                       type: string
                   required:
-                  - region
-                  - role
+                    - region
+                    - role
+                  type: object
+                type: array
+              ovhcloudSDConfigs:
+                description:
+                  ovhcloudSDConfigs defines a list of OVHcloud service
+                  discovery configurations.
+                items:
+                  description: |-
+                    OVHCloudSDConfig configurations allow retrieving scrape targets from OVHcloud's dedicated servers and VPS using their API.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ovhcloud_sd_config
+                  properties:
+                    applicationKey:
+                      description: |-
+                        applicationKey defines the access key to use for OVHCloud API authentication.
+                        This is obtained from the OVHCloud API credentials at https://api.ovh.com.
+                      minLength: 1
+                      type: string
+                    applicationSecret:
+                      description: |-
+                        applicationSecret defines the secret key for OVHCloud API authentication.
+                        This contains the application secret obtained during OVHCloud API credential creation.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    consumerKey:
+                      description: |-
+                        consumerKey defines the consumer key for OVHCloud API authentication.
+                        This is the third component of OVHCloud's three-key authentication system.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    endpoint:
+                      description: |-
+                        endpoint defines a custom API endpoint to be used.
+                        When not specified, defaults to the standard OVHCloud API endpoint for the region.
+                      minLength: 1
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    service:
+                      description: |-
+                        service defines the service type of the targets to retrieve.
+                        Must be either `VPS` or `DedicatedServer` to specify which OVHCloud resources to discover.
+                      enum:
+                        - VPS
+                        - DedicatedServer
+                      type: string
+                  required:
+                    - applicationKey
+                    - applicationSecret
+                    - consumerKey
+                    - service
                   type: object
                 type: array
               params:
@@ -4465,7 +12315,7 @@ spec:
                   items:
                     type: string
                   type: array
-                description: Optional HTTP URL parameters
+                description: params defines optional HTTP URL parameters
                 type: object
                 x-kubernetes-map-type: atomic
               proxyConnectHeader:
@@ -4474,51 +12324,805 @@ spec:
                     description: SecretKeySelector selects a key of a Secret.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
                 description: |-
-                  ProxyConnectHeader optionally specifies headers to send to
+                  proxyConnectHeader optionally specifies headers to send to
                   proxies during CONNECT requests.
 
-
-                  It requires Prometheus >= v2.43.0.
+                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                 type: object
                 x-kubernetes-map-type: atomic
               proxyFromEnvironment:
                 description: |-
-                  Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
-                  If unset, Prometheus uses its default value.
+                  proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
-
-                  It requires Prometheus >= v2.43.0.
+                  It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                 type: boolean
               proxyUrl:
-                description: |-
-                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                  It requires Prometheus >= v2.43.0.
-                pattern: ^http(s)?://.+$
+                description: proxyUrl defines the HTTP proxy server to use.
+                pattern: ^(http|https|socks5)://.+$
                 type: string
+              puppetDBSDConfigs:
+                description:
+                  puppetDBSDConfigs defines a list of PuppetDB service
+                  discovery configurations.
+                items:
+                  description: |-
+                    PuppetDBSDConfig configurations allow retrieving scrape targets from PuppetDB resources.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#puppetdb_sd_config
+                  properties:
+                    authorization:
+                      description: |-
+                        authorization defines the header configuration to authenticate against the PuppetDB API.
+                        Cannot be set at the same time as `oauth2`.
+                      properties:
+                        credentials:
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            type defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: |-
+                        basicAuth defines information to use on every scrape request.
+                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                      properties:
+                        password:
+                          description: |-
+                            password defines a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            username defines a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    includeParameters:
+                      description: |-
+                        includeParameters defines whether to include the parameters as meta labels.
+                        Note: Enabling this exposes parameters in the Prometheus UI and API. Make sure
+                        that you don't have secrets exposed as parameters if you enable this.
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    oauth2:
+                      description: |-
+                        oauth2 defines the optional OAuth 2.0 configuration to authenticate against the target HTTP endpoint.
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            clientId defines a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            clientSecret defines a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            endpointParams configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
+                        scopes:
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
+                      type: object
+                    port:
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    query:
+                      description: |-
+                        query defines the Puppet Query Language (PQL) query. Only resources are supported.
+                        https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html
+                      minLength: 1
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the PuppetDB server.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                    url:
+                      description:
+                        url defines the URL of the PuppetDB root query
+                        endpoint.
+                      pattern: ^https?://.+$
+                      type: string
+                  required:
+                    - query
+                    - url
+                  type: object
+                type: array
               relabelings:
                 description: |-
-                  RelabelConfigs defines how to rewrite the target's labels before scraping.
+                  relabelings defines how to rewrite the target's labels before scraping.
                   Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields.
                   The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
                   More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
@@ -4527,121 +13131,485 @@ spec:
                     RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                     scraped samples and remote write samples.
 
-
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
                       default: replace
                       description: |-
-                        Action to perform based on the regex matching.
-
+                        action to perform based on the regex matching.
 
                         `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                         Default: "Replace"
                       enum:
-                      - replace
-                      - Replace
-                      - keep
-                      - Keep
-                      - drop
-                      - Drop
-                      - hashmod
-                      - HashMod
-                      - labelmap
-                      - LabelMap
-                      - labeldrop
-                      - LabelDrop
-                      - labelkeep
-                      - LabelKeep
-                      - lowercase
-                      - Lowercase
-                      - uppercase
-                      - Uppercase
-                      - keepequal
-                      - KeepEqual
-                      - dropequal
-                      - DropEqual
+                        - replace
+                        - Replace
+                        - keep
+                        - Keep
+                        - drop
+                        - Drop
+                        - hashmod
+                        - HashMod
+                        - labelmap
+                        - LabelMap
+                        - labeldrop
+                        - LabelDrop
+                        - labelkeep
+                        - LabelKeep
+                        - lowercase
+                        - Lowercase
+                        - uppercase
+                        - Uppercase
+                        - keepequal
+                        - KeepEqual
+                        - dropequal
+                        - DropEqual
                       type: string
                     modulus:
                       description: |-
-                        Modulus to take of the hash of the source label values.
-
+                        modulus to take of the hash of the source label values.
 
                         Only applicable when the action is `HashMod`.
                       format: int64
                       type: integer
                     regex:
-                      description: Regular expression against which the extracted
-                        value is matched.
+                      description:
+                        regex defines the regular expression against which
+                        the extracted value is matched.
                       type: string
                     replacement:
                       description: |-
-                        Replacement value against which a Replace action is performed if the
+                        replacement value against which a Replace action is performed if the
                         regular expression matches.
-
 
                         Regex capture groups are available.
                       type: string
                     separator:
-                      description: Separator is the string between concatenated SourceLabels.
+                      description:
+                        separator defines the string between concatenated
+                        SourceLabels.
                       type: string
                     sourceLabels:
                       description: |-
-                        The source labels select values from existing labels. Their content is
+                        sourceLabels defines the source labels select values from existing labels. Their content is
                         concatenated using the configured Separator and matched against the
                         configured regular expression.
                       items:
                         description: |-
-                          LabelName is a valid Prometheus label name which may only contain ASCII
-                          letters, numbers, as well as underscores.
-                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                          LabelName is a valid Prometheus label name.
+                          For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                          For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                         type: string
                       type: array
                     targetLabel:
                       description: |-
-                        Label to which the resulting string is written in a replacement.
-
+                        targetLabel defines the label to which the resulting string is written in a replacement.
 
                         It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                         `KeepEqual` and `DropEqual` actions.
 
-
                         Regex capture groups are available.
                       type: string
                   type: object
+                minItems: 1
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
+                description:
+                  sampleLimit defines per-scrape limit on number of scraped
                   samples that will be accepted.
                 format: int64
                 type: integer
+              scalewaySDConfigs:
+                description:
+                  scalewaySDConfigs defines a list of Scaleway instances
+                  and baremetal service discovery configurations.
+                items:
+                  description: |-
+                    ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services.
+                    See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+
+                    Note: The `_file` variants of credential fields (e.g. `secret_key_file`)
+                    from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
+                  properties:
+                    accessKey:
+                      description: accessKey defines the access key to use. https://console.scaleway.com/project/credentials
+                      minLength: 1
+                      type: string
+                    apiURL:
+                      description:
+                        apiURL defines the API URL to use when doing the
+                        server listing requests.
+                      pattern: ^https?://.+$
+                      type: string
+                    enableHTTP2:
+                      description: enableHTTP2 defines whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description:
+                        followRedirects defines whether HTTP requests follow
+                        HTTP 3xx redirects.
+                      type: boolean
+                    nameFilter:
+                      description:
+                        nameFilter defines a name filter (works as a LIKE)
+                        to apply on the server listing request.
+                      minLength: 1
+                      type: string
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
+                    port:
+                      description:
+                        port defines the port to scrape metrics from. If
+                        using the public IP address, this must
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    projectID:
+                      description: projectID defines the Project ID of the targets.
+                      minLength: 1
+                      type: string
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
+                      type: string
+                    refreshInterval:
+                      description: |-
+                        refreshInterval defines the time after which the provided names are refreshed.
+                        If not set, Prometheus uses its default value.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    role:
+                      description:
+                        role defines the service of the targets to retrieve.
+                        Must be `Instance` or `Baremetal`.
+                      enum:
+                        - Instance
+                        - Baremetal
+                      type: string
+                    secretKey:
+                      description:
+                        secretKey defines the secret key to use when listing
+                        targets.
+                      properties:
+                        key:
+                          description:
+                            The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description:
+                            Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    tagsFilter:
+                      description:
+                        tagsFilter defines a tag filter (a server needs
+                        to have all defined tags to be listed) to apply on the server
+                        listing request.
+                      items:
+                        minLength: 1
+                        type: string
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: set
+                    tlsConfig:
+                      description:
+                        tlsConfig defines the TLS configuration to connect
+                        to the Scaleway API.
+                      properties:
+                        ca:
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
+                          properties:
+                            configMap:
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
+                          type: boolean
+                        keySecret:
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        serverName:
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
+                          type: string
+                      type: object
+                    zone:
+                      description:
+                        zone defines the availability zone of your targets
+                        (e.g. fr-par-1).
+                      minLength: 1
+                      type: string
+                  required:
+                    - accessKey
+                    - projectID
+                    - role
+                    - secretKey
+                  type: object
+                type: array
               scheme:
-                description: |-
-                  Configures the protocol scheme used for requests.
-                  If empty, Prometheus uses HTTP by default.
+                description: scheme defines the protocol scheme used for requests.
                 enum:
-                - HTTP
-                - HTTPS
+                  - http
+                  - https
+                  - HTTP
+                  - HTTPS
                 type: string
               scrapeClass:
-                description: The scrape class to apply.
+                description: scrapeClass defines the scrape class to apply.
                 minLength: 1
                 type: string
+              scrapeClassicHistograms:
+                description: |-
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
+                  It requires Prometheus >= v2.45.0.
+
+                  Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
+                type: boolean
               scrapeInterval:
-                description: ScrapeInterval is the interval between consecutive scrapes.
+                description:
+                  scrapeInterval defines the interval between consecutive
+                  scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
               scrapeProtocols:
                 description: |-
-                  The protocols to negotiate during a scrape. It tells clients the
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
                   protocols supported by Prometheus in order of preference (from most to least preferred).
 
-
                   If unset, Prometheus uses its default value.
-
 
                   It requires Prometheus >= v2.49.0.
                 items:
@@ -4652,21 +13620,26 @@ spec:
                     * `OpenMetricsText1.0.0`
                     * `PrometheusProto`
                     * `PrometheusText0.0.4`
+                    * `PrometheusText1.0.0`
                   enum:
-                  - PrometheusProto
-                  - OpenMetricsText0.0.1
-                  - OpenMetricsText1.0.0
-                  - PrometheusText0.0.4
+                    - PrometheusProto
+                    - OpenMetricsText0.0.1
+                    - OpenMetricsText1.0.0
+                    - PrometheusText0.0.4
+                    - PrometheusText1.0.0
                   type: string
+                minItems: 1
                 type: array
                 x-kubernetes-list-type: set
               scrapeTimeout:
-                description: ScrapeTimeout is the number of seconds to wait until
-                  a scrape request times out.
+                description: |-
+                  scrapeTimeout defines the number of seconds to wait until a scrape request times out.
+                  The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               staticConfigs:
-                description: StaticConfigs defines a list of static targets with a
+                description:
+                  staticConfigs defines a list of static targets with a
                   common label set.
                 items:
                   description: |-
@@ -4676,156 +13649,348 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels assigned to all metrics scraped from the
-                        targets.
+                      description:
+                        labels defines labels assigned to all metrics scraped
+                        from the targets.
                       type: object
                       x-kubernetes-map-type: atomic
                     targets:
-                      description: List of targets for this static configuration.
+                      description:
+                        targets defines the list of targets for this static
+                        configuration.
                       items:
-                        description: Target represents a target for Prometheus to
+                        description:
+                          Target represents a target for Prometheus to
                           scrape
+                        minLength: 1
                         type: string
+                      minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
+                  required:
+                    - targets
                   type: object
                 type: array
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
+                description:
+                  targetLimit defines a limit on the number of scraped
                   targets that will be accepted.
                 format: int64
                 type: integer
               tlsConfig:
-                description: TLS configuration to use on every scrape request
+                description:
+                  tlsConfig defines the TLS configuration to use on every
+                  scrape request
                 properties:
                   ca:
-                    description: Certificate authority used when verifying server
-                      certificates.
+                    description:
+                      ca defines the Certificate authority used when verifying
+                      server certificates.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
                         properties:
                           key:
                             description: The key to select.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
+                            description:
+                              Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
+                            description:
+                              The key of the secret to select from.  Must
                               be a valid secret key.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description:
+                              Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   cert:
-                    description: Client certificate to present when doing client-authentication.
+                    description:
+                      cert defines the Client certificate to present when
+                      doing client-authentication.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
+                        description:
+                          configMap defines the ConfigMap containing data
+                          to use for the targets.
                         properties:
                           key:
                             description: The key to select.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
+                            description:
+                              Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
+                        description:
+                          secret defines the Secret containing data to
+                          use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
+                            description:
+                              The key of the secret to select from.  Must
                               be a valid secret key.
                             type: string
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description:
+                              Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   insecureSkipVerify:
-                    description: Disable target certificate validation.
+                    description:
+                      insecureSkipVerify defines how to disable target
+                      certificate validation.
                     type: boolean
                   keySecret:
-                    description: Secret containing the client key file for the targets.
+                    description:
+                      keySecret defines the Secret containing the client
+                      key file for the targets.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
+                        description:
+                          The key of the secret to select from.  Must be
                           a valid secret key.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
+                        description:
+                          Specify whether the Secret or its key must be
                           defined
                         type: boolean
                     required:
-                    - key
+                      - key
                     type: object
                     x-kubernetes-map-type: atomic
+                  maxVersion:
+                    description: |-
+                      maxVersion defines the maximum acceptable TLS version.
+
+                      It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                    enum:
+                      - TLS10
+                      - TLS11
+                      - TLS12
+                      - TLS13
+                    type: string
+                  minVersion:
+                    description: |-
+                      minVersion defines the minimum acceptable TLS version.
+
+                      It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                    enum:
+                      - TLS10
+                      - TLS11
+                      - TLS12
+                      - TLS13
+                    type: string
                   serverName:
-                    description: Used to verify the hostname for the targets.
+                    description:
+                      serverName is used to verify the hostname for the
+                      targets.
                     type: string
                 type: object
               trackTimestampsStaleness:
                 description: |-
-                  TrackTimestampsStaleness whether Prometheus tracks staleness of
+                  trackTimestampsStaleness defines whether Prometheus tracks staleness of
                   the metrics that have an explicit timestamp present in scraped data.
                   Has no effect if `honorTimestamps` is false.
                   It requires Prometheus >= v2.48.0.
                 type: boolean
             type: object
+            x-kubernetes-validations:
+              - message: at most one of basicAuth, authorization, or oauth2 can be configured
+                rule:
+                  "[has(self.basicAuth), has(self.authorization), has(self.oauth2)].filter(x,
+                  x).size() <= 1"
+          status:
+            description: |-
+              status defines the status subresource. It is under active development and is updated only when the
+              "StatusForConfigurationResources" feature gate is enabled.
+
+              Most recent observed status of the ScrapeConfig. Read-only.
+              More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bindings:
+                description:
+                  bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
+                items:
+                  description:
+                    WorkloadBinding is a link between a configuration resource
+                    and a workload resource.
+                  properties:
+                    conditions:
+                      description:
+                        conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
+                      items:
+                        description:
+                          ConfigResourceCondition describes the status
+                          of configuration resources linked to Prometheus, PrometheusAgent,
+                          Alertmanager or ThanosRuler.
+                        properties:
+                          lastTransitionTime:
+                            description:
+                              lastTransitionTime defines the time of the
+                              last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description:
+                              message defines the human-readable message
+                              indicating details for the condition's last transition.
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration defines the .metadata.generation that the
+                              condition was set based upon. For instance, if `.metadata.generation` is
+                              currently 12, but the `.status.conditions[].observedGeneration` is 9, the
+                              condition is out of date with respect to the current state of the object.
+                            format: int64
+                            type: integer
+                          reason:
+                            description: reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition.
+                            minLength: 1
+                            type: string
+                          type:
+                            description: |-
+                              type of the condition being reported.
+                              Currently, only "Accepted" is supported.
+                            enum:
+                              - Accepted
+                            minLength: 1
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    group:
+                      description: group defines the group of the referenced resource.
+                      enum:
+                        - monitoring.coreos.com
+                      type: string
+                    name:
+                      description: name defines the name of the referenced object.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description:
+                        namespace defines the namespace of the referenced
+                        object.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description:
+                        resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
+                      enum:
+                        - prometheuses
+                        - prometheusagents
+                        - thanosrulers
+                        - alertmanagers
+                      type: string
+                  required:
+                    - group
+                    - name
+                    - namespace
+                    - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                  - group
+                  - resource
+                  - name
+                  - namespace
+                x-kubernetes-list-type: map
+            type: object
         required:
-        - spec
+          - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_servicemonitors.yaml
+++ b/charts/opentelemetry-kube-stack/charts/prometheus-crds/crds/monitoring.coreos.com_servicemonitors.yaml
@@ -3,26 +3,34 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-    operator.prometheus.io/version: 0.74.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+    operator.prometheus.io/version: 0.92.0
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
   names:
     categories:
-    - prometheus-operator
+      - prometheus-operator
     kind: ServiceMonitor
     listKind: ServiceMonitorList
     plural: servicemonitors
     shortNames:
-    - smon
+      - smon
     singular: servicemonitor
   scope: Namespaced
   versions:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ServiceMonitor defines monitoring for a set of services.
+        description: |-
+          The `ServiceMonitor` custom resource definition (CRD) defines how `Prometheus` and `PrometheusAgent` can scrape metrics from a group of services.
+          Among other things, it allows to specify:
+          * The services to scrape via label selectors.
+          * The container ports to scrape.
+          * Authentication credentials to use.
+          * Target and metric relabeling.
+
+          `Prometheus` and `PrometheusAgent` objects select `ServiceMonitor` objects using label and namespace selectors.
         properties:
           apiVersion:
             description: |-
@@ -43,34 +51,47 @@ spec:
             type: object
           spec:
             description: |-
-              Specification of desired Service selection for target discovery by
+              spec defines the specification of desired Service selection for target discovery by
               Prometheus.
             properties:
               attachMetadata:
                 description: |-
-                  `attachMetadata` defines additional metadata which is added to the
+                  attachMetadata defines additional metadata which is added to the
                   discovered targets.
-
 
                   It requires Prometheus >= v2.37.0.
                 properties:
                   node:
                     description: |-
-                      When set to true, Prometheus must have the `get` permission on the
-                      `Nodes` objects.
+                      node when set to true, Prometheus attaches node metadata to the discovered
+                      targets.
+
+                      The Prometheus service account must have the `list` and `watch`
+                      permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:
                 description: |-
-                  When defined, bodySizeLimit specifies a job level limit on the size
+                  bodySizeLimit when defined, bodySizeLimit specifies a job level limit on the size
                   of uncompressed response body that will be accepted by Prometheus.
-
 
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              convertClassicHistogramsToNHCB:
+                description: |-
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  It requires Prometheus >= v3.0.0.
+                type: boolean
               endpoints:
-                description: List of endpoints part of this ServiceMonitor.
+                description: |-
+                  endpoints defines the list of endpoints part of this ServiceMonitor.
+                  Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
+                  In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
                 items:
                   description: |-
                     Endpoint defines an endpoint serving Prometheus metrics to be scraped by
@@ -78,371 +99,645 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        `authorization` configures the Authorization header credentials to use when
-                        scraping the target.
+                        authorization configures the Authorization header credentials used by
+                        the client.
 
-
-                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                        Cannot be set at the same time as `basicAuth`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description:
+                            credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
-
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
-
 
                             Default: "Bearer"
                           type: string
                       type: object
                     basicAuth:
                       description: |-
-                        `basicAuth` configures the Basic Authentication credentials to use when
-                        scraping the target.
+                        basicAuth defines the Basic Authentication credentials used by the
+                        client.
 
-
-                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                        Cannot be set at the same time as `authorization`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenFile:
                       description: |-
-                        File to read bearer token for scraping the target.
-
+                        bearerTokenFile defines the file to read bearer token for scraping the target.
 
                         Deprecated: use `authorization` instead.
                       type: string
                     bearerTokenSecret:
                       description: |-
-                        `bearerTokenSecret` specifies a key of a Secret containing the bearer
-                        token for scraping targets. The secret needs to be in the same namespace
-                        as the ServiceMonitor object and readable by the Prometheus Operator.
+                        bearerTokenSecret defines a key of a Secret containing the bearer token
+                        used by the client for authentication. The secret needs to be in the
+                        same namespace as the custom resource and readable by the Prometheus
+                        Operator.
 
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `oauth2`.
 
                         Deprecated: use `authorization` instead.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description:
+                            The key of the secret to select from.  Must
                             be a valid secret key.
                           type: string
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description:
+                            Specify whether the Secret or its key must
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: '`enableHttp2` can be used to disable HTTP2 when
-                        scraping the target.'
+                      description: enableHttp2 can be used to disable HTTP2.
                       type: boolean
                     filterRunning:
                       description: |-
-                        When true, the pods which are not running (e.g. either in Failed or
+                        filterRunning when true, the pods which are not running (e.g. either in Failed or
                         Succeeded state) are dropped during the target discovery.
 
-
                         If unset, the filtering is enabled.
-
 
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
                       type: boolean
                     followRedirects:
                       description: |-
-                        `followRedirects` defines whether the scrape requests should follow HTTP
-                        3xx redirects.
+                        followRedirects defines whether the client should follow HTTP 3xx
+                        redirects.
                       type: boolean
                     honorLabels:
                       description: |-
-                        When true, `honorLabels` preserves the metric's labels when they collide
+                        honorLabels defines when true the metric's labels when they collide
                         with the target's labels.
                       type: boolean
                     honorTimestamps:
                       description: |-
-                        `honorTimestamps` controls whether Prometheus preserves the timestamps
+                        honorTimestamps defines whether Prometheus preserves the timestamps
                         when exposed by the target.
                       type: boolean
                     interval:
                       description: |-
-                        Interval at which Prometheus scrapes the metrics from the target.
-
+                        interval at which Prometheus scrapes the metrics from the target.
 
                         If empty, Prometheus uses the global scrape interval.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: |-
-                        `metricRelabelings` configures the relabeling rules to apply to the
+                        metricRelabelings defines the relabeling rules to apply to the
                         samples before ingestion.
                       items:
                         description: |-
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
-
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                               Default: "Replace"
                             enum:
-                            - replace
-                            - Replace
-                            - keep
-                            - Keep
-                            - drop
-                            - Drop
-                            - hashmod
-                            - HashMod
-                            - labelmap
-                            - LabelMap
-                            - labeldrop
-                            - LabelDrop
-                            - labelkeep
-                            - LabelKeep
-                            - lowercase
-                            - Lowercase
-                            - uppercase
-                            - Uppercase
-                            - keepequal
-                            - KeepEqual
-                            - dropequal
-                            - DropEqual
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
-
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description:
+                              regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description:
+                              separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
                         type: object
                       type: array
+                    noProxy:
+                      description: |-
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: string
                     oauth2:
                       description: |-
-                        `oauth2` configures the OAuth2 settings to use when scraping the target.
-
+                        oauth2 defines the OAuth2 settings used by the client.
 
                         It requires Prometheus >= 2.27.0.
 
-
-                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `bearerTokenSecret`.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
+                        noProxy:
+                          description: |-
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            proxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                          type: boolean
+                        proxyUrl:
+                          description: proxyUrl defines the HTTP proxy server to use.
+                          pattern: ^(http|https|socks5)://.+$
+                          type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description:
+                            scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
+                        tlsConfig:
+                          description: |-
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description:
+                                ca defines the Certificate authority used
+                                when verifying server certificates.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description:
+                                cert defines the Client certificate to
+                                present when doing client-authentication.
+                              properties:
+                                configMap:
+                                  description:
+                                    configMap defines the ConfigMap containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description:
+                                    secret defines the Secret containing
+                                    data to use for the targets.
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description:
+                                insecureSkipVerify defines how to disable
+                                target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description:
+                                keySecret defines the Secret containing
+                                the client key file for the targets.
+                              properties:
+                                key:
+                                  description:
+                                    The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description:
+                                    Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                maxVersion defines the maximum acceptable TLS version.
+
+                                It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                minVersion defines the minimum acceptable TLS version.
+
+                                It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                              enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                              type: string
+                            serverName:
+                              description:
+                                serverName is used to verify the hostname
+                                for the targets.
+                              type: string
+                          type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
-                          minLength: 1
+                          description:
+                            tokenUrl defines the URL to fetch the token
+                            from.
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
-                      - clientId
-                      - clientSecret
-                      - tokenUrl
+                        - clientId
+                        - clientSecret
+                        - tokenUrl
                       type: object
                     params:
                       additionalProperties:
@@ -453,34 +748,71 @@ spec:
                       type: object
                     path:
                       description: |-
-                        HTTP path from which to scrape for metrics.
-
+                        path defines the HTTP path from which to scrape for metrics.
 
                         If empty, Prometheus uses the default value (e.g. `/metrics`).
                       type: string
                     port:
                       description: |-
-                        Name of the Service port which this endpoint refers to.
-
+                        port defines the name of the Service port which this endpoint refers to
+                        (e.g. `.spec.ports[].name`).
 
                         It takes precedence over `targetPort`.
                       type: string
-                    proxyUrl:
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description:
+                                The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description:
+                                Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
                       description: |-
-                        `proxyURL` configures the HTTP Proxy URL (e.g.
-                        "http://proxyserver:2195") to go through when scraping the target.
+                        proxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                        It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
+                      type: boolean
+                    proxyUrl:
+                      description: proxyUrl defines the HTTP proxy server to use.
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     relabelings:
                       description: |-
-                        `relabelings` configures the relabeling rules to apply the target's
+                        relabelings defines the relabeling rules to apply the target's
                         metadata labels.
-
 
                         The Operator automatically adds relabelings for a few standard Kubernetes fields.
 
-
                         The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
-
 
                         More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                       items:
@@ -488,282 +820,348 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
-
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
-
                               Default: "Replace"
                             enum:
-                            - replace
-                            - Replace
-                            - keep
-                            - Keep
-                            - drop
-                            - Drop
-                            - hashmod
-                            - HashMod
-                            - labelmap
-                            - LabelMap
-                            - labeldrop
-                            - LabelDrop
-                            - labelkeep
-                            - LabelKeep
-                            - lowercase
-                            - Lowercase
-                            - uppercase
-                            - Uppercase
-                            - keepequal
-                            - KeepEqual
-                            - dropequal
-                            - DropEqual
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
-
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description:
+                              regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description:
+                              separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     scheme:
-                      description: |-
-                        HTTP scheme to use for scraping.
-
-
-                        `http` and `https` are the expected values unless you rewrite the
-                        `__scheme__` label via relabeling.
-
-
-                        If empty, Prometheus uses the default value `http`.
+                      description:
+                        scheme defines the HTTP scheme to use when scraping
+                        the metrics.
                       enum:
-                      - http
-                      - https
+                        - http
+                        - https
+                        - HTTP
+                        - HTTPS
                       type: string
                     scrapeTimeout:
                       description: |-
-                        Timeout after which Prometheus considers the scrape to be failed.
-
+                        scrapeTimeout defines the timeout after which Prometheus considers the scrape to be failed.
 
                         If empty, Prometheus uses the global scrape timeout unless it is less
                         than the target's scrape interval value in which the latter is used.
+                        The value cannot be greater than the scrape interval otherwise the operator will reject the resource.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
-                      - type: integer
-                      - type: string
+                        - type: integer
+                        - type: string
                       description: |-
-                        Name or number of the target port of the `Pod` object behind the
-                        Service. The port must be specified with the container's port property.
+                        targetPort defines the name or number of a container port on Pods selected
+                        by the Service.
+                        If a name, it matches against `.spec.containers[].ports[].name` of the Pods.
+                        If a number, it matches against `.spec.containers[].ports[].containerPort` of the Pods.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the target.
+                      description:
+                        tlsConfig defines TLS configuration used by the
+                        client.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description:
+                            ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container
-                            to use for the targets.
+                          description:
+                            caFile defines the path to the CA cert in the
+                            Prometheus container to use for the targets.
                           type: string
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description:
+                            cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description:
+                                configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description:
+                                    Specify whether the ConfigMap or its
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description:
+                                secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
+                                  description:
+                                    The key of the secret to select from.  Must
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ""
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
+                                  description:
+                                    Specify whether the Secret or its key
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus
-                            container for the targets.
+                          description:
+                            certFile defines the path to the client cert
+                            file in the Prometheus container for the targets.
                           type: string
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description:
+                            insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus
-                            container for the targets.
+                          description:
+                            keyFile defines the path to the client key
+                            file in the Prometheus container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description:
+                            keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description:
+                                The key of the secret to select from.  Must
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
+                              description:
+                                Specify whether the Secret or its key must
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            maxVersion defines the maximum acceptable TLS version.
+
+                            It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            minVersion defines the minimum acceptable TLS version.
+
+                            It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                          enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                          type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description:
+                            serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     trackTimestampsStaleness:
                       description: |-
-                        `trackTimestampsStaleness` defines whether Prometheus tracks staleness of
+                        trackTimestampsStaleness defines whether Prometheus tracks staleness of
                         the metrics that have an explicit timestamp present in scraped data.
                         Has no effect if `honorTimestamps` is false.
-
 
                         It requires Prometheus >= v2.48.0.
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
-                  `jobLabel` selects the label from the associated Kubernetes `Service`
+                  jobLabel selects the label from the associated Kubernetes `Service`
                   object which will be used as the `job` label for all metrics.
-
 
                   For example if `jobLabel` is set to `foo` and the Kubernetes `Service`
                   object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
                   label to all ingested metrics.
-
 
                   If the value of this field is empty or if the label doesn't exist for
                   the given Service, the `job` label of the metrics defaults to the name
@@ -771,78 +1169,103 @@ spec:
                 type: string
               keepDroppedTargets:
                 description: |-
-                  Per-scrape limit on the number of targets dropped by relabeling
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
                   that will be kept in memory. 0 means no limit.
-
 
                   It requires Prometheus >= v2.47.0.
                 format: int64
                 type: integer
               labelLimit:
                 description: |-
-                  Per-scrape limit on number of labels that will be accepted for a sample.
-
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelNameLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels name that will be accepted for a sample.
-
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelValueLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels value that will be accepted for a sample.
-
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               namespaceSelector:
                 description: |-
-                  Selector to select which namespaces the Kubernetes `Endpoints` objects
-                  are discovered from.
+                  namespaceSelector defines in which namespace(s) Prometheus should discover the services.
+                  By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
                 properties:
                   any:
                     description: |-
-                      Boolean describing whether all namespaces are selected in contrast to a
+                      any defines the boolean describing whether all namespaces are selected in contrast to a
                       list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
+                    description:
+                      matchNames defines the list of namespace names to
+                      select from.
                     items:
                       type: string
                     type: array
                 type: object
+              nativeHistogramBucketLimit:
+                description: |-
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
+                  buckets will be merged to stay within the limit.
+                  It requires Prometheus >= v2.45.0.
+                format: int64
+                type: integer
+              nativeHistogramMinBucketFactor:
+                anyOf:
+                  - type: integer
+                  - type: string
+                description: |-
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
+                  buckets will be merged to increase the factor sufficiently.
+                  It requires Prometheus >= v2.50.0.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               podTargetLabels:
                 description: |-
-                  `podTargetLabels` defines the labels which are transferred from the
+                  podTargetLabels defines the labels which are transferred from the
                   associated Kubernetes `Pod` object onto the ingested metrics.
                 items:
                   type: string
                 type: array
               sampleLimit:
                 description: |-
-                  `sampleLimit` defines a per-scrape limit on the number of scraped samples
+                  sampleLimit defines a per-scrape limit on the number of scraped samples
                   that will be accepted.
                 format: int64
                 type: integer
               scrapeClass:
-                description: The scrape class to apply.
+                description: scrapeClass defines the scrape class to apply.
                 minLength: 1
                 type: string
+              scrapeClassicHistograms:
+                description: |-
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
+                  It requires Prometheus >= v2.45.0.
+
+                  Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
+                type: boolean
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
               scrapeProtocols:
                 description: |-
-                  `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
                   protocols supported by Prometheus in order of preference (from most to least preferred).
 
-
                   If unset, Prometheus uses its default value.
-
 
                   It requires Prometheus >= v2.49.0.
                 items:
@@ -853,19 +1276,24 @@ spec:
                     * `OpenMetricsText1.0.0`
                     * `PrometheusProto`
                     * `PrometheusText0.0.4`
+                    * `PrometheusText1.0.0`
                   enum:
-                  - PrometheusProto
-                  - OpenMetricsText0.0.1
-                  - OpenMetricsText1.0.0
-                  - PrometheusText0.0.4
+                    - PrometheusProto
+                    - OpenMetricsText0.0.1
+                    - OpenMetricsText1.0.0
+                    - PrometheusText0.0.4
+                    - PrometheusText1.0.0
                   type: string
                 type: array
                 x-kubernetes-list-type: set
               selector:
-                description: Label selector to select the Kubernetes `Endpoints` objects.
+                description:
+                  selector defines the label selector to select the Kubernetes
+                  `Endpoints` objects to scrape metrics from.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
+                    description:
+                      matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
                       description: |-
@@ -873,7 +1301,8 @@ spec:
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
+                          description:
+                            key is the label key that the selector applies
                             to.
                           type: string
                         operator:
@@ -890,11 +1319,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
-                      - key
-                      - operator
+                        - key
+                        - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
@@ -905,24 +1336,161 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              selectorMechanism:
+                description: |-
+                  selectorMechanism defines the mechanism used to select the endpoints to scrape.
+                  By default, the selection process relies on relabel configurations to filter the discovered targets.
+                  Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
+                  Which strategy is best for your use case needs to be carefully evaluated.
+
+                  It requires Prometheus >= v2.17.0.
+                enum:
+                  - RelabelConfig
+                  - RoleSelector
+                type: string
+              serviceDiscoveryRole:
+                description: |-
+                  serviceDiscoveryRole defines the service discovery role used to discover targets.
+
+                  If set, the value should be either "Endpoints" or "EndpointSlice".
+                  Otherwise it defaults to the value defined in the
+                  Prometheus/PrometheusAgent resource.
+                enum:
+                  - Endpoints
+                  - EndpointSlice
+                type: string
               targetLabels:
                 description: |-
-                  `targetLabels` defines the labels which are transferred from the
+                  targetLabels defines the labels which are transferred from the
                   associated Kubernetes `Service` object onto the ingested metrics.
                 items:
                   type: string
                 type: array
               targetLimit:
                 description: |-
-                  `targetLimit` defines a limit on the number of scraped targets that will
+                  targetLimit defines a limit on the number of scraped targets that will
                   be accepted.
                 format: int64
                 type: integer
             required:
-            - selector
+              - endpoints
+              - selector
+            type: object
+          status:
+            description: |-
+              status defines the status subresource. It is under active development and is updated only when the
+              "StatusForConfigurationResources" feature gate is enabled.
+
+              Most recent observed status of the ServiceMonitor. Read-only.
+              More info:
+              https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              bindings:
+                description:
+                  bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
+                items:
+                  description:
+                    WorkloadBinding is a link between a configuration resource
+                    and a workload resource.
+                  properties:
+                    conditions:
+                      description:
+                        conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
+                      items:
+                        description:
+                          ConfigResourceCondition describes the status
+                          of configuration resources linked to Prometheus, PrometheusAgent,
+                          Alertmanager or ThanosRuler.
+                        properties:
+                          lastTransitionTime:
+                            description:
+                              lastTransitionTime defines the time of the
+                              last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description:
+                              message defines the human-readable message
+                              indicating details for the condition's last transition.
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration defines the .metadata.generation that the
+                              condition was set based upon. For instance, if `.metadata.generation` is
+                              currently 12, but the `.status.conditions[].observedGeneration` is 9, the
+                              condition is out of date with respect to the current state of the object.
+                            format: int64
+                            type: integer
+                          reason:
+                            description: reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: status of the condition.
+                            minLength: 1
+                            type: string
+                          type:
+                            description: |-
+                              type of the condition being reported.
+                              Currently, only "Accepted" is supported.
+                            enum:
+                              - Accepted
+                            minLength: 1
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    group:
+                      description: group defines the group of the referenced resource.
+                      enum:
+                        - monitoring.coreos.com
+                      type: string
+                    name:
+                      description: name defines the name of the referenced object.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description:
+                        namespace defines the namespace of the referenced
+                        object.
+                      minLength: 1
+                      type: string
+                    resource:
+                      description:
+                        resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
+                      enum:
+                        - prometheuses
+                        - prometheusagents
+                        - thanosrulers
+                        - alertmanagers
+                      type: string
+                  required:
+                    - group
+                    - name
+                    - namespace
+                    - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                  - group
+                  - resource
+                  - name
+                  - namespace
+                x-kubernetes-list-type: map
             type: object
         required:
-        - spec
+          - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.3
+    helm.sh/chart: opentelemetry-kube-stack-0.20.4
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.1
+    helm.sh/chart: opentelemetry-kube-stack-0.20.2
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.3"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.4"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.1"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.2"


### PR DESCRIPTION
#### Description
This PR updates the prometheus-crds in the opentelemetry-kube-stack helm-chart.

Currently the prometheus-crds are out of date and not updated automatically. 
They are updated the manual way to the corresponding prometheus-operator version of the [compatibility matrix](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md#compatibility-matrix).

Chart version bumped to 0.20.2.
Generated new examples via make generate-examples.


#### Link to tracking issue
Fixes #2281 

#### Authorship

- [x] I, a human, wrote this pull request description myself.
