### PR TITLE
fix(opentelemetry-kube-stack): make prometheus-otel example work from the packaged chart

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.6
+version: 0.20.7
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/README.md
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/README.md
@@ -2,4 +2,26 @@
 This example contains files to allow a user to replace an installation of kube-prometheus-stack. The opentelemetry-kube-stack chart aims to make the replacement process straightforward by utilizing the target allocator to pull any servicemonitors and podmonitors.
 
 > [!INFO]
-> This chart has most of the same configurations as the kube-prometheus-stack chart, but requires that kubelet monitoring is done via a manual scrape config. This is because of how the prometheus-operator manages endpoints for the Kubelet service. If you'd like to avoid a scrape-config altogether, it's recommended to use the kubelet receiver in the opentelemetry collector.
+> This chart has most of the same configurations as the kube-prometheus-stack chart, but requires that kubelet monitoring is done via ScrapeConfig custom resources. This is because of how the prometheus-operator manages endpoints for the Kubelet service. If you'd like to avoid scrape configs altogether, it's recommended to use the kubelet receiver in the opentelemetry collector.
+
+## Usage
+
+Install the chart with this example's values file:
+
+```bash
+helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack -f values.yaml
+```
+
+Then create the kubelet scrape configuration. The manifests assume the `default` namespace, so adjust the namespace fields in the file first if you installed the chart elsewhere:
+
+```bash
+kubectl apply -n default -f kubelet_scrape_configs_cr.yaml
+```
+
+The chart installs the required ScrapeConfig CRD by default through its prometheus-crds dependency (`crds.installPrometheus`).
+
+## How kubelet scraping works here
+
+`kubelet_scrape_configs_cr.yaml` contains ScrapeConfig custom resources for the kubelet's `/metrics`, `/metrics/cadvisor`, and `/metrics/probes` endpoints, along with a dedicated service account, token secret, and the RBAC needed to authenticate against the kubelet. The target allocator picks these up through the `scrapeConfigSelector` configured in this example's values.yaml and distributes the resulting jobs to the daemonset collector.
+
+Earlier versions of this example pointed `scrape_configs_file` at `examples/prometheus-otel/kubelet_scrape_configs.yaml`. That only works from a checkout of this repository's source tree, because packaged charts (for example those fetched with `helm pull`) do not include the examples folder. The ScrapeConfig approach works the same way regardless of how the chart was obtained. The raw prometheus form of the kubelet scrape configuration is kept in `kubelet_scrape_configs.yaml` as a reference for users who prefer to inline it into their collector configuration.

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/kubelet_scrape_configs_cr.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/kubelet_scrape_configs_cr.yaml
@@ -1,0 +1,180 @@
+# Kubelet scrape configuration as Prometheus Operator ScrapeConfig custom resources.
+#
+# These resources replace the static scrape_configs_file that this example used to
+# reference. The target allocator discovers them through prometheusCR.scrapeConfigSelector
+# (enabled in this example's values.yaml) and hands the resulting jobs to the collector,
+# so they work with the packaged chart where the examples folder is not shipped.
+#
+# The kubelet requires authentication. ScrapeConfig resources cannot reference the
+# collector's mounted service account token file, so this manifest creates a dedicated
+# service account with a long-lived token secret and the RBAC needed to scrape the
+# kubelet endpoints. The target allocator reads the token from the secret and embeds
+# it in the scrape configuration it serves to the collector.
+#
+# Apply this file into the same namespace the chart is installed in. The manifests
+# below assume the `default` namespace; change it if you installed elsewhere.
+#
+#   kubectl apply -n default -f kubelet_scrape_configs_cr.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubelet-monitoring
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubelet-monitoring-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: kubelet-monitoring
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelet-monitoring
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes/metrics
+    verbs: ["get"]
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+      - /metrics/probes
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubelet-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: kubelet-monitoring
+    namespace: default
+---
+# Scrapes the kubelet's /metrics endpoint.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kubelet
+  namespace: default
+spec:
+  authorization:
+    type: Bearer
+    credentials:
+      name: kubelet-monitoring-token
+      key: token
+  honorLabels: true
+  honorTimestamps: true
+  kubernetesSDConfigs:
+    - role: Node
+  metricsPath: /metrics
+  relabelings:
+    - sourceLabels: [job]
+      targetLabel: __tmp_prometheus_job_name
+    - targetLabel: job
+      replacement: kubelet
+    - sourceLabels: [__meta_kubernetes_node_name]
+      targetLabel: node
+    - targetLabel: endpoint
+      replacement: https-metrics
+    - sourceLabels: [__metrics_path__]
+      targetLabel: metrics_path
+  scheme: HTTPS
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  tlsConfig:
+    insecureSkipVerify: true
+---
+# Scrapes the kubelet's /metrics/cadvisor endpoint for container metrics.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kubelet-cadvisor
+  namespace: default
+spec:
+  authorization:
+    type: Bearer
+    credentials:
+      name: kubelet-monitoring-token
+      key: token
+  honorLabels: true
+  honorTimestamps: true
+  kubernetesSDConfigs:
+    - role: Node
+  metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
+      action: drop
+    - sourceLabels: [__name__]
+      regex: container_fs_(io_current|io_time_seconds_total|io_time_weighted_seconds_total|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+      action: drop
+    - sourceLabels: [__name__]
+      regex: container_memory_(mapped_file|swap)
+      action: drop
+    - sourceLabels: [__name__]
+      regex: container_(file_descriptors|tasks_state|threads_max)
+      action: drop
+    - sourceLabels: [__name__]
+      regex: container_spec.*
+      action: drop
+    - sourceLabels: [id, pod]
+      regex: .+;
+      action: drop
+  metricsPath: /metrics/cadvisor
+  relabelings:
+    - sourceLabels: [job]
+      targetLabel: __tmp_prometheus_job_name
+    - targetLabel: job
+      replacement: kubelet
+    - sourceLabels: [__meta_kubernetes_node_name]
+      targetLabel: node
+    - targetLabel: endpoint
+      replacement: https-metrics
+    - sourceLabels: [__metrics_path__]
+      targetLabel: metrics_path
+  scheme: HTTPS
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  tlsConfig:
+    insecureSkipVerify: true
+---
+# Scrapes the kubelet's /metrics/probes endpoint.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kubelet-probes
+  namespace: default
+spec:
+  authorization:
+    type: Bearer
+    credentials:
+      name: kubelet-monitoring-token
+      key: token
+  honorLabels: true
+  honorTimestamps: true
+  kubernetesSDConfigs:
+    - role: Node
+  metricsPath: /metrics/probes
+  relabelings:
+    - sourceLabels: [job]
+      targetLabel: __tmp_prometheus_job_name
+    - targetLabel: job
+      replacement: kubelet
+    - sourceLabels: [__meta_kubernetes_node_name]
+      targetLabel: node
+    - targetLabel: endpoint
+      replacement: https-metrics
+    - sourceLabels: [__metrics_path__]
+      targetLabel: metrics_path
+  scheme: HTTPS
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+  tlsConfig:
+    insecureSkipVerify: true

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    
@@ -96,6 +96,7 @@ spec:
     prometheusCR:
       enabled: true
       podMonitorSelector: {}
+      scrapeConfigSelector: {}
       scrapeInterval: 30s
       serviceMonitorSelector: {}
   env:

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/values.yaml
@@ -2,8 +2,11 @@ clusterName: demo
 collectors:
   daemon:
     enabled: true
-    # because this file is inside the examples folder, we need to reference it directly.
-    scrape_configs_file: "examples/prometheus-otel/kubelet_scrape_configs.yaml"
+    # Kubelet metrics come from the ScrapeConfig custom resources in
+    # kubelet_scrape_configs_cr.yaml, discovered via scrapeConfigSelector below.
+    # A scrape_configs_file cannot be used for this because the packaged chart
+    # does not ship the examples folder.
+    scrape_configs_file: ""
     # Adding an additional label for this collctor.
     labels:
       otel-collector-type: daemonset-example
@@ -14,6 +17,7 @@ collectors:
       prometheusCR:
         enabled: true
         podMonitorSelector: {}
+        scrapeConfigSelector: {}
         scrapeInterval: "30s"
         serviceMonitorSelector: {}
     config:

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -1167,8 +1167,11 @@ kubeApiServer:
     #  foo: bar
 
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
-## the configuration for this is currently only in kubelet_scrape_configs.yaml
-## This is because kubelet doesn't have a service and can only be scraped manually.
+## These values only take effect when a scrape_configs_file that references them
+## is loaded, because kubelet doesn't have a service and can only be scraped
+## manually. The packaged chart does not ship such a file; the recommended way
+## to scrape the kubelet is via ScrapeConfig custom resources picked up by the
+## target allocator. See the prometheus-otel example for a working setup.
 kubelet:
   enabled: false
   namespace: kube-system


### PR DESCRIPTION
#### Description

the example tells you to set scrape_configs_file to examples/prometheus-otel/kubelet_scrape_configs.yaml, but that folder never ships in a packaged chart, so if you helm pull or install from the repo you just get nothing back. that's #1777.

it's actually worse than just packaged charts though, .helmignore excludes examples/ and helm applies that even when loading from a directory, so .Files.Get comes back empty on a source checkout too. the committed rendered output already shows scrape_configs: [], so kubelet, cAdvisor and probes were being silently dropped for everyone this whole time.

**What the fix does**

went with what the issue thread suggested, the example uses ScrapeConfig CRs now instead of the static file.

new kubelet_scrape_configs_cr.yaml with three ScrapeConfigs, kubelet /metrics, /metrics/cadvisor with the usual drop rules, and /metrics/probes. same scrape config the old file had, minus the prometheus-operator sharding stuff (hashmod + the $(SHARD) keep pair) since that doesn't apply once the target allocator is handing out targets. ScrapeConfig can't read the collector's mounted SA token, so the manifest creates its own service account, a long lived token secret and the RBAC to scrape kubelet, the TA picks the secret up through its asset store and embeds the token in what it serves the collector.

example values sets scrape_configs_file: "" and turns on scrapeConfigSelector: {}. README gets usage steps plus why the static file doesn't work. also fixed the stale comment above kubelet: in the chart values that said the config "is currently only in kubelet_scrape_configs.yaml". bumped to 0.20.7 and re-ran make generate-examples.

left the old kubelet_scrape_configs.yaml where it is so existing links keep working, and for anyone who'd rather inline the raw prometheus form.

**How I tested it**

make check-examples CHARTS=opentelemetry-kube-stack passes all eleven, helm lint is clean.

diffed the freshly rendered prometheus-otel output byte for byte against what was already committed, only difference is the added scrapeConfigSelector: {} line, rest is just the version label.

applied the manifest to a throwaway kind cluster on 1.35 with the bundled ScrapeConfig CRD, server side dry run passes on all seven resources and a real apply confirmed kube-controller-manager fills in the token secret. also checked field names and enum casing (role: Node, scheme: HTTPS, secret based aut) against the CRD in charts/prometheus-crds.

what I didn't do is a real end to end run with the operator, TA and collector actually scrapiI read the operator source to confirm the TA side holds up, the prometheus CR watcher does
register a ScrapeConfig informer and resolves secrets through the asset store, defaults to ity the README says apply into the release namespace.

#### Link to tracking issue

Fixes #1777

#### Authorship

- [x] I, a human, wrote this pull request description myself.
