### PR TITLE
feat(opentelemetry-demo): add BROWSER_GENERATOR_VUS env var to load-generator

### DIFF
--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -638,6 +638,8 @@ components:
     env:
       - name: LOAD_GENERATOR_VUS
         value: "5"
+      - name: BROWSER_GENERATOR_VUS
+        value: "1"
       - name: K6_TARGET_URL
         value: http://frontend-proxy:8080
       - name: K6_BROWSER_ENABLED


### PR DESCRIPTION
#### Description
Adds a `BROWSER_GENERATOR_VUS` env var to the load-generator's `values.yaml` env list, letting the k6 browser/RUM scenario scale independently of `LOAD_GENERATOR_VUS`. Default `"1"`, matching the script's own fallback, so chart behavior is unchanged until overridden.

**Depends on open-telemetry/opentelemetry-demo#3903 (must merge first)** — that PR adds the `BROWSER_GENERATOR_VUS` support in `script.js`; without it this env var is a no-op.

#### Link to tracking issue
Fixes open-telemetry/opentelemetry-demo#3813

#### Authorship

- [x] I, a human, wrote this pull request description myself.


---
Assisted-by: Claude Sonnet 5
