### PR TITLE
 fix(opentelemetry-kube-stack): Add missing namespace to hook and instrumentation resources

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.8
+version: 0.20.9
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,10 +5,10 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"    
 spec:
   endpoint: http://opamp-server:8080
   capabilities:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"    
+    release: "example"
 spec:
   endpoint: http://opamp-server:8080
   capabilities:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
     opentelemetry.io/opamp-reporting: "true"
 spec:
   managementState: managed
@@ -486,7 +486,7 @@ spec:
       port: 4317
       protocol: TCP
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -515,7 +515,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   - name: ACCESS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
     opentelemetry.io/opamp-reporting: "true"
 spec:
   managementState: managed
@@ -486,7 +486,7 @@ spec:
       port: 4317
       protocol: TCP
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -515,7 +515,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   - name: ACCESS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -4,6 +4,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: example
+  namespace: default
   labels:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"    
 spec:
   exporter:
     endpoint: http://${OTEL_K8S_NODE_NAME}:4317

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"    
+    release: "example"
 spec:
   exporter:
     endpoint: http://${OTEL_K8S_NODE_NAME}:4317

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -95,7 +95,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -95,7 +95,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -93,7 +93,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -93,7 +93,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -101,7 +101,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -101,7 +101,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -215,7 +215,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -215,7 +215,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -205,7 +205,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -205,7 +205,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -472,7 +472,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -501,7 +501,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
-
+  
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -472,7 +472,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -501,7 +501,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
-  
+
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -191,7 +191,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
@@ -61,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/instrumentation.yaml
@@ -4,8 +4,9 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: example
+  namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -176,7 +176,7 @@ spec:
   - mountPath: /var/lib/otelcol/agent
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -205,7 +205,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   tolerations:
     - effect: NoExecute
       operator: Exists
@@ -232,10 +232,10 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: deployment
@@ -287,7 +287,7 @@ spec:
           - resource/common
           receivers:
           - otlp
-  replicas:
+  replicas: 
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   terminationGracePeriodSeconds: 30
@@ -315,7 +315,7 @@ spec:
   - mountPath: /var/lib/otelcol/gateway
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -344,7 +344,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   tolerations:
     - effect: NoExecute
       operator: Exists
@@ -365,10 +365,10 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: deployment
@@ -414,7 +414,7 @@ spec:
           - otlp
           receivers:
           - otlp
-  replicas:
+  replicas: 
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   terminationGracePeriodSeconds: 30
@@ -442,7 +442,7 @@ spec:
   - mountPath: /var/lib/otelcol/ingress
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -471,7 +471,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   tolerations:
     - effect: NoExecute
       operator: Exists

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -176,7 +176,7 @@ spec:
   - mountPath: /var/lib/otelcol/agent
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -205,7 +205,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   tolerations:
     - effect: NoExecute
       operator: Exists
@@ -235,7 +235,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: deployment
@@ -287,7 +287,7 @@ spec:
           - resource/common
           receivers:
           - otlp
-  replicas: 
+  replicas:
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   terminationGracePeriodSeconds: 30
@@ -315,7 +315,7 @@ spec:
   - mountPath: /var/lib/otelcol/gateway
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -344,7 +344,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   tolerations:
     - effect: NoExecute
       operator: Exists
@@ -368,7 +368,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: deployment
@@ -414,7 +414,7 @@ spec:
           - otlp
           receivers:
           - otlp
-  replicas: 
+  replicas:
   imagePullPolicy: IfNotPresent
   upgradeStrategy: automatic
   terminationGracePeriodSeconds: 30
