### PR TITLE
[opentelemetry-demo]: raise memory limit on product-catalog and checkout

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.41.0
+version: 0.41.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/agent-fixtures-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/agent-fixtures-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent-fixtures
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: product-catalog-product-catalog-otel-config
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -50,7 +50,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -78,7 +78,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -103,7 +103,7 @@ kind: Service
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -128,7 +128,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -153,7 +153,7 @@ kind: Service
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -178,7 +178,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -203,7 +203,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -253,7 +253,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -309,7 +309,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -359,7 +359,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -387,7 +387,7 @@ kind: Service
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -412,7 +412,7 @@ kind: Service
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -440,7 +440,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -465,7 +465,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -490,7 +490,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -515,7 +515,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -540,7 +540,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -565,7 +565,7 @@ kind: Service
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -590,7 +590,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -615,7 +615,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: accounting
     
@@ -689,7 +689,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -766,7 +766,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -950,7 +950,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -1031,7 +1031,7 @@ kind: Deployment
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -1104,7 +1104,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -1183,7 +1183,7 @@ spec:
               value: service.version=3.0.0,service.criticality=critical
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -1206,7 +1206,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -1275,7 +1275,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -1346,7 +1346,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -1476,7 +1476,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: fraud-detection
     
@@ -1556,7 +1556,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -1655,7 +1655,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1777,7 +1777,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -1850,7 +1850,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -1931,7 +1931,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: load-generator
     
@@ -2014,7 +2014,7 @@ kind: Deployment
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -2085,7 +2085,7 @@ kind: Deployment
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -2141,7 +2141,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -2220,7 +2220,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -2287,7 +2287,7 @@ spec:
               value: service.version=3.0.0,service.criticality=high
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -2317,7 +2317,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -2392,7 +2392,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -2467,7 +2467,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -2548,7 +2548,7 @@ kind: Deployment
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -2619,7 +2619,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/bring-your-own-observability/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/agent-fixtures-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/agent-fixtures-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent-fixtures
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: product-catalog-product-catalog-otel-config
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -50,7 +50,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -78,7 +78,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -103,7 +103,7 @@ kind: Service
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -128,7 +128,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -153,7 +153,7 @@ kind: Service
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -178,7 +178,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -203,7 +203,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -253,7 +253,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -309,7 +309,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -359,7 +359,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -387,7 +387,7 @@ kind: Service
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -412,7 +412,7 @@ kind: Service
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -440,7 +440,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -465,7 +465,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -490,7 +490,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -515,7 +515,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -540,7 +540,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -565,7 +565,7 @@ kind: Service
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -590,7 +590,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -615,7 +615,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: accounting
     
@@ -691,7 +691,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -770,7 +770,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -868,7 +868,7 @@ kind: Deployment
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -954,7 +954,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -1037,7 +1037,7 @@ kind: Deployment
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -1110,7 +1110,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -1191,7 +1191,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME),service.criticality=critical
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -1214,7 +1214,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -1285,7 +1285,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -1358,7 +1358,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -1488,7 +1488,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: fraud-detection
     
@@ -1570,7 +1570,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -1671,7 +1671,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -1866,7 +1866,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -1947,7 +1947,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: load-generator
     
@@ -2032,7 +2032,7 @@ kind: Deployment
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -2103,7 +2103,7 @@ kind: Deployment
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -2159,7 +2159,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -2240,7 +2240,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -2309,7 +2309,7 @@ spec:
               value: service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),app.eng.team=$(TEAM_NAME),service.criticality=high
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -2339,7 +2339,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -2416,7 +2416,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -2493,7 +2493,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -2576,7 +2576,7 @@ kind: Deployment
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -2647,7 +2647,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/custom-environment-variables/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/agent-fixtures-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/agent-fixtures-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent-fixtures
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: product-catalog-product-catalog-otel-config
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -50,7 +50,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -78,7 +78,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -103,7 +103,7 @@ kind: Service
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -128,7 +128,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -153,7 +153,7 @@ kind: Service
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -178,7 +178,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -203,7 +203,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -253,7 +253,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -309,7 +309,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -359,7 +359,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -387,7 +387,7 @@ kind: Service
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -412,7 +412,7 @@ kind: Service
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -440,7 +440,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -465,7 +465,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -490,7 +490,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -515,7 +515,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -540,7 +540,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -565,7 +565,7 @@ kind: Service
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -590,7 +590,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -615,7 +615,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: accounting
     