@@ -442,7 +442,7 @@ spec:
   - mountPath: /var/lib/otelcol/ingress
     name: varlibotelcol
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -471,7 +471,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   tolerations:
     - effect: NoExecute
       operator: Exists

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: deployment
@@ -136,7 +136,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -604,7 +604,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -633,7 +633,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
-  
+
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: deployment
@@ -136,7 +136,7 @@ spec:
   securityContext:
     {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -173,10 +173,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -604,7 +604,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -633,7 +633,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
-
+  
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,11 +6,11 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
-    otel-collector-type: daemonset-example
+    release: "example"    
+    otel-collector-type: daemonset-example    
 spec:
   managementState: managed
   mode: daemonset
@@ -99,7 +99,7 @@ spec:
       scrapeInterval: 30s
       serviceMonitorSelector: {}
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -128,7 +128,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   - name: ACCESS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -9,8 +9,8 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"    
-    otel-collector-type: daemonset-example    
+    release: "example"
+    otel-collector-type: daemonset-example
 spec:
   managementState: managed
   mode: daemonset
@@ -99,7 +99,7 @@ spec:
       scrapeInterval: 30s
       serviceMonitorSelector: {}
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -128,7 +128,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   - name: ACCESS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
-  
+
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     port: https

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
-
+  
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     port: https

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     release: "example"
 spec:
   jobLabel: jobLabel
-  
+
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-controller-manager

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
   jobLabel: jobLabel
-
+  
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-controller-manager

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     release: "example"
 spec:
   jobLabel: jobLabel
-  
+
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-dns

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
   jobLabel: jobLabel
-
+  
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-dns

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     release: "example"
 spec:
   jobLabel: jobLabel
-    
+
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-etcd

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
   jobLabel: jobLabel
-
+    
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-etcd

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     release: "example"
 spec:
   jobLabel: jobLabel
-  
+
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-proxy

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
   jobLabel: jobLabel
-
+  
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-proxy

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     release: "example"
 spec:
   jobLabel: jobLabel
-  
+
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-scheduler

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"
 spec:
   jobLabel: jobLabel
-
+  
   selector:
     matchLabels:
       app: opentelemetry-kube-stack-kube-scheduler

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.8
+    helm.sh/chart: opentelemetry-kube-stack-0.20.9
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"
+    release: "example"        
 spec:
   managementState: managed
   mode: daemonset
@@ -472,7 +472,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME
+  - name: K8S_NODE_NAME 
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -501,7 +501,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-
+  
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: opentelemetry-kube-stack-0.20.8
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
-    release: "example"        
+    release: "example"
 spec:
   managementState: managed
   mode: daemonset
@@ -472,7 +472,7 @@ spec:
     readOnly: true
     mountPropagation: HostToContainer
   env:
-  - name: K8S_NODE_NAME 
+  - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
@@ -501,7 +501,7 @@ spec:
         fieldPath: status.podIP
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=demo"
-  
+
   volumes:
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: default
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -46,6 +49,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: opentelemetry-kube-stack-pre-delete-job
+  namespace: default
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -65,4 +65,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.8"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.9"

--- a/charts/opentelemetry-kube-stack/templates/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/templates/hooks.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: delete-resources-sa
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- end}}
@@ -13,6 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: delete-resources-role
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
@@ -31,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: delete-resources-rolebinding
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -50,6 +53,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "opentelemetry-kube-stack.name" . }}-pre-delete-job
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
@@ -4,6 +4,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: {{ include "opentelemetry-kube-stack.instrumentation" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-kube-stack.labels" $ | nindent 4 }}
     {{- include "opentelemetry-kube-stack.renderkv" .Values.instrumentation.labels | indent 4 }}


### PR DESCRIPTION
#### Description

Hook resources (ServiceAccount, Role, RoleBinding, Job) and the Instrumentation CR were missing `namespace: {{ .Release.Namespace }}`. Without it, tools like kustomize that post-process Helm output cannot reliably inject the namespace, because kustomize >=5.8.0 no longer applies its namespace transformer to resources rendered via [helmCharts](https://github.com/kubernetes-sigs/kustomize/issues/6058).

When deploying purely with Helm the namespace is set implicitly by the API server, but explicit namespacing is best practice and required for kustomize-based workflows.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-helm-charts/issues/2370

#### Authorship

- [x] I, a human, wrote this pull request description myself.