@@ -689,7 +689,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -766,7 +766,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -950,7 +950,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -1031,7 +1031,7 @@ kind: Deployment
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -1104,7 +1104,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -1183,7 +1183,7 @@ spec:
               value: service.version=3.0.0,service.criticality=critical
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -1206,7 +1206,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -1275,7 +1275,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -1346,7 +1346,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -1476,7 +1476,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: fraud-detection
     
@@ -1556,7 +1556,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -1655,7 +1655,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1777,7 +1777,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -1850,7 +1850,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -1931,7 +1931,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: load-generator
     
@@ -2014,7 +2014,7 @@ kind: Deployment
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -2085,7 +2085,7 @@ kind: Deployment
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -2141,7 +2141,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -2220,7 +2220,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -2287,7 +2287,7 @@ spec:
               value: service.version=3.0.0,service.criticality=high
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -2317,7 +2317,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -2392,7 +2392,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -2467,7 +2467,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -2548,7 +2548,7 @@ kind: Deployment
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -2619,7 +2619,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/agent-fixtures-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/agent-fixtures-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent-fixtures
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: product-catalog-product-catalog-otel-config
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -50,7 +50,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -78,7 +78,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -103,7 +103,7 @@ kind: Service
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -128,7 +128,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -153,7 +153,7 @@ kind: Service
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -178,7 +178,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -203,7 +203,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -253,7 +253,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -309,7 +309,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -359,7 +359,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -387,7 +387,7 @@ kind: Service
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -412,7 +412,7 @@ kind: Service
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -440,7 +440,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -465,7 +465,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -490,7 +490,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -515,7 +515,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -540,7 +540,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -565,7 +565,7 @@ kind: Service
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -590,7 +590,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -615,7 +615,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: accounting
     
@@ -689,7 +689,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -766,7 +766,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -950,7 +950,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -1031,7 +1031,7 @@ kind: Deployment
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -1104,7 +1104,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -1183,7 +1183,7 @@ spec:
               value: service.version=3.0.0,service.criticality=critical
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -1206,7 +1206,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -1275,7 +1275,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -1346,7 +1346,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -1476,7 +1476,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: fraud-detection
     
@@ -1556,7 +1556,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -1655,7 +1655,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1777,7 +1777,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -1850,7 +1850,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -1931,7 +1931,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: load-generator
     
@@ -2014,7 +2014,7 @@ kind: Deployment
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -2085,7 +2085,7 @@ kind: Deployment
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -2141,7 +2141,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -2220,7 +2220,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -2287,7 +2287,7 @@ spec:
               value: service.version=3.0.0,service.criticality=high
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -2317,7 +2317,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -2392,7 +2392,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -2467,7 +2467,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -2548,7 +2548,7 @@ kind: Deployment
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -2619,7 +2619,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/disable-kubernetes-infra-monitoring/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/agent-fixtures-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/agent-fixtures-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent-fixtures
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: product-catalog-product-catalog-otel-config
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -50,7 +50,7 @@ kind: Service
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -78,7 +78,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -103,7 +103,7 @@ kind: Service
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -128,7 +128,7 @@ kind: Service
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -153,7 +153,7 @@ kind: Service
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -178,7 +178,7 @@ kind: Service
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -203,7 +203,7 @@ kind: Service
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -228,7 +228,7 @@ kind: Service
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -253,7 +253,7 @@ kind: Service
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -284,7 +284,7 @@ kind: Service
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -309,7 +309,7 @@ kind: Service
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -334,7 +334,7 @@ kind: Service
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -359,7 +359,7 @@ kind: Service
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -387,7 +387,7 @@ kind: Service
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -412,7 +412,7 @@ kind: Service
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -440,7 +440,7 @@ kind: Service
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -465,7 +465,7 @@ kind: Service
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -490,7 +490,7 @@ kind: Service
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -515,7 +515,7 @@ kind: Service
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -540,7 +540,7 @@ kind: Service
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -565,7 +565,7 @@ kind: Service
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -590,7 +590,7 @@ kind: Service
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -615,7 +615,7 @@ kind: Deployment
 metadata:
   name: accounting
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: accounting
     
@@ -689,7 +689,7 @@ kind: Deployment
 metadata:
   name: ad
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: ad
     
@@ -766,7 +766,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: agent
     
@@ -864,7 +864,7 @@ kind: Deployment
 metadata:
   name: astronomy-db
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: astronomy-db
     
@@ -950,7 +950,7 @@ kind: Deployment
 metadata:
   name: cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: cart
     
@@ -1031,7 +1031,7 @@ kind: Deployment
 metadata:
   name: chatbot
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: chatbot
     
@@ -1104,7 +1104,7 @@ kind: Deployment
 metadata:
   name: checkout
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: checkout
     
@@ -1183,7 +1183,7 @@ spec:
               value: service.version=3.0.0,service.criticality=critical
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -1206,7 +1206,7 @@ kind: Deployment
 metadata:
   name: currency
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: currency
     
@@ -1275,7 +1275,7 @@ kind: Deployment
 metadata:
   name: email
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: email
     
@@ -1346,7 +1346,7 @@ kind: Deployment
 metadata:
   name: flagd
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: flagd
     
@@ -1476,7 +1476,7 @@ kind: Deployment
 metadata:
   name: fraud-detection
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: fraud-detection
     
@@ -1556,7 +1556,7 @@ kind: Deployment
 metadata:
   name: frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend
     
@@ -1655,7 +1655,7 @@ kind: Deployment
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     
@@ -1777,7 +1777,7 @@ kind: Deployment
 metadata:
   name: image-provider
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: image-provider
     
@@ -1850,7 +1850,7 @@ kind: Deployment
 metadata:
   name: kafka
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: kafka
     
@@ -1931,7 +1931,7 @@ kind: Deployment
 metadata:
   name: load-generator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: load-generator
     
@@ -2014,7 +2014,7 @@ kind: Deployment
 metadata:
   name: mcp
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: mcp
     
@@ -2085,7 +2085,7 @@ kind: Deployment
 metadata:
   name: opamp-server
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: opamp-server
     
@@ -2141,7 +2141,7 @@ kind: Deployment
 metadata:
   name: payment
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: payment
     
@@ -2220,7 +2220,7 @@ kind: Deployment
 metadata:
   name: product-catalog
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: product-catalog
     
@@ -2287,7 +2287,7 @@ spec:
               value: service.version=3.0.0,service.criticality=high
           resources:
             limits:
-              memory: 20Mi
+              memory: 128Mi
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -2317,7 +2317,7 @@ kind: Deployment
 metadata:
   name: quote
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: quote
     
@@ -2392,7 +2392,7 @@ kind: Deployment
 metadata:
   name: recommendation
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: recommendation
     
@@ -2467,7 +2467,7 @@ kind: Deployment
 metadata:
   name: shipping
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: shipping
     
@@ -2548,7 +2548,7 @@ kind: Deployment
 metadata:
   name: telemetry-docs
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: telemetry-docs
     
@@ -2619,7 +2619,7 @@ kind: Deployment
 metadata:
   name: valkey-cart
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: valkey-cart
     
@@ -2679,7 +2679,7 @@ kind: Ingress
 metadata:
   name: frontend-proxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     opentelemetry.io/name: frontend-proxy
     

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: flagd-config
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/grafana-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: grafana-alerting
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -24,7 +24,7 @@ metadata:
   name: grafana-dashboard-nginx-metrics
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -382,7 +382,7 @@ metadata:
   name: grafana-dashboard-apm-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -2666,7 +2666,7 @@ metadata:
   name: grafana-dashboard-demo-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -3870,7 +3870,7 @@ metadata:
   name: grafana-dashboard-exemplars-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -4346,7 +4346,7 @@ metadata:
   name: grafana-dashboard-linux-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -7203,7 +7203,7 @@ metadata:
   name: grafana-dashboard-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -12987,7 +12987,7 @@ metadata:
   name: grafana-dashboard-postgresql-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -14478,7 +14478,7 @@ metadata:
   name: grafana-dashboard-spanmetrics-dashboard
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"
@@ -15529,7 +15529,7 @@ metadata:
   name: grafana-datasources
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/posgresql-init-config.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/posgresql-init-config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-init
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/public-hosted-ingress/rendered/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-demo-0.41.0
+    helm.sh/chart: opentelemetry-demo-0.41.1
     
     
     app.kubernetes.io/version: "3.0.0"

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -381,7 +381,7 @@ components:
         value: service.criticality=critical
     resources:
       limits:
-        memory: 20Mi
+        memory: 128Mi
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
@@ -792,7 +792,7 @@ components:
         command: ["sh", "-c", "until nc -z -v -w30 astronomy-db 5432; do echo waiting for astronomy-db; sleep 2; done;"]
     resources:
       limits:
-        memory: 20Mi
+        memory: 128Mi
     securityContext:
       readOnlyRootFilesystem: true
     mountedEmptyDirs:


### PR DESCRIPTION
#### Description

The memory limits of some services were too low, which caused disk latency on our k8s cluster and even nodes that could no longer schedule new pods. To fix this, we increased the memory limit of the services.

#### Link to tracking issue
Fixes #2376

#### Authorship

- [X] I, a human, wrote this pull request description myself.

Assited-by: Claude